### PR TITLE
Add rename support to style source input

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import store from "immerhin";
 import { nanoid } from "nanoid";
 import { theme, DeprecatedText2 } from "@webstudio-is/design-system";
@@ -82,12 +83,12 @@ const addStyleSourceToInstace = (styleSourceId: StyleSource["id"]) => {
 
 const removeStyleSourceFromInstance = (styleSourceId: StyleSource["id"]) => {
   const selectedInstanceId = selectedInstanceIdStore.get();
+  if (selectedInstanceId === undefined) {
+    return;
+  }
   store.createTransaction(
     [styleSourceSelectionsStore],
     (styleSourceSelections) => {
-      if (selectedInstanceId === undefined) {
-        return;
-      }
       const styleSourceSelection =
         styleSourceSelections.get(selectedInstanceId);
       if (styleSourceSelection === undefined) {
@@ -117,6 +118,15 @@ const reorderStyleSources = (styleSourceIds: StyleSource["id"][]) => {
       styleSourceSelection.values = styleSourceIds;
     }
   );
+};
+
+const renameStyleSource = (id: StyleSource["id"], label: string) => {
+  store.createTransaction([styleSourcesStore], (styleSources) => {
+    const styleSource = styleSources.get(id);
+    if (styleSource?.type === "token") {
+      styleSource.name = label;
+    }
+  });
 };
 
 type StyleSourceInputItem = {
@@ -164,6 +174,10 @@ export const StyleSourcesSection = () => {
     convertToInputItem(styleSource, selectedStyleSource?.id)
   );
 
+  const [editingItemId, setEditingItemId] = useState<
+    undefined | StyleSource["id"]
+  >(undefined);
+
   return (
     <>
       <DeprecatedText2 css={{ py: theme.spacing[9] }} variant="label">
@@ -185,6 +199,15 @@ export const StyleSourcesSection = () => {
         }}
         onSelectItem={(selectedItem) => {
           selectedStyleSourceIdStore.set(selectedItem?.id);
+        }}
+        // style source renaming
+        editingItemId={editingItemId}
+        onEditItem={(id) => {
+          setEditingItemId(id);
+          selectedStyleSourceIdStore.set(id);
+        }}
+        onChangeItem={(item) => {
+          renameStyleSource(item.id, item.label);
         }}
       />
     </>

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.stories.tsx
@@ -148,14 +148,14 @@ export const Complete: ComponentStory<typeof StyleSourceInput> = () => {
       state: "disabled",
     },
   ]);
-  const [editingItem, setEditingItem] = useState<Item>();
+  const [editingItemId, setEditingItemId] = useState<undefined | Item["id"]>();
 
   return (
     <StyleSourceInput
       css={{ width: 300 }}
       items={getItems()}
       value={value}
-      editingItem={editingItem}
+      editingItemId={editingItemId}
       onSelectItem={(itemToSelect) => {
         setValue(
           value.map((item) => {
@@ -169,7 +169,7 @@ export const Complete: ComponentStory<typeof StyleSourceInput> = () => {
           })
         );
       }}
-      onEditItem={setEditingItem}
+      onEditItem={setEditingItemId}
       onCreateItem={(label) => {
         createItem(label, value, setValue);
       }}

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
@@ -329,7 +329,7 @@ const StyledSourceButton = styled(Box, {
   display: "inline-flex",
   borderRadius: theme.borderRadius[3],
   padding: theme.spacing[4],
-  minWidth: 32,
+  minWidth: theme.spacing[13],
   maxWidth: "100%",
   position: "relative",
   color: theme.colors.foregroundContrastMain,

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
@@ -290,6 +290,8 @@ const EditableText = ({
       css={{
         outline: "none",
         textOverflow: isEditing ? "clip" : "ellipsis",
+        userSelect: isEditing ? "auto" : "none",
+        cursor: isEditing ? "auto" : "default",
       }}
       {...handlers}
     >
@@ -327,6 +329,7 @@ const StyledSourceButton = styled(Box, {
   display: "inline-flex",
   borderRadius: theme.borderRadius[3],
   padding: theme.spacing[4],
+  minWidth: 32,
   maxWidth: "100%",
   position: "relative",
   color: theme.colors.foregroundContrastMain,


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/807

- set min width to source source values
- added renaming support
- added user select for better dnd
- set default cursor when not renaming
- fix style source removing when press backspace while renaming

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
