### PR TITLE
Input Field

### DIFF
--- a/apps/builder/app/auth/secret-login.tsx
+++ b/apps/builder/app/auth/secret-login.tsx
@@ -1,4 +1,9 @@
-import { Button, Flex, TextField, theme } from "@webstudio-is/design-system";
+import {
+  Button,
+  Flex,
+  DeprecatedTextField,
+  theme,
+} from "@webstudio-is/design-system";
 import { CommitIcon } from "@webstudio-is/icons";
 import { useState } from "react";
 import { authPath } from "~/shared/router-utils";
@@ -18,7 +23,7 @@ export const SecretLogin = () => {
           gap: theme.spacing[5],
         }}
       >
-        <TextField
+        <DeprecatedTextField
           name="secret"
           type="text"
           minLength={2}

--- a/apps/builder/app/builder/features/breakpoints/breakpoints-editor.tsx
+++ b/apps/builder/app/builder/features/breakpoints/breakpoints-editor.tsx
@@ -6,7 +6,7 @@ import type { Breakpoint } from "@webstudio-is/project-build";
 import {
   theme,
   Button,
-  TextField,
+  DeprecatedTextField,
   Flex,
   DeprecatedText2,
 } from "@webstudio-is/design-system";
@@ -60,7 +60,7 @@ const BreakpointEditorItem = ({
         gap="1"
         css={{ paddingLeft: theme.spacing[10], paddingRight: theme.spacing[9] }}
       >
-        <TextField
+        <DeprecatedTextField
           css={{ width: 100, flexGrow: 1 }}
           type="text"
           variant="ghost"
@@ -70,7 +70,7 @@ const BreakpointEditorItem = ({
           minLength={2}
           required
         />
-        <TextField
+        <DeprecatedTextField
           css={{ textAlign: "right", width: 50 }}
           variant="ghost"
           defaultValue={breakpoint.minWidth ?? breakpoint.maxWidth ?? 0}

--- a/apps/builder/app/builder/features/props-panel/controls/color.tsx
+++ b/apps/builder/app/builder/features/props-panel/controls/color.tsx
@@ -1,4 +1,9 @@
-import { Flex, TextField, theme, useId } from "@webstudio-is/design-system";
+import {
+  Flex,
+  DeprecatedTextField,
+  theme,
+  useId,
+} from "@webstudio-is/design-system";
 import {
   type ControlProps,
   getLabel,
@@ -35,7 +40,7 @@ export const ColorControl = ({
           width: theme.spacing[22],
         }}
       >
-        <TextField
+        <DeprecatedTextField
           id={id}
           value={localValue.value}
           onChange={(event) => localValue.set(event.target.value)}

--- a/apps/builder/app/builder/features/props-panel/controls/number.tsx
+++ b/apps/builder/app/builder/features/props-panel/controls/number.tsx
@@ -1,4 +1,9 @@
-import { Flex, TextField, theme, useId } from "@webstudio-is/design-system";
+import {
+  Flex,
+  DeprecatedTextField,
+  theme,
+  useId,
+} from "@webstudio-is/design-system";
 import {
   type ControlProps,
   getLabel,
@@ -37,7 +42,7 @@ export const NumberControl = ({
           width: theme.spacing[21],
         }}
       >
-        <TextField
+        <DeprecatedTextField
           id={id}
           type="number"
           value={localValue.value}

--- a/apps/builder/app/builder/features/props-panel/controls/text.tsx
+++ b/apps/builder/app/builder/features/props-panel/controls/text.tsx
@@ -1,5 +1,5 @@
 import {
-  TextField,
+  DeprecatedTextField,
   Flex,
   theme,
   useId,
@@ -38,7 +38,7 @@ const AsInput = ({
           width: theme.spacing[22],
         }}
       >
-        <TextField
+        <DeprecatedTextField
           id={id}
           value={localValue.value}
           onChange={(event) => localValue.set(event.target.value)}

--- a/apps/builder/app/builder/features/props-panel/controls/url.tsx
+++ b/apps/builder/app/builder/features/props-panel/controls/url.tsx
@@ -1,7 +1,7 @@
 import { useStore } from "@nanostores/react";
 import { pagesStore } from "~/shared/nano-states";
 import {
-  TextField,
+  DeprecatedTextField,
   Flex,
   theme,
   useId,
@@ -36,7 +36,7 @@ const BaseUrl = ({ prop, onChange, id }: BaseControlProps) => {
 
   return (
     <Flex css={{ py: theme.spacing[2] }} direction="column" align="stretch">
-      <TextField
+      <DeprecatedTextField
         id={id}
         value={localValue.value}
         placeholder="https://example.com/"

--- a/apps/builder/app/builder/features/props-panel/props-panel.tsx
+++ b/apps/builder/app/builder/features/props-panel/props-panel.tsx
@@ -9,7 +9,7 @@ import {
   ComboboxAnchor,
   ComboboxListbox,
   ComboboxListboxItem,
-  TextField,
+  DeprecatedTextField,
   SmallIconButton,
   Separator,
   Flex,
@@ -88,7 +88,7 @@ const PropsCombobox = ({
     <Combobox>
       <div {...combobox.getComboboxProps()}>
         <ComboboxAnchor>
-          <TextField
+          <DeprecatedTextField
             autoFocus
             {...combobox.getInputProps()}
             placeholder="Property"

--- a/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
@@ -1,5 +1,10 @@
 import { useStore } from "@nanostores/react";
-import { Flex, Label, TextField, theme } from "@webstudio-is/design-system";
+import {
+  Flex,
+  Label,
+  DeprecatedTextField,
+  theme,
+} from "@webstudio-is/design-system";
 import { getComponentMeta } from "@webstudio-is/react-sdk";
 import { selectedInstanceStore } from "~/shared/nano-states";
 import { useSettingsLogic } from "./use-settings-logic";
@@ -15,7 +20,7 @@ export const SettingsPanel = () => {
     <Flex css={{ px: theme.spacing[9] }}>
       <Flex gap="1" direction="column" grow>
         <Label>Instance Name</Label>
-        <TextField
+        <DeprecatedTextField
           /* Key is required, otherwise when label is undefined, previous value stayed */
           key={selectedInstance.id}
           onBlur={handleBlur}

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
@@ -20,7 +20,7 @@ import {
   Box,
   DeprecatedLabel,
   TextArea,
-  TextField,
+  DeprecatedTextField,
   styled,
   Flex,
   InputErrorsTooltip,
@@ -147,7 +147,7 @@ const FormFields = ({
       <Group>
         <DeprecatedLabel htmlFor={fieldIds.name}>Page Name</DeprecatedLabel>
         <InputErrorsTooltip errors={errors.name}>
-          <TextField
+          <DeprecatedTextField
             tabIndex={1}
             state={errors.name && "invalid"}
             id={fieldIds.name}
@@ -167,7 +167,7 @@ const FormFields = ({
         <Group>
           <DeprecatedLabel htmlFor={fieldIds.path}>Path</DeprecatedLabel>
           <InputErrorsTooltip errors={errors.path}>
-            <TextField
+            <DeprecatedTextField
               tabIndex={1}
               state={errors.path && "invalid"}
               id={fieldIds.path}
@@ -185,7 +185,7 @@ const FormFields = ({
       <Group>
         <DeprecatedLabel htmlFor={fieldIds.title}>Title</DeprecatedLabel>
         <InputErrorsTooltip errors={errors.title}>
-          <TextField
+          <DeprecatedTextField
             tabIndex={1}
             state={errors.title && "invalid"}
             id={fieldIds.title}

--- a/apps/builder/app/builder/features/style-panel/controls/font-family/font-family-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/font-family/font-family-control.tsx
@@ -1,4 +1,4 @@
-import { TextField } from "@webstudio-is/design-system";
+import { DeprecatedTextField } from "@webstudio-is/design-system";
 import { FontsManager } from "~/builder/shared/fonts-manager";
 import type { ControlProps } from "../../style-sections";
 import { FloatingPanel } from "~/builder/shared/floating-panel";
@@ -21,7 +21,7 @@ export const FontFamilyControl = ({
       content={<FontsManager value={toValue(value)} onChange={setValue} />}
       onOpenChange={setIsOpen}
     >
-      <TextField
+      <DeprecatedTextField
         defaultValue={toValue(value)}
         state={isOpen ? "active" : undefined}
       />

--- a/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
@@ -293,7 +293,7 @@ export const ColorPicker = ({
   return (
     <CssValueInput
       styleSource={styleSource}
-      icon={prefix}
+      prefix={prefix}
       property={property}
       value={value}
       intermediateValue={intermediateValue}

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Flex, TextField } from "@webstudio-is/design-system";
+import { Flex, DeprecatedTextField } from "@webstudio-is/design-system";
 import type { StyleValue } from "@webstudio-is/css-data";
 import { CssValueInput, type IntermediateStyleValue } from "./css-value-input";
 import { action } from "@storybook/addon-actions";
@@ -135,7 +135,7 @@ export const WithUnits = () => {
           action("onAbort")();
         }}
       />
-      <TextField
+      <DeprecatedTextField
         readOnly
         value={
           value

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -22,10 +22,10 @@ import type {
 import {
   type KeyboardEventHandler,
   type KeyboardEvent,
+  type ReactNode,
   useCallback,
   useEffect,
   useRef,
-  ReactNode,
 } from "react";
 import { useUnitSelect } from "./unit-select";
 import { unstable_batchedUpdates as unstableBatchedUpdates } from "react-dom";

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -1,7 +1,6 @@
 import { matchSorter } from "match-sorter";
 import {
   Box,
-  TextField,
   useCombobox,
   Combobox,
   ComboboxContent,
@@ -9,9 +8,9 @@ import {
   ComboboxListbox,
   ComboboxListboxItem,
   numericScrubControl,
-  TextFieldIcon,
-  TextFieldIconButton,
-  styled,
+  NestedSelectButton,
+  NestedIconLabel,
+  InputField,
 } from "@webstudio-is/design-system";
 import { ChevronDownIcon } from "@webstudio-is/icons";
 import type {
@@ -34,7 +33,6 @@ import { toValue } from "@webstudio-is/css-engine";
 import { useDebouncedCallback } from "use-debounce";
 import type { StyleSource } from "../style-info";
 import { toPascalCase } from "../keyword-utils";
-import { theme } from "@webstudio-is/design-system";
 import { isValid } from "../parse-css-value";
 
 // We increment by 10 when shift is pressed, by 0.1 when alt/option is pressed and by 1 by default.
@@ -108,6 +106,7 @@ const useScrub = ({
       onValueInput(event) {
         // Moving focus to container of the input to hide the caret
         // (it makes text harder to read and may jump around as you scrub)
+        scrubRef.current?.setAttribute("tabindex", "-1");
         scrubRef.current?.focus();
 
         onChangeRef.current({
@@ -128,6 +127,7 @@ const useScrub = ({
         });
 
         // Returning focus that we've moved above
+        scrubRef.current?.removeAttribute("tabindex");
         inputRef.current?.focus();
         inputRef.current?.select();
       },
@@ -456,29 +456,22 @@ export const CssValueInput = ({
     onKeyDown: inputProps.onKeyDown,
   });
 
-  let state = undefined;
-  if (styleSource === "local") {
-    state = "set" as const;
-  }
-  if (styleSource === "remote") {
-    state = "inherited" as const;
-  }
   const prefix = icon && (
-    <CssValueInputIconButton
-      state={state}
+    <NestedIconLabel
+      color={styleSource}
       css={value.type === "unit" ? { cursor: "ew-resize" } : undefined}
     >
       {icon}
-    </CssValueInputIconButton>
+    </NestedIconLabel>
   );
 
   const keywordButtonElement = (
-    <TextFieldIconButton
+    <NestedSelectButton
       {...getToggleButtonProps()}
-      state={isOpen ? "active" : undefined}
+      data-state={isOpen ? "open" : "closed"}
     >
       <ChevronDownIcon />
-    </TextFieldIconButton>
+    </NestedSelectButton>
   );
   const hasItems = items.length !== 0;
   const isUnitValue = "unit" in value;
@@ -498,7 +491,7 @@ export const CssValueInput = ({
     <Combobox>
       <Box {...getComboboxProps()}>
         <ComboboxAnchor>
-          <TextField
+          <InputField
             disabled={disabled}
             {...inputProps}
             onFocus={() => {
@@ -512,9 +505,11 @@ export const CssValueInput = ({
             containerRef={scrubRef}
             inputRef={inputRef}
             name={property}
-            state={value.type === "invalid" ? "invalid" : undefined}
+            color={value.type === "invalid" ? "error" : undefined}
             prefix={prefix}
             suffix={suffix}
+            // no need for arrow focus unless we have a unit-select control to focus
+            arrowFocus={isUnitValue}
             css={{ cursor: "default" }}
           />
         </ComboboxAnchor>
@@ -535,27 +530,3 @@ export const CssValueInput = ({
     </Combobox>
   );
 };
-
-const CssValueInputIconButton = styled(TextFieldIcon, {
-  variants: {
-    state: {
-      set: {
-        backgroundColor: theme.colors.blue4,
-        color: theme.colors.blue11,
-        "&:hover": {
-          backgroundColor: theme.colors.blue4,
-          color: theme.colors.blue11,
-        },
-      },
-
-      inherited: {
-        backgroundColor: theme.colors.orange4,
-        color: theme.colors.orange11,
-        "&:hover": {
-          backgroundColor: theme.colors.orange4,
-          color: theme.colors.orange11,
-        },
-      },
-    },
-  },
-});

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -25,6 +25,7 @@ import {
   useCallback,
   useEffect,
   useRef,
+  ReactNode,
 } from "react";
 import { useUnitSelect } from "./unit-select";
 import { unstable_batchedUpdates as unstableBatchedUpdates } from "react-dom";
@@ -226,6 +227,8 @@ type CssValueInputProps = {
   }) => void;
   onHighlight: (value: StyleValue | undefined) => void;
   onAbort: () => void;
+  icon?: ReactNode;
+  prefix?: ReactNode;
 };
 
 const initialValue: IntermediateStyleValue = {
@@ -285,6 +288,7 @@ const match = <Item,>(
  */
 export const CssValueInput = ({
   icon,
+  prefix,
   styleSource,
   property,
   keywords = [],
@@ -292,7 +296,7 @@ export const CssValueInput = ({
   onAbort,
   disabled,
   ...props
-}: CssValueInputProps & { icon?: JSX.Element }) => {
+}: CssValueInputProps) => {
   const value = props.intermediateValue ?? props.value ?? initialValue;
 
   const onChange = (input: string | undefined) => {
@@ -456,19 +460,22 @@ export const CssValueInput = ({
     onKeyDown: inputProps.onKeyDown,
   });
 
-  const prefix = icon && (
-    <NestedIconLabel
-      color={styleSource}
-      css={value.type === "unit" ? { cursor: "ew-resize" } : undefined}
-    >
-      {icon}
-    </NestedIconLabel>
-  );
+  const finalPrefix =
+    prefix ||
+    (icon && (
+      <NestedIconLabel
+        color={styleSource}
+        css={value.type === "unit" ? { cursor: "ew-resize" } : undefined}
+      >
+        {icon}
+      </NestedIconLabel>
+    ));
 
   const keywordButtonElement = (
     <NestedSelectButton
       {...getToggleButtonProps()}
       data-state={isOpen ? "open" : "closed"}
+      tabIndex={-1}
     >
       <ChevronDownIcon />
     </NestedSelectButton>
@@ -506,10 +513,8 @@ export const CssValueInput = ({
             inputRef={inputRef}
             name={property}
             color={value.type === "invalid" ? "error" : undefined}
-            prefix={prefix}
+            prefix={finalPrefix}
             suffix={suffix}
-            // no need for arrow focus unless we have a unit-select control to focus
-            arrowFocus={isUnitValue}
             css={{ cursor: "default" }}
           />
         </ComboboxAnchor>

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/unit-select.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/unit-select.tsx
@@ -8,9 +8,8 @@ import {
   SelectViewport,
   SelectItem,
   SelectContent,
-  TextFieldIconButton,
-  styled,
-  deprecatedTextStyle,
+  NestedSelectButton,
+  nestedSelectButtonUnitless,
 } from "@webstudio-is/design-system";
 import { ChevronDownIcon, ChevronUpIcon } from "@webstudio-is/icons";
 
@@ -44,7 +43,7 @@ export const useUnitSelect = ({
     const { unitGroups } = properties[property as keyof typeof properties];
     for (const unitGroup of unitGroups) {
       if (unitGroup === "number") {
-        options.push({ id: "number", label: "—" });
+        options.push({ id: "number", label: nestedSelectButtonUnitless });
         continue;
       }
       const visibleUnits =
@@ -55,7 +54,7 @@ export const useUnitSelect = ({
     }
 
     if (showUnitless && !options.some((o) => o.id === "number")) {
-      options.push({ id: "number", label: "—" });
+      options.push({ id: "number", label: nestedSelectButtonUnitless });
     }
 
     return options;
@@ -83,10 +82,6 @@ export const useUnitSelect = ({
   return [isOpen, select];
 };
 
-const StyledTrigger = styled(TextFieldIconButton, deprecatedTextStyle, {
-  px: 3,
-});
-
 type UnitSelectProps = {
   options: Array<UnitOption>;
   value: string;
@@ -113,13 +108,12 @@ const UnitSelect = ({
       open={open}
     >
       <SelectPrimitive.SelectTrigger asChild>
-        <StyledTrigger variant="unit">
+        <NestedSelectButton tabIndex={-1}>
           <SelectPrimitive.Value>
-            {/* fallback to uppercased value for not listed units, show - for number unit */}
             {matchedOption?.label ??
-              (value === "number" ? "—" : value.toLocaleUpperCase())}
+              (value === "number" ? nestedSelectButtonUnitless : value)}
           </SelectPrimitive.Value>
-        </StyledTrigger>
+        </NestedSelectButton>
       </SelectPrimitive.SelectTrigger>
       <SelectPrimitive.Portal>
         <SelectContent

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
@@ -19,9 +19,9 @@ import {
   Combobox,
   ComboboxAnchor,
   ComboboxContent,
-  TextFieldContainer,
-  TextFieldInput,
-  useTextFieldFocus,
+  DeprecatedTextFieldContainer,
+  DeprecatedTextFieldInput,
+  useDeprecatedTextFieldFocus,
   useCombobox,
   type CSS,
   ComboboxLabel,
@@ -65,7 +65,7 @@ type TextFieldBaseWrapperProps<Item extends IntermediateItem> = Omit<
   "value"
 > &
   Pick<
-    ComponentProps<typeof TextFieldContainer>,
+    ComponentProps<typeof DeprecatedTextFieldContainer>,
     "variant" | "state" | "css"
   > & {
     value: Array<Item>;
@@ -109,7 +109,7 @@ const TextFieldBase: ForwardRefRenderFunction<
     editingItemId,
     ...textFieldProps
   } = props;
-  const [internalInputRef, focusProps] = useTextFieldFocus({
+  const [internalInputRef, focusProps] = useDeprecatedTextFieldFocus({
     disabled,
     onFocus,
     onBlur,
@@ -120,7 +120,7 @@ const TextFieldBase: ForwardRefRenderFunction<
   });
 
   return (
-    <TextFieldContainer
+    <DeprecatedTextFieldContainer
       {...focusProps}
       aria-disabled={disabled}
       ref={mergeRefs(forwardedRef, containerRef ?? null, sortableRefCallback)}
@@ -161,7 +161,7 @@ const TextFieldBase: ForwardRefRenderFunction<
       {placementIndicator}
       {/* We want input to be the first element in DOM so it receives the focus first */}
       {editingItemId === undefined && (
-        <TextFieldInput
+        <DeprecatedTextFieldInput
           {...textFieldProps}
           value={label}
           type={type}
@@ -171,7 +171,7 @@ const TextFieldBase: ForwardRefRenderFunction<
           aria-label="New Style Source Input"
         />
       )}
-    </TextFieldContainer>
+    </DeprecatedTextFieldContainer>
   );
 };
 

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -7,7 +7,7 @@ import {
   Flex,
   Label,
   Link,
-  TextField,
+  DeprecatedTextField,
   useId,
   Tooltip,
   FloatingPanelPopover,
@@ -58,7 +58,7 @@ const Content = ({ project }: PublishButtonProps) => {
           <Flex gap="2" align="center">
             <input type="hidden" name="projectId" value={project.id} />
             <Label htmlFor={id}>Domain:</Label>
-            <TextField id={id} name="domain" defaultValue={domain} />
+            <DeprecatedTextField id={id} name="domain" defaultValue={domain} />
           </Flex>
           {fetcher.data?.errors !== undefined && (
             <Text color="destructive">{fetcher.data?.errors}</Text>

--- a/apps/builder/app/dashboard/projects/project-dialogs.tsx
+++ b/apps/builder/app/dashboard/projects/project-dialogs.tsx
@@ -5,7 +5,7 @@ import {
   Flex,
   Label,
   Text,
-  TextField,
+  DeprecatedTextField,
   theme,
 } from "@webstudio-is/design-system";
 import { PlusIcon } from "@webstudio-is/icons";
@@ -68,7 +68,7 @@ const DialogContent = ({
           </DialogDescription>
         )}
         <Label>{label}</Label>
-        <TextField
+        <DeprecatedTextField
           placeholder={placeholder}
           name="title"
           defaultValue={title}

--- a/apps/builder/app/shared/share-project/share-project.tsx
+++ b/apps/builder/app/shared/share-project/share-project.tsx
@@ -10,7 +10,7 @@ import {
   rawTheme,
   Separator,
   Switch,
-  TextField,
+  DeprecatedTextField,
   theme,
   Tooltip,
   useId,
@@ -88,7 +88,7 @@ const Menu = ({
       <PopoverContent css={{ zIndex: theme.zIndices[1] }}>
         <Item>
           <Label>Name</Label>
-          <TextField
+          <DeprecatedTextField
             autoFocus
             value={name}
             onChange={(event) => {

--- a/packages/design-system/src/components/__DEPRECATED__/text-field.stories.tsx
+++ b/packages/design-system/src/components/__DEPRECATED__/text-field.stories.tsx
@@ -1,66 +1,69 @@
 import * as React from "react";
 import type { ComponentStory } from "@storybook/react";
 import { RowGapIcon, ChevronDownIcon } from "@webstudio-is/icons";
-import { Button } from "./button";
-import { Flex } from "./flex";
-import { DeprecatedIconButton } from "./__DEPRECATED__/icon-button";
-import { TextField } from "./text-field";
-import { Box } from "./box";
-import { Grid } from "./grid";
-import { DeprecatedText2 } from "./__DEPRECATED__/text2";
-import { theme } from "../stitches.config";
+import { Button } from "../button";
+import { Flex } from "../flex";
+import { DeprecatedIconButton } from "./icon-button";
+import { DeprecatedTextField } from "./text-field";
+import { Box } from "../box";
+import { Grid } from "../grid";
+import { DeprecatedText2 } from "./text2";
+import { theme } from "../../stitches.config";
 
 export default {
-  component: TextField,
+  component: DeprecatedTextField,
   argTypes: {
     onFocus: { action: true },
     onBlur: { action: true },
   },
 };
 
-export const Default: ComponentStory<typeof TextField> = () => {
-  return <TextField />;
+export const Default: ComponentStory<typeof DeprecatedTextField> = () => {
+  return <DeprecatedTextField />;
 };
 
-export const NativeProps: ComponentStory<typeof TextField> = () => {
+export const NativeProps: ComponentStory<typeof DeprecatedTextField> = () => {
   return (
     <Flex direction="column" gap={3}>
-      <TextField placeholder="This is a placeholder" />
-      <TextField disabled placeholder="This is a disabled placeholder" />
-      <TextField type="number" defaultValue={25} />
-      <TextField type="search" placeholder="This is a search input" />
-      <TextField type="button" defaultValue={"Arial"} />
-      <TextField readOnly value="Read-only" />
-      <TextField disabled value="Disabled" />
+      <DeprecatedTextField placeholder="This is a placeholder" />
+      <DeprecatedTextField
+        disabled
+        placeholder="This is a disabled placeholder"
+      />
+      <DeprecatedTextField type="number" defaultValue={25} />
+      <DeprecatedTextField type="search" placeholder="This is a search input" />
+      <DeprecatedTextField type="button" defaultValue={"Arial"} />
+      <DeprecatedTextField readOnly value="Read-only" />
+      <DeprecatedTextField disabled value="Disabled" />
     </Flex>
   );
 };
 
-export const Variants: ComponentStory<typeof TextField> = () => {
+export const Variants: ComponentStory<typeof DeprecatedTextField> = () => {
   return (
     <Flex direction="column" gap={3}>
-      <TextField />
-      <TextField variant="ghost" />
-      <TextField type="button" />
-      <TextField type="button" state="active" />
+      <DeprecatedTextField />
+      <DeprecatedTextField variant="ghost" />
+      <DeprecatedTextField type="button" />
+      <DeprecatedTextField type="button" state="active" />
     </Flex>
   );
 };
 
-export const State: ComponentStory<typeof TextField> = () => {
+export const State: ComponentStory<typeof DeprecatedTextField> = () => {
   return (
     <Flex direction="column" gap={3}>
-      <TextField />
-      <TextField state="invalid" />
-      <TextField state="valid" />
+      <DeprecatedTextField />
+      <DeprecatedTextField state="invalid" />
+      <DeprecatedTextField state="valid" />
     </Flex>
   );
 };
 
-export const PrefixSuffix: ComponentStory<typeof TextField> = () => {
+export const PrefixSuffix: ComponentStory<typeof DeprecatedTextField> = () => {
   return (
     <Flex direction="column" gap={3}>
-      <TextField
+      <DeprecatedTextField
         prefix={<RowGapIcon />}
         suffix={
           <DeprecatedIconButton>
@@ -68,7 +71,7 @@ export const PrefixSuffix: ComponentStory<typeof TextField> = () => {
           </DeprecatedIconButton>
         }
       />
-      <TextField
+      <DeprecatedTextField
         state="invalid"
         prefix={<RowGapIcon />}
         suffix={
@@ -77,7 +80,7 @@ export const PrefixSuffix: ComponentStory<typeof TextField> = () => {
           </DeprecatedIconButton>
         }
       />
-      <TextField
+      <DeprecatedTextField
         disabled
         prefix={<RowGapIcon />}
         suffix={
@@ -90,11 +93,11 @@ export const PrefixSuffix: ComponentStory<typeof TextField> = () => {
   );
 };
 
-export const Layout: ComponentStory<typeof TextField> = () => {
+export const Layout: ComponentStory<typeof DeprecatedTextField> = () => {
   return (
     <>
       <Flex direction="row" gap={2} css={{ justifyContent: "space-between" }}>
-        <TextField
+        <DeprecatedTextField
           value="Long content comes here and it doesn't wrap"
           prefix={<RowGapIcon />}
           suffix={
@@ -108,7 +111,7 @@ export const Layout: ComponentStory<typeof TextField> = () => {
           }}
         />
         <Box css={{ background: theme.colors.muted }}>Content</Box>
-        <TextField
+        <DeprecatedTextField
           state="invalid"
           value="Long content comes here and it doesn't wrap"
         />
@@ -128,7 +131,7 @@ export const Layout: ComponentStory<typeof TextField> = () => {
           </DeprecatedText2>
         </Box>
         <Box css={{ background: theme.colors.muted }}>
-          <TextField
+          <DeprecatedTextField
             id="field"
             value="Long content comes here and it doesn't wrap"
             prefix={<RowGapIcon />}
@@ -139,7 +142,7 @@ export const Layout: ComponentStory<typeof TextField> = () => {
             This is a label
           </DeprecatedText2>
         </Box>
-        <TextField
+        <DeprecatedTextField
           id="field2"
           value="Long content comes here and it doesn't wrap"
         />
@@ -148,14 +151,19 @@ export const Layout: ComponentStory<typeof TextField> = () => {
   );
 };
 
-export const Interactive: ComponentStory<typeof TextField> = () => {
+export const Interactive: ComponentStory<typeof DeprecatedTextField> = () => {
   const [value, setValue] = React.useState("");
   const wrapperRef = React.useRef<HTMLDivElement>(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   return (
     <Flex direction="column" gap={3}>
-      <TextField ref={wrapperRef} inputRef={inputRef} value={value} readOnly />
+      <DeprecatedTextField
+        ref={wrapperRef}
+        inputRef={inputRef}
+        value={value}
+        readOnly
+      />
       <Button
         onClick={() => {
           // eslint-disable-next-line no-console

--- a/packages/design-system/src/components/__DEPRECATED__/text-field.tsx
+++ b/packages/design-system/src/components/__DEPRECATED__/text-field.tsx
@@ -5,10 +5,9 @@ import React, {
   type FocusEventHandler,
 } from "react";
 import { useFocusWithin } from "@react-aria/interactions";
-import { css, styled } from "../stitches.config";
+import { css, styled, theme } from "../../stitches.config";
 import { ChevronLeftIcon } from "@webstudio-is/icons";
 import { cssVars } from "@webstudio-is/css-vars";
-import { theme } from "../stitches.config";
 
 const backgroundColorVar = cssVars.define("background-color");
 const colorVar = cssVars.define("color");
@@ -36,50 +35,13 @@ const textFieldIconBaseStyle = css({
   borderRadius: 2,
 });
 
-// Trigger can be used as a button, which is focusable/hoverable itself or as an icon,
-// which has the same states but activated over the parent component element.
-export const TextFieldIconButton = styled(
-  "button",
-  {
-    background: "none",
-    border: "none",
-    boxSizing: "border-box",
-    fontFamily: "inherit",
-    fontSize: "inherit",
-    color: "inherit",
-    padding: 0,
-    margin: 0,
-    "&:hover": {
-      backgroundColor: theme.colors.slate7,
-      color: theme.colors.hiContrast,
-    },
-    "&:focus": {
-      backgroundColor: theme.colors.blue10,
-      color: "white",
-    },
-    variants: {
-      state: {
-        active: {
-          backgroundColor: theme.colors.blue10,
-          color: "white",
-          "&:hover": {
-            backgroundColor: theme.colors.blue10,
-            color: "white",
-          },
-        },
-      },
-    },
-  },
-  textFieldIconBaseStyle
-);
-
-export const TextFieldIcon = styled("span", textFieldIconBaseStyle, {
+const DeprecatedTextFieldIcon = styled("span", textFieldIconBaseStyle, {
   // Icon receives colors from parent.
   backgroundColor: cssVars.use(backgroundColorVar),
   color: cssVars.use(colorVar),
 });
 
-export const TextFieldInput = styled("input", {
+export const DeprecatedTextFieldInput = styled("input", {
   // Reset
   appearance: "none",
   borderWidth: "0",
@@ -139,7 +101,7 @@ export const TextFieldInput = styled("input", {
   },
 });
 
-export const TextFieldContainer = styled("div", {
+export const DeprecatedTextFieldContainer = styled("div", {
   // Custom
   display: "flex",
   flexWrap: "wrap",
@@ -247,7 +209,7 @@ const SuffixSlot = styled("div", {
   borderRadius: 2,
 });
 
-export const useTextFieldFocus = ({
+export const useDeprecatedTextFieldFocus = ({
   disabled,
   onFocus,
   onBlur,
@@ -257,7 +219,7 @@ export const useTextFieldFocus = ({
   onBlur?: FocusEventHandler<HTMLInputElement>;
 }): [
   RefObject<HTMLInputElement>,
-  ComponentProps<typeof TextFieldContainer>
+  ComponentProps<typeof DeprecatedTextFieldContainer>
 ] => {
   const ref = React.useRef<HTMLInputElement>(null);
 
@@ -287,8 +249,8 @@ export const useTextFieldFocus = ({
   ];
 };
 
-export type TextFieldProps = Pick<
-  React.ComponentProps<typeof TextFieldContainer>,
+export type DeprecatedTextFieldProps = Pick<
+  React.ComponentProps<typeof DeprecatedTextFieldContainer>,
   "variant" | "state" | "css"
 > &
   Omit<React.ComponentProps<"input">, "prefix" | "children"> & {
@@ -298,72 +260,73 @@ export type TextFieldProps = Pick<
     suffix?: React.ReactNode;
   };
 
-export const TextField = React.forwardRef<HTMLDivElement, TextFieldProps>(
-  (props, forwardedRef) => {
-    const {
-      prefix,
-      css,
-      disabled,
-      containerRef,
-      inputRef,
-      state,
-      variant: variantProp,
-      onFocus,
-      onBlur,
-      onClick,
-      type,
-      onKeyDown,
-      // prevent spreading it into the dom
-      suffix: suffixProp,
-      ...textFieldProps
-    } = props;
-    let suffix = suffixProp;
-    const variant =
-      type === "button" && variantProp === undefined ? "button" : variantProp;
+export const DeprecatedTextField = React.forwardRef<
+  HTMLDivElement,
+  DeprecatedTextFieldProps
+>((props, forwardedRef) => {
+  const {
+    prefix,
+    css,
+    disabled,
+    containerRef,
+    inputRef,
+    state,
+    variant: variantProp,
+    onFocus,
+    onBlur,
+    onClick,
+    type,
+    onKeyDown,
+    // prevent spreading it into the dom
+    suffix: suffixProp,
+    ...textFieldProps
+  } = props;
+  let suffix = suffixProp;
+  const variant =
+    type === "button" && variantProp === undefined ? "button" : variantProp;
 
-    const [internalInputRef, focusProps] = useTextFieldFocus({
-      disabled,
-      onFocus,
-      onBlur,
-    });
+  const [internalInputRef, focusProps] = useDeprecatedTextFieldFocus({
+    disabled,
+    onFocus,
+    onBlur,
+  });
 
-    if (type === "button" && suffix === undefined) {
-      suffix = (
-        <TextFieldIcon
-          as={ChevronLeftIcon}
-          onClick={() => {
-            internalInputRef.current?.click();
-          }}
-        />
-      );
-    }
-
-    return (
-      <TextFieldContainer
-        {...focusProps}
-        aria-disabled={disabled}
-        ref={mergeRefs(forwardedRef, containerRef ?? null)}
-        state={state}
-        variant={variant}
-        css={css}
-        withPrefix={Boolean(prefix)}
-        withSuffix={Boolean(suffix)}
-        onKeyDown={onKeyDown}
-      >
-        {/* We want input to be the first element in DOM so it receives the focus first */}
-        <TextFieldInput
-          {...textFieldProps}
-          type={type}
-          disabled={disabled}
-          onClick={onClick}
-          ref={mergeRefs(internalInputRef, inputRef ?? null)}
-        />
-
-        {prefix && <PrefixSlot>{prefix}</PrefixSlot>}
-        {suffix && <SuffixSlot>{suffix}</SuffixSlot>}
-      </TextFieldContainer>
+  if (type === "button" && suffix === undefined) {
+    suffix = (
+      <DeprecatedTextFieldIcon
+        as={ChevronLeftIcon}
+        onClick={() => {
+          internalInputRef.current?.click();
+        }}
+      />
     );
   }
-);
 
-TextField.displayName = "TextField";
+  return (
+    <DeprecatedTextFieldContainer
+      {...focusProps}
+      aria-disabled={disabled}
+      ref={mergeRefs(forwardedRef, containerRef ?? null)}
+      state={state}
+      variant={variant}
+      css={css}
+      withPrefix={Boolean(prefix)}
+      withSuffix={Boolean(suffix)}
+      onKeyDown={onKeyDown}
+    >
+      {/* We want input to be the first element in DOM so it receives the focus first */}
+      <DeprecatedTextFieldInput
+        {...textFieldProps}
+        type={type}
+        disabled={disabled}
+        onClick={onClick}
+        ref={mergeRefs(internalInputRef, inputRef ?? null)}
+      />
+
+      {prefix && <PrefixSlot>{prefix}</PrefixSlot>}
+      {suffix && <SuffixSlot>{suffix}</SuffixSlot>}
+    </DeprecatedTextFieldContainer>
+  );
+});
+
+DeprecatedTextField.displayName = "TextField";

--- a/packages/design-system/src/components/combobox.stories.tsx
+++ b/packages/design-system/src/components/combobox.stories.tsx
@@ -1,6 +1,6 @@
 import { MagnifyingGlassIcon } from "@webstudio-is/icons";
 import React, { useCallback } from "react";
-import { TextField } from "./text-field";
+import { DeprecatedTextField } from "./__DEPRECATED__/text-field";
 import {
   ComboboxListboxItem,
   useCombobox,
@@ -58,7 +58,7 @@ export const Complex = () => {
       {...getComboboxProps()}
       css={{ flexDirection: "column", gap: theme.spacing[9] }}
     >
-      <TextField
+      <DeprecatedTextField
         type="search"
         prefix={<MagnifyingGlassIcon />}
         {...getInputProps({})}

--- a/packages/design-system/src/components/enhanced-tooltip.stories.tsx
+++ b/packages/design-system/src/components/enhanced-tooltip.stories.tsx
@@ -1,5 +1,5 @@
 // import React, { useCallback } from "react";
-import { TextField } from "./text-field";
+import { DeprecatedTextField } from "./__DEPRECATED__/text-field";
 import { EnhancedTooltip, EnhancedTooltipProvider } from "./enhanced-tooltip";
 import { Flex } from "./flex";
 
@@ -12,7 +12,7 @@ export const Simple = () => {
     <EnhancedTooltipProvider>
       <Flex>
         <EnhancedTooltip content="Hello world">
-          <TextField />
+          <DeprecatedTextField />
         </EnhancedTooltip>
       </Flex>
     </EnhancedTooltipProvider>

--- a/packages/design-system/src/components/input-field.stories.tsx
+++ b/packages/design-system/src/components/input-field.stories.tsx
@@ -1,0 +1,75 @@
+import { RowGapIcon } from "@webstudio-is/icons";
+import { Flex } from "./flex";
+import { InputField, inputFieldColors } from "./input-field";
+import { NestedIconLabel } from "./nested-icon-label";
+import { NestedSelectButton } from "./nested-select-button";
+import { StorySection, StoryGrid } from "./storybook";
+
+export default {
+  title: "Library/Input Field",
+};
+
+const prefix = (
+  <NestedIconLabel color="local">
+    <RowGapIcon />
+  </NestedIconLabel>
+);
+
+const suffix = <NestedSelectButton />;
+
+export const Demo = () => (
+  <>
+    <StorySection title="Basic">
+      <StoryGrid horizontal>
+        {inputFieldColors.map((color) => (
+          <InputField key={color} defaultValue={color} color={color} />
+        ))}
+        <InputField defaultValue="disabled" disabled />
+        <InputField placeholder="Actual placeholder" />
+      </StoryGrid>
+    </StorySection>
+
+    <StorySection title="Nested Controls">
+      <StoryGrid horizontal>
+        {inputFieldColors.map((color) => (
+          <InputField
+            key={color}
+            defaultValue={color}
+            color={color}
+            prefix={prefix}
+            suffix={suffix}
+            arrowFocus
+          />
+        ))}
+        <InputField
+          defaultValue="disabled"
+          prefix={
+            <NestedIconLabel disabled color="local" tabIndex={-1}>
+              <RowGapIcon />
+            </NestedIconLabel>
+          }
+          suffix={<NestedSelectButton disabled />}
+          disabled
+        />
+      </StoryGrid>
+    </StorySection>
+
+    <StorySection title="Width text">
+      <StoryGrid>
+        {[300, 100].map((width) => (
+          <>
+            <Flex css={{ width, background: "black", height: 4 }} />
+            <Flex
+              css={{ width, justifyItems: "stretch", flexDirection: "column" }}
+            >
+              <InputField prefix={prefix} suffix={suffix} />
+            </Flex>
+            <InputField prefix={prefix} suffix={suffix} css={{ width }} />
+          </>
+        ))}
+      </StoryGrid>
+    </StorySection>
+  </>
+);
+
+Demo.storyName = "Input Field";

--- a/packages/design-system/src/components/input-field.stories.tsx
+++ b/packages/design-system/src/components/input-field.stories.tsx
@@ -10,12 +10,12 @@ export default {
 };
 
 const prefix = (
-  <NestedIconLabel color="local">
+  <NestedIconLabel color="local" tabIndex={-1}>
     <RowGapIcon />
   </NestedIconLabel>
 );
 
-const suffix = <NestedSelectButton />;
+const suffix = <NestedSelectButton tabIndex={-1} />;
 
 export const Demo = () => (
   <>
@@ -43,7 +43,7 @@ export const Demo = () => (
         <InputField
           defaultValue="disabled"
           prefix={
-            <NestedIconLabel disabled color="local" tabIndex={-1}>
+            <NestedIconLabel disabled color="local">
               <RowGapIcon />
             </NestedIconLabel>
           }

--- a/packages/design-system/src/components/input-field.stories.tsx
+++ b/packages/design-system/src/components/input-field.stories.tsx
@@ -38,7 +38,6 @@ export const Demo = () => (
             color={color}
             prefix={prefix}
             suffix={suffix}
-            arrowFocus
           />
         ))}
         <InputField

--- a/packages/design-system/src/components/input-field.stories.tsx
+++ b/packages/design-system/src/components/input-field.stories.tsx
@@ -53,6 +53,17 @@ export const Demo = () => (
       </StoryGrid>
     </StorySection>
 
+    <StorySection title="Focused (initially)">
+      <StoryGrid horizontal>
+        <InputField
+          defaultValue="Some value"
+          prefix={prefix}
+          suffix={suffix}
+          autoFocus
+        />
+      </StoryGrid>
+    </StorySection>
+
     <StorySection title="Width text">
       <StoryGrid>
         {[300, 100].map((width) => (

--- a/packages/design-system/src/components/input-field.tsx
+++ b/packages/design-system/src/components/input-field.tsx
@@ -3,7 +3,12 @@
  * https://www.figma.com/file/sfCE7iLS0k25qCxiifQNLE/%F0%9F%93%9A-Webstudio-Library?node-id=4-3304
  */
 
-import { forwardRef, ReactNode, type ComponentProps, type Ref } from "react";
+import {
+  forwardRef,
+  type ReactNode,
+  type ComponentProps,
+  type Ref,
+} from "react";
 import { textVariants } from "./text";
 import { css, theme, type CSS } from "../stitches.config";
 import { ArrowFocus } from "./primitives/arrow-focus";

--- a/packages/design-system/src/components/input-field.tsx
+++ b/packages/design-system/src/components/input-field.tsx
@@ -83,10 +83,8 @@ const Container = forwardRef(
       css,
       prefix,
       suffix,
-      arrowFocus = false,
       ...props
     }: {
-      arrowFocus?: boolean;
       children: ReactNode;
       prefix?: ReactNode;
       suffix?: ReactNode;
@@ -94,7 +92,8 @@ const Container = forwardRef(
     } & Omit<ComponentProps<"div">, "prefix">,
     ref: Ref<HTMLDivElement>
   ) => {
-    if (arrowFocus === false) {
+    // no reason to use ArrowFocus if there's no prefix or suffix
+    if (!prefix && !suffix) {
       return (
         <div
           className={containerStyle({ className, css })}
@@ -168,15 +167,12 @@ export const InputField = forwardRef(
       suffix,
       containerRef,
       inputRef,
-      arrowFocus,
       ...props
     }: InputProps & {
       prefix?: ReactNode;
       suffix?: ReactNode;
       containerRef?: Ref<HTMLDivElement>;
       inputRef?: Ref<HTMLInputElement>;
-      /** whether arrow keys should move focus between input/suffix/prefix */
-      arrowFocus?: boolean;
     },
     ref: Ref<HTMLDivElement>
   ) => (
@@ -185,7 +181,6 @@ export const InputField = forwardRef(
       className={className}
       prefix={prefix}
       suffix={suffix}
-      arrowFocus={arrowFocus}
       ref={mergeRefs(ref, containerRef ?? null)}
     >
       <Input {...props} ref={inputRef} />

--- a/packages/design-system/src/components/input-field.tsx
+++ b/packages/design-system/src/components/input-field.tsx
@@ -1,0 +1,190 @@
+/**
+ * Implementation of the "Input Field" component from:
+ * https://www.figma.com/file/sfCE7iLS0k25qCxiifQNLE/%F0%9F%93%9A-Webstudio-Library?node-id=4-3304
+ */
+
+import { forwardRef, ReactNode, type ComponentProps, type Ref } from "react";
+import { textVariants } from "./text";
+import { css, theme, type CSS } from "../stitches.config";
+import { ArrowFocus } from "./primitives/arrow-focus";
+import { mergeRefs } from "@react-aria/utils";
+
+// we only support types that behave more or less like a regular text input
+export const inputFieldTypes = [
+  "email",
+  "password",
+  "tel",
+  "text",
+  "url",
+] as const;
+
+export const inputFieldColors = ["placeholder", "set", "error"] as const;
+
+const inputStyle = css({
+  all: "unset",
+  ...textVariants.regular,
+  color: theme.colors.foregroundMain,
+  flexGrow: 1,
+  flexShrink: 1,
+  minWidth: 0,
+  height: "100%",
+  paddingRight: theme.spacing[2],
+  paddingLeft: theme.spacing[3],
+  "&[data-color=placeholder]:not(:hover):not(:disabled), &::placeholder": {
+    color: theme.colors.foregroundSubtle,
+  },
+  "&[data-color=error]": { color: theme.colors.foregroundDestructive },
+  "&:disabled, &:disabled::placeholder": {
+    color: theme.colors.foregroundDisabled,
+  },
+});
+
+const containerStyle = css({
+  display: "flex",
+  height: theme.spacing[12],
+  boxSizing: "border-box",
+  alignItems: "center",
+  borderRadius: theme.borderRadius[4],
+  border: `solid 1px ${theme.colors.borderMain}`,
+  backgroundColor: theme.colors.backgroundControls,
+
+  "&:has([data-input-field-input]:focus), &:focus": {
+    outline: `solid 2px ${theme.colors.borderFocus}`,
+    outlineOffset: "-1px",
+  },
+
+  "&:has([data-input-field-input][data-color=error])": {
+    borderColor: theme.colors.borderDestructiveMain,
+  },
+
+  "&:has([data-input-field-input]:disabled)": {
+    backgroundColor: theme.colors.backgroundInputDisabled,
+  },
+});
+
+const suffixSlotStyle = css({
+  marginRight: theme.spacing[1],
+});
+
+const prefixSlotStyle = css({
+  marginLeft: theme.spacing[1],
+});
+
+const Container = forwardRef(
+  (
+    {
+      children,
+      className,
+      css,
+      prefix,
+      suffix,
+      arrowFocus = false,
+      ...props
+    }: {
+      arrowFocus?: boolean;
+      children: ReactNode;
+      prefix?: ReactNode;
+      suffix?: ReactNode;
+      css?: CSS;
+    } & Omit<ComponentProps<"div">, "prefix">,
+    ref: Ref<HTMLDivElement>
+  ) => {
+    if (arrowFocus === false) {
+      return (
+        <div
+          className={containerStyle({ className, css })}
+          {...props}
+          ref={ref}
+        >
+          {children}
+        </div>
+      );
+    }
+
+    return (
+      <ArrowFocus
+        render={({ handleKeyDown }) => (
+          <div
+            className={containerStyle({ className, css })}
+            {...props}
+            onKeyDown={(event) => {
+              props.onKeyDown?.(event);
+
+              // ignore up/down,
+              // because they're likely used for dropdowns or increment/decrement
+              if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+                return;
+              }
+
+              handleKeyDown(event);
+            }}
+            ref={ref}
+          >
+            {prefix && <div className={prefixSlotStyle()}>{prefix}</div>}
+            {children}
+            {suffix && <div className={suffixSlotStyle()}>{suffix}</div>}
+          </div>
+        )}
+      />
+    );
+  }
+);
+Container.displayName = "Container";
+
+type InputProps = {
+  type?: (typeof inputFieldTypes)[number];
+  color?: (typeof inputFieldColors)[number];
+  css?: CSS;
+} & Omit<ComponentProps<"input">, "prefix">;
+
+const Input = forwardRef(
+  (
+    { css, className, color, disabled = false, ...props }: InputProps,
+    ref: Ref<HTMLInputElement>
+  ) => (
+    <input
+      {...props}
+      data-input-field-input // to distinguish from potential other inputs in prefix/suffix
+      data-color={color}
+      disabled={disabled}
+      className={inputStyle({ className, css })}
+      ref={ref}
+    />
+  )
+);
+Input.displayName = "Input";
+
+export const InputField = forwardRef(
+  (
+    {
+      css,
+      className,
+      prefix,
+      suffix,
+      containerRef,
+      inputRef,
+      arrowFocus,
+      ...props
+    }: InputProps & {
+      prefix?: ReactNode;
+      suffix?: ReactNode;
+      containerRef?: Ref<HTMLDivElement>;
+      inputRef?: Ref<HTMLInputElement>;
+      /** whether arrow keys should move focus between input/suffix/prefix */
+      arrowFocus?: boolean;
+    },
+    ref: Ref<HTMLDivElement>
+  ) => (
+    <Container
+      css={css}
+      className={className}
+      prefix={prefix}
+      suffix={suffix}
+      arrowFocus={arrowFocus}
+      ref={mergeRefs(ref, containerRef ?? null)}
+    >
+      <Input {...props} ref={inputRef} />
+    </Container>
+  )
+);
+InputField.displayName = "InputField";

--- a/packages/design-system/src/components/menu.stories.tsx
+++ b/packages/design-system/src/components/menu.stories.tsx
@@ -34,7 +34,7 @@ import {
   SelectGroup,
 } from "./select";
 import { MenuCheckedAndSetIcon, MenuSetDotIcon } from "./menu";
-import { TextField } from "./text-field";
+import { DeprecatedTextField } from "./__DEPRECATED__/text-field";
 import { Button } from "./button";
 import {
   ChevronDownIcon,
@@ -178,7 +178,7 @@ const ComboboxDemo = () => {
     <Combobox>
       <div {...getComboboxProps()}>
         <ComboboxAnchor>
-          <TextField
+          <DeprecatedTextField
             {...getInputProps()}
             placeholder="Enter: Apple"
             suffix={

--- a/packages/design-system/src/components/nested-select-button.stories.tsx
+++ b/packages/design-system/src/components/nested-select-button.stories.tsx
@@ -1,0 +1,31 @@
+import { NestedSelectButton } from "./nested-select-button";
+import { StoryGrid, StorySection } from "./storybook";
+
+export default {
+  title: "Library/Nested Select Button",
+};
+
+export const Demo = () => {
+  return (
+    <>
+      <StorySection title="Text">
+        <StoryGrid horizontal>
+          <NestedSelectButton>px</NestedSelectButton>
+          <NestedSelectButton data-state="hover">px</NestedSelectButton>
+          <NestedSelectButton data-state="open">px</NestedSelectButton>
+          <NestedSelectButton disabled>px</NestedSelectButton>
+        </StoryGrid>
+      </StorySection>
+      <StorySection title="Icon">
+        <StoryGrid horizontal>
+          <NestedSelectButton />
+          <NestedSelectButton data-state="hover" />
+          <NestedSelectButton data-state="open" />
+          <NestedSelectButton disabled />
+        </StoryGrid>
+      </StorySection>
+    </>
+  );
+};
+
+Demo.storyName = "Nested Select Button";

--- a/packages/design-system/src/components/nested-select-button.tsx
+++ b/packages/design-system/src/components/nested-select-button.tsx
@@ -1,0 +1,56 @@
+/**
+ * Implementation of the "Nested Select Button" component from:
+ * https://www.figma.com/file/sfCE7iLS0k25qCxiifQNLE/%F0%9F%93%9A-Webstudio-Library?node-id=148-3113
+ */
+
+import { ChevronDownIcon } from "@webstudio-is/icons";
+import { forwardRef, type ComponentProps, type Ref } from "react";
+import { textVariants } from "./text";
+import { type CSS, css, theme } from "../stitches.config";
+
+// From Figma:
+// In production the unitless unit should be an en dash with a space before and after
+export const nestedSelectButtonUnitless = " – ";
+
+const style = css({
+  all: "unset",
+  ...textVariants.unit,
+  color: theme.colors.foregroundSubtle,
+  borderRadius: theme.borderRadius[2],
+  display: "inline-flex",
+  alignItems: "center",
+  height: theme.spacing[11],
+  whiteSpace: "pre", // to make nestedSelectButtonUnitless work as expected
+  "&:not(:has(svg))": {
+    paddingLeft: theme.spacing[2],
+    paddingRight: theme.spacing[2],
+  },
+  "&[data-state=hover], &:not([data-state=open], :disabled):hover": {
+    color: theme.colors.foregroundMain,
+    backgroundColor: theme.colors.backgroundHover,
+  },
+  "&[data-state=open], &:focus-visible": {
+    color: theme.colors.foregroundContrastMain,
+    backgroundColor: theme.colors.backgroundActive,
+  },
+  "&:disabled": {
+    color: theme.colors.foregroundDisabled,
+  },
+});
+
+export const NestedSelectButton = forwardRef(
+  (
+    {
+      css,
+      className,
+      children = <ChevronDownIcon />,
+      ...props
+    }: ComponentProps<"button"> & { css?: CSS },
+    ref: Ref<HTMLButtonElement>
+  ) => (
+    <button className={style({ css, className })} {...props} ref={ref}>
+      {children}
+    </button>
+  )
+);
+NestedSelectButton.displayName = "NestedSelectButton";

--- a/packages/design-system/src/components/primitives/arrow-focus.tsx
+++ b/packages/design-system/src/components/primitives/arrow-focus.tsx
@@ -23,6 +23,21 @@ const ContextHelper = ({ render }: { render: Render }) => {
       event: KeyboardEvent,
       focusManagerOptions?: FocusManagerOptions
     ) => {
+      const { activeElement } = document;
+
+      // In a text input, arrow keys are used for moving the caret,
+      // so unless Alt is pressed, we don't want to move focus
+      //
+      // @todo: this may not set :focus-visible correctly
+      //        https://github.com/webstudio-is/webstudio-builder/issues/1364
+      if (
+        (activeElement instanceof HTMLInputElement ||
+          activeElement instanceof HTMLTextAreaElement) &&
+        event.altKey === false
+      ) {
+        return;
+      }
+
       if (event.key === "ArrowRight" || event.key === "ArrowDown") {
         focusManager.focusNext({ wrap: true, ...focusManagerOptions });
         event.preventDefault(); // Prevents the page from scrolling

--- a/packages/design-system/src/components/search-field.tsx
+++ b/packages/design-system/src/components/search-field.tsx
@@ -10,7 +10,7 @@ import {
   CrossCircledFilledIcon,
   MagnifyingGlassIcon,
 } from "@webstudio-is/icons";
-import { TextField } from "./text-field";
+import { DeprecatedTextField } from "./__DEPRECATED__/text-field";
 import { DeprecatedIconButton } from "./__DEPRECATED__/icon-button";
 import { styled } from "../stitches.config";
 import { theme } from "../stitches.config";
@@ -26,7 +26,7 @@ const AbortButton = styled(DeprecatedIconButton, {
 
 const SearchFieldBase: ForwardRefRenderFunction<
   HTMLInputElement,
-  ComponentProps<typeof TextField> & { onCancel?: () => void }
+  ComponentProps<typeof DeprecatedTextField> & { onCancel?: () => void }
 > = (props, ref) => {
   const {
     onChange,
@@ -41,7 +41,7 @@ const SearchFieldBase: ForwardRefRenderFunction<
     setValue(String(propsValue));
   }, [propsValue]);
   return (
-    <TextField
+    <DeprecatedTextField
       {...rest}
       ref={ref}
       type="search"

--- a/packages/design-system/src/components/section-title.tsx
+++ b/packages/design-system/src/components/section-title.tsx
@@ -1,5 +1,5 @@
 /**
- * Implementation of the "Title (title of: section)" component from:
+ * Implementation of the "Section Title" component from:
  * https://www.figma.com/file/sfCE7iLS0k25qCxiifQNLE/%F0%9F%93%9A-Webstudio-Library?node-id=2%3A12361
  *
  * Designed to be used with Collapsible.Trigger

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -32,6 +32,7 @@ export * from "./components/radio";
 export * from "./components/checkbox";
 export * from "./components/component-card";
 export * from "./components/primitives/arrow-focus";
+export * from "./components/nested-select-button";
 
 // Not aligned
 

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -41,7 +41,6 @@ export * as Collapsible from "@radix-ui/react-collapsible";
 export { AccessibleIcon } from "@radix-ui/react-accessible-icon";
 export * from "./components/toggle-group";
 export * from "./components/progress-radial";
-export * from "./components/text-field";
 export { SearchField } from "./components/search-field";
 export { Tabs, TabsContent, TabsList, TabsTrigger } from "./components/tabs";
 export {
@@ -88,3 +87,4 @@ export { DeprecatedHeading } from "./components/__DEPRECATED__/heading";
 export { DeprecatedLabel } from "./components/__DEPRECATED__/label";
 export * from "./components/__DEPRECATED__/popover";
 export * from "./components/__DEPRECATED__/paragraph";
+export * from "./components/__DEPRECATED__/text-field";

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -31,7 +31,7 @@ export * from "./components/text-area";
 export * from "./components/radio";
 export * from "./components/checkbox";
 export * from "./components/component-card";
-export * from "./components/primitives/arrow-focus";
+export * from "./components/input-field";
 export * from "./components/nested-select-button";
 
 // Not aligned
@@ -76,6 +76,7 @@ export { Grid } from "./components/grid";
 export * from "./components/primitives/dnd";
 export * from "./components/primitives/numeric-gesture-control";
 export * from "./components/primitives/is-truncated";
+export * from "./components/primitives/arrow-focus";
 
 // Deprecated
 


### PR DESCRIPTION
## Description

1. Added `InputField` aligned with Figma. [Demo](https://input-field--638245578b47d4399fba191a.chromatic.com/?path=/story/library-input-field--demo). Closes #614
2. Added `NestedSelectButton` that should be used as `InputField`'s suffix. [Demo](https://input-field--638245578b47d4399fba191a.chromatic.com/?path=/story/library-nested-select-button--demo)
3. Deprecated `TextField`
4. Used `InputField` instead of `TextField` in `CssValueInput`
5. Added support for `<input>` in `ArrowFocus`. Closes #1364

## Steps for reproduction

1. Open style panel
6. Test `CssValueInput`'s

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
