### PR TITLE
Move breakpoints schema to project-build

### DIFF
--- a/apps/builder/app/builder/features/breakpoints/breakpoints-editor.tsx
+++ b/apps/builder/app/builder/features/breakpoints/breakpoints-editor.tsx
@@ -2,8 +2,9 @@ import { useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
 import { nanoid } from "nanoid";
 import store from "immerhin";
-import type { Breakpoint } from "@webstudio-is/css-data";
+import type { Breakpoint } from "@webstudio-is/project-build";
 import {
+  theme,
   Button,
   TextField,
   Flex,
@@ -12,7 +13,6 @@ import {
 import { PlusIcon, TrashIcon } from "@webstudio-is/icons";
 import { breakpointsContainer, useBreakpoints } from "~/shared/nano-states";
 import { replaceByOrAppendMutable } from "~/shared/array-utils";
-import { theme } from "@webstudio-is/design-system";
 
 type BreakpointEditorItemProps = {
   breakpoint: Breakpoint;

--- a/apps/builder/app/builder/features/breakpoints/breakpoints.tsx
+++ b/apps/builder/app/builder/features/breakpoints/breakpoints.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
+import { useStore } from "@nanostores/react";
 import store from "immerhin";
-import type { Breakpoint } from "@webstudio-is/css-data";
-import { useSubscribe } from "~/shared/pubsub";
+import type { Breakpoint } from "@webstudio-is/project-build";
+import { utils } from "@webstudio-is/project";
 import {
   theme,
   DropdownMenu,
@@ -13,6 +14,7 @@ import {
   DropdownMenuTrigger,
   DropdownMenuItemRightSlot,
 } from "@webstudio-is/design-system";
+import { useSubscribe } from "~/shared/pubsub";
 import { BreakpointsEditor } from "./breakpoints-editor";
 import { Preview } from "./preview";
 import { ZoomSetting } from "./zoom-setting";
@@ -24,9 +26,7 @@ import {
   stylesStore,
   useBreakpoints,
 } from "~/shared/nano-states";
-import { utils } from "@webstudio-is/project";
 import { removeByMutable } from "~/shared/array-utils";
-import { useStore } from "@nanostores/react";
 import {
   selectedBreakpointIdStore,
   selectedBreakpointStore,

--- a/apps/builder/app/builder/features/breakpoints/confirmation-dialog.tsx
+++ b/apps/builder/app/builder/features/breakpoints/confirmation-dialog.tsx
@@ -1,6 +1,10 @@
-import type { Breakpoint } from "@webstudio-is/css-data";
-import { Button, Flex, DeprecatedParagraph } from "@webstudio-is/design-system";
-import { theme } from "@webstudio-is/design-system";
+import type { Breakpoint } from "@webstudio-is/project-build";
+import {
+  theme,
+  Button,
+  Flex,
+  DeprecatedParagraph,
+} from "@webstudio-is/design-system";
 
 type ConfirmationDialogProps = {
   onAbort: () => void;

--- a/apps/builder/app/builder/features/breakpoints/preview.tsx
+++ b/apps/builder/app/builder/features/breakpoints/preview.tsx
@@ -1,10 +1,10 @@
-import type { Breakpoint } from "@webstudio-is/css-data";
+import type { Breakpoint } from "@webstudio-is/project-build";
 import {
+  theme,
   DeprecatedParagraph,
   Flex,
   DeprecatedText2,
 } from "@webstudio-is/design-system";
-import { theme } from "@webstudio-is/design-system";
 
 type PreviewProps = {
   breakpoint?: Breakpoint;

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
@@ -1,5 +1,8 @@
-import type { Breakpoint } from "@webstudio-is/css-data";
-import type { Instance, StyleDecl } from "@webstudio-is/project-build";
+import type {
+  Breakpoint,
+  Instance,
+  StyleDecl,
+} from "@webstudio-is/project-build";
 import {
   getCascadedBreakpointIds,
   getCascadedInfo,

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.ts
@@ -1,14 +1,10 @@
 import { useMemo } from "react";
 import { useStore } from "@nanostores/react";
-import type {
-  Breakpoint,
-  Style,
-  StyleProperty,
-  StyleValue,
-} from "@webstudio-is/css-data";
+import type { Style, StyleProperty, StyleValue } from "@webstudio-is/css-data";
 import { properties } from "@webstudio-is/css-data";
 import { utils } from "@webstudio-is/project";
 import type {
+  Breakpoint,
   Instance,
   StyleDecl,
   StyleSource as StyleSourceType,

--- a/apps/builder/app/builder/shared/breakpoints/will-render.ts
+++ b/apps/builder/app/builder/shared/breakpoints/will-render.ts
@@ -1,4 +1,4 @@
-import type { Breakpoint } from "@webstudio-is/css-data";
+import type { Breakpoint } from "@webstudio-is/project-build";
 
 export const willRender = (breakpoint: Breakpoint, canvasWidth: number) =>
   canvasWidth >= breakpoint.minWidth;

--- a/apps/builder/app/shared/nano-states/breakpoints.ts
+++ b/apps/builder/app/shared/nano-states/breakpoints.ts
@@ -1,5 +1,5 @@
 import { atom, computed } from "nanostores";
-import type { Breakpoint } from "@webstudio-is/css-data";
+import type { Breakpoint } from "@webstudio-is/project-build";
 import { utils } from "@webstudio-is/project";
 import { breakpointsContainer } from "./nano-states";
 

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -5,6 +5,7 @@ import { nanoid } from "nanoid";
 import type { AuthPermit } from "@webstudio-is/trpc-interface";
 import type { Asset } from "@webstudio-is/asset-uploader";
 import type {
+  Breakpoint,
   Instance,
   Prop,
   Props,
@@ -17,7 +18,7 @@ import type {
   StyleSourceSelections,
   Tree,
 } from "@webstudio-is/project-build";
-import type { Breakpoint, Style } from "@webstudio-is/css-data";
+import type { Style } from "@webstudio-is/css-data";
 import type {
   DropTargetChangePayload,
   DragStartPayload,

--- a/packages/css-data/src/schema.ts
+++ b/packages/css-data/src/schema.ts
@@ -152,15 +152,3 @@ export const CssRule = z.object({
 });
 
 export type CssRule = z.infer<typeof CssRule>;
-
-export const Breakpoint = z.object({
-  id: z.string(),
-  label: z.string(),
-  minWidth: z.number(),
-});
-
-export type Breakpoint = z.infer<typeof Breakpoint>;
-
-export const Breakpoints = z.array(Breakpoint);
-
-export type Breakpoints = z.infer<typeof Breakpoints>;

--- a/packages/project-build/src/index.ts
+++ b/packages/project-build/src/index.ts
@@ -3,4 +3,5 @@ export * from "./schema/props";
 export * from "./schema/styles";
 export * from "./schema/style-sources";
 export * from "./schema/style-source-selections";
+export * from "./schema/breakpoints";
 export * from "./types";

--- a/packages/project-build/src/schema/breakpoints.ts
+++ b/packages/project-build/src/schema/breakpoints.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+const BreakpointId = z.string();
+
+export const Breakpoint = z.object({
+  id: BreakpointId,
+  label: z.string(),
+  minWidth: z.number(),
+});
+
+export type Breakpoint = z.infer<typeof Breakpoint>;
+
+export const BreakpointsList = z.array(Breakpoint);
+
+export type BreakpointsList = z.infer<typeof BreakpointsList>;

--- a/packages/project/src/db/breakpoints.ts
+++ b/packages/project/src/db/breakpoints.ts
@@ -5,14 +5,14 @@ import {
   type Breakpoints as DbBreakpoints,
   prisma,
 } from "@webstudio-is/prisma-client";
-import { Breakpoints } from "@webstudio-is/css-data";
+import { BreakpointsList } from "@webstudio-is/project-build";
 import type { Project } from "../shared/schema";
 import {
   authorizeProject,
   type AppContext,
 } from "@webstudio-is/trpc-interface/server";
 
-export const createValues = (): Breakpoints => {
+export const createValues = (): BreakpointsList => {
   return initialBreakpoints.map((breakpoint) => ({
     ...breakpoint,
     id: nanoid(),
@@ -45,8 +45,8 @@ export const patch = async (
   if (build === null) {
     return;
   }
-  const breakpoints = Breakpoints.parse(JSON.parse(build.breakpoints));
-  const patchedBreakpoints = Breakpoints.parse(
+  const breakpoints = BreakpointsList.parse(JSON.parse(build.breakpoints));
+  const patchedBreakpoints = BreakpointsList.parse(
     applyPatches(breakpoints, patches)
   );
 

--- a/packages/project/src/db/build.ts
+++ b/packages/project/src/db/build.ts
@@ -5,7 +5,7 @@ import {
   Prisma,
   Project,
 } from "@webstudio-is/prisma-client";
-import { Breakpoints } from "@webstudio-is/css-data";
+import { BreakpointsList } from "@webstudio-is/project-build";
 import * as db from ".";
 import { Build, Page, Pages } from "../shared/schema";
 import * as pagesUtils from "../shared/pages";
@@ -22,7 +22,7 @@ const parseBuild = async (build: DbBuild): Promise<Build> => {
     isProd: build.isProd,
     createdAt: build.createdAt.toISOString(),
     pages,
-    breakpoints: Breakpoints.parse(JSON.parse(build.breakpoints)),
+    breakpoints: BreakpointsList.parse(JSON.parse(build.breakpoints)),
     styles: Array.from(await parseStyles(build.projectId, build.styles)),
     styleSources: Array.from(parseStyleSources(build.styleSources)),
   };

--- a/packages/project/src/shared/canvas-components/instance-data.ts
+++ b/packages/project/src/shared/canvas-components/instance-data.ts
@@ -1,9 +1,5 @@
-import type { Instance } from "@webstudio-is/project-build";
-import type {
-  StyleProperty,
-  StyleValue,
-  Breakpoint,
-} from "@webstudio-is/css-data";
+import type { Instance, Breakpoint } from "@webstudio-is/project-build";
+import type { StyleProperty, StyleValue } from "@webstudio-is/css-data";
 
 export type StyleUpdate =
   | {

--- a/packages/project/src/shared/schema.ts
+++ b/packages/project/src/shared/schema.ts
@@ -1,6 +1,6 @@
 import { z, type ZodType } from "zod";
-import type { Breakpoints } from "@webstudio-is/css-data";
 import type {
+  Breakpoint,
   StyleDecl,
   StyleDeclKey,
   StyleSource,
@@ -102,7 +102,7 @@ export type Build = {
   isDev: boolean;
   isProd: boolean;
   pages: Pages;
-  breakpoints: Breakpoints;
+  breakpoints: Breakpoint[];
   styles: [StyleDeclKey, StyleDecl][];
   styleSources: [StyleSource["id"], StyleSource][];
 };

--- a/packages/project/src/shared/styles/style-rules.ts
+++ b/packages/project/src/shared/styles/style-rules.ts
@@ -1,5 +1,6 @@
-import type { Breakpoint, Style } from "@webstudio-is/css-data";
+import type { Style } from "@webstudio-is/css-data";
 import type {
+  Breakpoint,
   StyleDecl,
   Styles,
   StyleSource,

--- a/packages/project/src/shared/tree-utils/set-instance-children.ts
+++ b/packages/project/src/shared/tree-utils/set-instance-children.ts
@@ -1,5 +1,4 @@
-import type { Breakpoint } from "@webstudio-is/css-data";
-import type { Instance, Text } from "@webstudio-is/project-build";
+import type { Breakpoint, Instance, Text } from "@webstudio-is/project-build";
 import type { ChildrenUpdates } from "@webstudio-is/react-sdk";
 import { createInstance, createInstanceId } from "./create-instance";
 import { findInstanceById } from "./find-instance";

--- a/packages/react-sdk/src/css/breakpoints.ts
+++ b/packages/react-sdk/src/css/breakpoints.ts
@@ -1,4 +1,4 @@
-import type { Breakpoint } from "@webstudio-is/css-data";
+import type { Breakpoint } from "@webstudio-is/project-build";
 
 export type BaseBreakpoint = Pick<Breakpoint, "label" | "minWidth">;
 


### PR DESCRIPTION
Breakpoints are not really related to css data and represent project build data so moving it before switching to map patches.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
