### PR TITLE
Represent breakpoints as map

### DIFF
--- a/apps/builder/app/builder/features/breakpoints/breakpoints-editor.tsx
+++ b/apps/builder/app/builder/features/breakpoints/breakpoints-editor.tsx
@@ -12,7 +12,6 @@ import {
 } from "@webstudio-is/design-system";
 import { PlusIcon, TrashIcon } from "@webstudio-is/icons";
 import { breakpointsContainer, useBreakpoints } from "~/shared/nano-states";
-import { replaceByOrAppendMutable } from "~/shared/array-utils";
 
 type BreakpointEditorItemProps = {
   breakpoint: Breakpoint;
@@ -101,7 +100,7 @@ export const BreakpointsEditor = ({ onDelete }: BreakpointsEditorProps) => {
   const [breakpoints] = useBreakpoints();
   const [addedBreakpoints, setAddedBreakpoints] = useState<Breakpoint[]>([]);
   const storedBreakpoints = new Set<string>();
-  for (const breakpoint of breakpoints) {
+  for (const breakpoint of breakpoints.values()) {
     storedBreakpoints.add(breakpoint.id);
   }
   // filter out new breakpoints which are already store
@@ -139,18 +138,14 @@ export const BreakpointsEditor = ({ onDelete }: BreakpointsEditorProps) => {
           prefix={<PlusIcon />}
         />
       </Flex>
-      {[...breakpoints, ...newBreakpoints].map((breakpoint) => {
+      {[...breakpoints.values(), ...newBreakpoints].map((breakpoint) => {
         return (
           <BreakpointEditorItem
             key={breakpoint.id}
             breakpoint={breakpoint}
             onChange={(updatedBreakpoint) => {
               store.createTransaction([breakpointsContainer], (breakpoints) => {
-                replaceByOrAppendMutable(
-                  breakpoints,
-                  updatedBreakpoint,
-                  ({ id }) => id === updatedBreakpoint.id
-                );
+                breakpoints.set(updatedBreakpoint.id, updatedBreakpoint);
               });
             }}
             onDelete={onDelete}

--- a/apps/builder/app/builder/features/breakpoints/breakpoints.tsx
+++ b/apps/builder/app/builder/features/breakpoints/breakpoints.tsx
@@ -26,7 +26,6 @@ import {
   stylesStore,
   useBreakpoints,
 } from "~/shared/nano-states";
-import { removeByMutable } from "~/shared/array-utils";
 import {
   selectedBreakpointIdStore,
   selectedBreakpointStore,
@@ -68,7 +67,7 @@ export const Breakpoints = () => {
       [breakpointsContainer, stylesStore],
       (breakpoints, styles) => {
         const breakpointId = breakpointToDelete.id;
-        removeByMutable(breakpoints, ({ id }) => id === breakpointId);
+        breakpoints.delete(breakpointId);
         for (const [styleDeclKey, styleDecl] of styles) {
           if (styleDecl.breakpointId === breakpointId) {
             styles.delete(styleDeclKey);

--- a/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
@@ -53,9 +53,7 @@ const PropertyPopoverContent = ({
 
             if (styleValueInfo?.cascaded) {
               const { value, breakpointId } = styleValueInfo.cascaded;
-              const breakpoint = breakpoints.find(
-                (item) => item.id === breakpointId
-              );
+              const breakpoint = breakpoints.get(breakpointId);
               return (
                 <DeprecatedText2 key={property} color="hint">
                   Resetting will change {property} to cascaded {toValue(value)}{" "}
@@ -93,9 +91,7 @@ const PropertyPopoverContent = ({
 
         if (styleValueInfo?.cascaded) {
           const { breakpointId } = styleValueInfo.cascaded;
-          const breakpoint = breakpoints.find(
-            (item) => item.id === breakpointId
-          );
+          const breakpoint = breakpoints.get(breakpointId);
           return (
             <DeprecatedText2 key={property} color="hint">
               {property} value is cascaded from {breakpoint?.label}

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
@@ -1,5 +1,5 @@
 import type {
-  Breakpoint,
+  Breakpoints,
   Instance,
   StyleDecl,
 } from "@webstudio-is/project-build";
@@ -9,28 +9,12 @@ import {
   getInheritedInfo,
 } from "./style-info";
 
-const breakpoints: Breakpoint[] = [
-  {
-    id: "1",
-    label: "1",
-    minWidth: 0,
-  },
-  {
-    id: "2",
-    label: "2",
-    minWidth: 768,
-  },
-  {
-    id: "3",
-    label: "3",
-    minWidth: 1280,
-  },
-  {
-    id: "4",
-    label: "4",
-    minWidth: 1920,
-  },
-];
+const breakpoints: Breakpoints = new Map([
+  ["1", { id: "1", label: "1", minWidth: 0 }],
+  ["2", { id: "2", label: "2", minWidth: 768 }],
+  ["3", { id: "3", label: "3", minWidth: 1280 }],
+  ["4", { id: "4", label: "4", minWidth: 1920 }],
+]);
 
 const selectedBreakpointId = "3";
 const selectedInstanceId = "3";

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.ts
@@ -4,7 +4,7 @@ import type { Style, StyleProperty, StyleValue } from "@webstudio-is/css-data";
 import { properties } from "@webstudio-is/css-data";
 import { utils } from "@webstudio-is/project";
 import type {
-  Breakpoint,
+  Breakpoints,
   Instance,
   StyleDecl,
   StyleSource as StyleSourceType,
@@ -98,7 +98,7 @@ const getSelectedStyle = (
  * find all breakpoints which may affect current view
  */
 export const getCascadedBreakpointIds = (
-  breakpoints: Breakpoint[],
+  breakpoints: Breakpoints,
   selectedBreakpointId?: string
 ) => {
   const sortedBreakpoints = utils.breakpoints.sort(breakpoints);

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -66,7 +66,7 @@ const useElementsTree = () => {
           instanceId,
           updates,
           rootInstance,
-          breakpoints[0].id
+          Array.from(breakpoints.values())[0].id
         );
       });
     },

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -71,7 +71,7 @@ export const GlobalStyles = () => {
   const assets = useStore(assetsStore);
 
   useIsomorphicLayoutEffect(() => {
-    for (const breakpoint of breakpoints) {
+    for (const breakpoint of breakpoints.values()) {
       cssEngine.addMediaRule(breakpoint.id, breakpoint);
     }
   }, [breakpoints]);
@@ -175,7 +175,7 @@ export const useCssRules = ({
       style[item.property] = item.value;
     }
 
-    for (const { id: breakpointId } of breakpoints) {
+    for (const breakpointId of breakpoints.keys()) {
       const style = stylePerBreakpoint.get(breakpointId) ?? {};
       const rule = getRule(instanceId, breakpointId);
       // It's the first time the rule is being used

--- a/apps/builder/app/shared/array-utils.test.ts
+++ b/apps/builder/app/shared/array-utils.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@jest/globals";
-import { removeByMutable, replaceByOrAppendMutable } from "./array-utils";
+import { removeByMutable } from "./array-utils";
 
 test("removeByMutable", () => {
   const array = [
@@ -29,41 +29,6 @@ test("removeByMutable", () => {
     [
       {
         "param": 4,
-      },
-    ]
-  `);
-});
-
-test("replaceByOrAppendMutable", () => {
-  const array = [{ param: 1 }, { param: 2 }, { param: 3 }];
-  replaceByOrAppendMutable(array, { param: 6 }, (item) => item.param === 2);
-  expect(array).toMatchInlineSnapshot(`
-    [
-      {
-        "param": 1,
-      },
-      {
-        "param": 6,
-      },
-      {
-        "param": 3,
-      },
-    ]
-  `);
-  replaceByOrAppendMutable(array, { param: 8 }, (item) => item.param === 8);
-  expect(array).toMatchInlineSnapshot(`
-    [
-      {
-        "param": 1,
-      },
-      {
-        "param": 6,
-      },
-      {
-        "param": 3,
-      },
-      {
-        "param": 8,
       },
     ]
   `);

--- a/apps/builder/app/shared/array-utils.ts
+++ b/apps/builder/app/shared/array-utils.ts
@@ -11,16 +11,3 @@ export const removeByMutable = <Item>(
     }
   }
 };
-
-export const replaceByOrAppendMutable = <Item>(
-  array: Item[],
-  item: Item,
-  predicate: Predicate<Item>
-) => {
-  const matchedIndex = array.findIndex(predicate);
-  if (matchedIndex === -1) {
-    array.push(item);
-  } else {
-    array[matchedIndex] = item;
-  }
-};

--- a/apps/builder/app/shared/nano-states/breakpoints.ts
+++ b/apps/builder/app/shared/nano-states/breakpoints.ts
@@ -24,10 +24,10 @@ export const selectedBreakpointIdStore = atom<undefined | Breakpoint["id"]>(
 export const selectedBreakpointStore = computed(
   [breakpointsContainer, selectedBreakpointIdStore],
   (breakpoints, selectedBreakpointId) => {
-    if (selectedBreakpointId === undefined) {
-      return undefined;
-    }
-    const matchedBreakpoint = breakpoints.get(selectedBreakpointId);
+    const matchedBreakpoint =
+      selectedBreakpointId === undefined
+        ? undefined
+        : breakpoints.get(selectedBreakpointId);
     // initially set first breakpoint as selected breakpoint
     const fallbackBreakpoint = utils.breakpoints.sort(breakpoints).at(0);
     return matchedBreakpoint ?? fallbackBreakpoint;

--- a/apps/builder/app/shared/nano-states/breakpoints.ts
+++ b/apps/builder/app/shared/nano-states/breakpoints.ts
@@ -24,11 +24,12 @@ export const selectedBreakpointIdStore = atom<undefined | Breakpoint["id"]>(
 export const selectedBreakpointStore = computed(
   [breakpointsContainer, selectedBreakpointIdStore],
   (breakpoints, selectedBreakpointId) => {
-    const matchedBreakpoint = breakpoints.find(
-      (breakpoint) => breakpoint.id === selectedBreakpointId
-    );
+    if (selectedBreakpointId === undefined) {
+      return undefined;
+    }
+    const matchedBreakpoint = breakpoints.get(selectedBreakpointId);
     // initially set first breakpoint as selected breakpoint
-    const fallbackBreakpoint = utils.breakpoints.sort(breakpoints)[0];
+    const fallbackBreakpoint = utils.breakpoints.sort(breakpoints).at(0);
     return matchedBreakpoint ?? fallbackBreakpoint;
   }
 );

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -6,6 +6,7 @@ import type { AuthPermit } from "@webstudio-is/trpc-interface";
 import type { Asset } from "@webstudio-is/asset-uploader";
 import type {
   Breakpoint,
+  Breakpoints,
   Instance,
   Prop,
   Props,
@@ -198,11 +199,13 @@ export const stylesIndexStore = computed(
   }
 );
 
-export const breakpointsContainer = atom<Breakpoint[]>([]);
+export const breakpointsContainer = atom<Breakpoints>(new Map());
 export const useBreakpoints = () => useValue(breakpointsContainer);
-export const useSetBreakpoints = (breakpoints: Breakpoint[]) => {
+export const useSetBreakpoints = (
+  breakpoints: [Breakpoint["id"], Breakpoint][]
+) => {
   useSyncInitializeOnce(() => {
-    breakpointsContainer.set(breakpoints);
+    breakpointsContainer.set(new Map(breakpoints));
   });
 };
 

--- a/packages/project-build/src/schema/breakpoints.ts
+++ b/packages/project-build/src/schema/breakpoints.ts
@@ -13,3 +13,7 @@ export type Breakpoint = z.infer<typeof Breakpoint>;
 export const BreakpointsList = z.array(Breakpoint);
 
 export type BreakpointsList = z.infer<typeof BreakpointsList>;
+
+export const Breakpoints = z.map(BreakpointId, Breakpoint);
+
+export type Breakpoints = z.infer<typeof Breakpoints>;

--- a/packages/project/src/shared/breakpoints/sort.test.ts
+++ b/packages/project/src/shared/breakpoints/sort.test.ts
@@ -1,26 +1,31 @@
 import { describe, test, expect } from "@jest/globals";
-import {
-  initialBreakpoints,
-  type BaseBreakpoint,
-} from "@webstudio-is/react-sdk";
+import type { Breakpoints } from "@webstudio-is/project-build";
+import { initialBreakpoints } from "@webstudio-is/react-sdk";
+import { nanoid } from "nanoid";
 import { sort } from "./sort";
 
 describe("Breakpoints sorting for visual rendering", () => {
   test("sort initial breakpoints", () => {
-    expect(sort(initialBreakpoints)).toStrictEqual(initialBreakpoints);
+    const breakpoints: Breakpoints = new Map();
+    for (const breakpoint of initialBreakpoints) {
+      const id = nanoid();
+      breakpoints.set(id, { ...breakpoint, id });
+    }
+
+    expect(sort(breakpoints)).toStrictEqual(Array.from(breakpoints.values()));
   });
 
   test("sort custom breakpoints", () => {
-    const breakpoints = [
-      { label: "0", minWidth: 0 },
-      { label: "3", minWidth: 3 },
-      { label: "2", minWidth: 2 },
-    ];
+    const breakpoints = new Map([
+      ["1", { id: "1", label: "0", minWidth: 0 }],
+      ["2", { id: "2", label: "3", minWidth: 3 }],
+      ["3", { id: "3", label: "2", minWidth: 2 }],
+    ]);
     const sortedBreakpoints = [
-      { label: "0", minWidth: 0 },
-      { label: "2", minWidth: 2 },
-      { label: "3", minWidth: 3 },
+      { id: "1", label: "0", minWidth: 0 },
+      { id: "3", label: "2", minWidth: 2 },
+      { id: "2", label: "3", minWidth: 3 },
     ];
-    expect(sort<BaseBreakpoint>(breakpoints)).toStrictEqual(sortedBreakpoints);
+    expect(sort(breakpoints)).toStrictEqual(sortedBreakpoints);
   });
 });

--- a/packages/project/src/shared/breakpoints/sort.ts
+++ b/packages/project/src/shared/breakpoints/sort.ts
@@ -1,11 +1,11 @@
+import type { Breakpoints } from "@webstudio-is/project-build";
+
 /**
  * Sort by minWidth descending.
  * We want media querries with bigger minWidth to override the smaller once.
  */
-export const sort = <BreakpointSubset extends { minWidth: number }>(
-  breakpoints: Array<BreakpointSubset>
-) => {
-  return [...breakpoints].sort((breakpointA, breakpointB) => {
+export const sort = (breakpoints: Breakpoints) => {
+  return Array.from(breakpoints.values()).sort((breakpointA, breakpointB) => {
     return breakpointA.minWidth - breakpointB.minWidth;
   });
 };

--- a/packages/project/src/shared/schema.ts
+++ b/packages/project/src/shared/schema.ts
@@ -102,7 +102,7 @@ export type Build = {
   isDev: boolean;
   isProd: boolean;
   pages: Pages;
-  breakpoints: Breakpoint[];
+  breakpoints: [Breakpoint["id"], Breakpoint][];
   styles: [StyleDeclKey, StyleDecl][];
   styleSources: [StyleSource["id"], StyleSource][];
 };

--- a/packages/project/src/shared/styles/css.ts
+++ b/packages/project/src/shared/styles/css.ts
@@ -20,7 +20,7 @@ export const generateCssText = (data: Data) => {
   const assets = new Map<Asset["id"], Asset>(
     data.assets.map((asset) => [asset.id, asset])
   );
-  const breakpoints = data.build?.breakpoints ?? [];
+  const breakpoints = new Map(data.build?.breakpoints);
   const styles = new Map(data.build?.styles);
   const styleSourceSelections = new Map(data.tree?.styleSourceSelections);
 
@@ -28,7 +28,7 @@ export const generateCssText = (data: Data) => {
 
   addGlobalRules(engine, { assets });
 
-  for (const breakpoint of breakpoints) {
+  for (const breakpoint of breakpoints.values()) {
     engine.addMediaRule(breakpoint.id, breakpoint);
   }
 


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/696

One more diff to support better conflict resolution in breakpoints patches. Breakpoints is now map and patches rely on keys instead of array indexes.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
