### PR TITLE
Fix trpc client setup with default .env for local dev

### DIFF
--- a/apps/builder/app/services/trpc.server.ts
+++ b/apps/builder/app/services/trpc.server.ts
@@ -1,12 +1,12 @@
 import { createTrpcProxyServiceClient } from "@webstudio-is/trpc-interface/server";
 import env from "~/env/env.server";
 
-const TRPC_SERVER_URL = env.TRPC_SERVER_URL;
-const TRPC_SERVER_API_TOKEN = env.TRPC_SERVER_API_TOKEN;
+const TRPC_SERVER_URL = env.TRPC_SERVER_URL ?? "";
+const TRPC_SERVER_API_TOKEN = env.TRPC_SERVER_API_TOKEN ?? "";
 const BRANCH_NAME = env.BRANCH_NAME;
 
 export const trpcClient = createTrpcProxyServiceClient(
-  TRPC_SERVER_URL !== undefined && TRPC_SERVER_API_TOKEN !== undefined
+  TRPC_SERVER_URL !== "" && TRPC_SERVER_API_TOKEN !== ""
     ? {
         url: TRPC_SERVER_URL,
         token: TRPC_SERVER_API_TOKEN,


### PR DESCRIPTION
We have trpc envs specified like this

TRPC_SERVER_URL=
TRPC_SERVER_API_TOKEN=

Which gives empty string in runtime though we check for undefined expecting envs are not defined.

In this PR I covered both undefined and empty string to not break new setups.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
