### PR TITLE
Move pages schema to project-build

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -1,11 +1,9 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { type Publish, usePublish, useSubscribe } from "~/shared/pubsub";
-import {
-  type Pages,
-  utils as projectUtils,
-  type Project,
-} from "@webstudio-is/project";
+import { utils as projectUtils, type Project } from "@webstudio-is/project";
 import { theme, Box, type CSS, Flex, Grid } from "@webstudio-is/design-system";
+import type { AuthPermit } from "@webstudio-is/trpc-interface";
+import type { Pages } from "@webstudio-is/project-build";
 import { registerContainers, useBuilderStore } from "~/shared/sync";
 import { useSyncServer } from "./shared/sync/sync-server";
 // eslint-disable-next-line import/no-internal-modules
@@ -39,7 +37,6 @@ import { Navigator } from "./features/sidebar-left";
 import { getBuildUrl } from "~/shared/router-utils";
 import { useCopyPasteInstance } from "~/shared/copy-paste";
 import { AssetsProvider } from "./shared/assets";
-import type { AuthPermit } from "@webstudio-is/trpc-interface";
 
 registerContainers();
 export const links = () => {

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
@@ -19,7 +19,7 @@ import {
   NewPageIcon,
   PageIcon,
 } from "@webstudio-is/icons";
-import type { Page, Pages } from "@webstudio-is/project";
+import type { Page, Pages } from "@webstudio-is/project-build";
 import type { Publish } from "~/shared/pubsub";
 import {
   useCurrentPageId,

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
@@ -4,7 +4,7 @@ import { useDebouncedCallback } from "use-debounce";
 import { useUnmount } from "react-use";
 import slugify from "slugify";
 import { useFetcher } from "@remix-run/react";
-import type { Page } from "@webstudio-is/project";
+import type { Page, Pages } from "@webstudio-is/project-build";
 import {
   theme,
   Button,
@@ -18,7 +18,7 @@ import {
   Tooltip,
 } from "@webstudio-is/design-system";
 import { ChevronDoubleLeftIcon, TrashIcon } from "@webstudio-is/icons";
-import { type Pages, utils as projectUtils } from "@webstudio-is/project";
+import { utils as projectUtils } from "@webstudio-is/project";
 import { usePages } from "~/builder/shared/nano-states";
 import { useOnFetchEnd, usePersistentFetcher } from "~/shared/fetcher";
 import {

--- a/apps/builder/app/builder/features/topbar/topbar.tsx
+++ b/apps/builder/app/builder/features/topbar/topbar.tsx
@@ -7,15 +7,16 @@ import {
   ToolbarSeparator,
   ToolbarToggleGroup,
 } from "@webstudio-is/design-system";
+import type { Page } from "@webstudio-is/project-build";
+import type { Project } from "@webstudio-is/project";
+import { theme } from "@webstudio-is/design-system";
+import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import { PreviewButton } from "./preview";
 import { ShareButton } from "./share";
 import { PublishButton } from "./publish";
 import { SyncStatus } from "./sync-status";
 import { Menu } from "./menu";
 import { Breakpoints } from "../breakpoints";
-import type { Page, Project } from "@webstudio-is/project";
-import { theme } from "@webstudio-is/design-system";
-import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import { ViewMode } from "./view-mode";
 
 const topbarContainerStyle = css({

--- a/apps/builder/app/builder/shared/nano-states/index.ts
+++ b/apps/builder/app/builder/shared/nano-states/index.ts
@@ -1,6 +1,7 @@
 import { atom, type WritableAtom } from "nanostores";
 import { useStore } from "@nanostores/react";
-import type { Pages, Project } from "@webstudio-is/project";
+import type { Pages } from "@webstudio-is/project-build";
+import type { Project } from "@webstudio-is/project";
 import type { AssetContainer, DeletingAssetContainer } from "../assets";
 
 const useValue = <T>(atom: WritableAtom<T>) => {

--- a/apps/builder/app/builder/shared/sync/sync-server.ts
+++ b/apps/builder/app/builder/shared/sync/sync-server.ts
@@ -1,6 +1,6 @@
 import { sync } from "immerhin";
-import type { Build, Project } from "@webstudio-is/project";
-import type { Tree } from "@webstudio-is/project-build";
+import type { Project } from "@webstudio-is/project";
+import type { Build, Tree } from "@webstudio-is/project-build";
 import { restPatchPath } from "~/shared/router-utils";
 import { useEffect } from "react";
 import { enqueue, dequeue, queueStatus } from "./queue";

--- a/apps/builder/app/routes/rest/pages.$projectId.ts
+++ b/apps/builder/app/routes/rest/pages.$projectId.ts
@@ -1,6 +1,7 @@
 import type { LoaderArgs, ActionArgs } from "@remix-run/node";
 import { db } from "@webstudio-is/project/server";
-import { type Pages, utils, pathValidators } from "@webstudio-is/project";
+import { type Pages, pathValidators } from "@webstudio-is/project-build";
+import { utils } from "@webstudio-is/project";
 import { zfd } from "zod-form-data";
 import { z } from "zod";
 import { sentryException } from "~/shared/sentry";

--- a/apps/builder/app/routes/rest/patch.ts
+++ b/apps/builder/app/routes/rest/patch.ts
@@ -1,8 +1,8 @@
 import type { ActionArgs } from "@remix-run/node";
-import type { Build, Project } from "@webstudio-is/project";
-import { db as projectDb } from "@webstudio-is/project/server";
 import type { SyncItem } from "immerhin";
-import type { Tree } from "@webstudio-is/project-build";
+import type { Build, Tree } from "@webstudio-is/project-build";
+import type { Project } from "@webstudio-is/project";
+import { db as projectDb } from "@webstudio-is/project/server";
 import { createContext } from "~/shared/context.server";
 
 type PatchData = {

--- a/apps/builder/app/shared/pages/types.ts
+++ b/apps/builder/app/shared/pages/types.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@webstudio-is/project";
+import type { Page } from "@webstudio-is/project-build";
 import type { FetcherData } from "~/shared/form-utils";
 
 export type CreatePageData = FetcherData<{ page: Page }>;

--- a/apps/builder/app/shared/router-utils/path-utils.ts
+++ b/apps/builder/app/shared/router-utils/path-utils.ts
@@ -1,5 +1,6 @@
 import type { AUTH_PROVIDERS } from "~/shared/session";
-import type { Page, Project } from "@webstudio-is/project";
+import type { Page } from "@webstudio-is/project-build";
+import type { Project } from "@webstudio-is/project";
 import type { BuildMode } from "./build-params";
 import type { ThemeSetting } from "~/shared/theme";
 import env from "~/shared/env";

--- a/packages/project-build/src/index.ts
+++ b/packages/project-build/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./schema/pages";
 export * from "./schema/instances";
 export * from "./schema/props";
 export * from "./schema/styles";

--- a/packages/project-build/src/schema/pages.ts
+++ b/packages/project-build/src/schema/pages.ts
@@ -1,0 +1,77 @@
+import { z, type ZodType } from "zod";
+
+const MIN_TITLE_LENGTH = 2;
+
+const Title = z
+  .string()
+  .refine(
+    (val) => val.length >= MIN_TITLE_LENGTH,
+    `Minimum ${MIN_TITLE_LENGTH} characters required`
+  );
+
+const commonPageFields = {
+  id: z.string(),
+  name: z.string().refine((val) => val !== "", "Can't be empty"),
+  title: Title,
+  meta: z.record(z.string(), z.string()),
+  treeId: z.string(),
+} as const;
+
+const HomePage = z.object({
+  ...commonPageFields,
+  path: z
+    .string()
+    .refine((path) => path === "", "Home page path must be empty"),
+});
+
+export const pathValidators = (
+  baseValidator: ZodType<string>
+): ZodType<string> =>
+  baseValidator
+    .refine((path) => path !== "", "Can't be empty")
+    .refine((path) => path !== "/", "Can't be just a /")
+    .refine(
+      (path) => path === "" || path.startsWith("/"),
+      "Must start with a /"
+    )
+    .refine((path) => path.endsWith("/") === false, "Can't end with a /")
+    .refine(
+      (path) => path.includes("//") === false,
+      "Can't contain repeating /"
+    )
+    .refine(
+      (path) => /^[-_a-z0-9\\/]*$/.test(path),
+      "Only a-z, 0-9, -, _ and / are allowed"
+    )
+    .refine(
+      // We use /s for our system stuff like /s/css or /s/uploads
+      (path) => path !== "/s" && path.startsWith("/s/") === false,
+      "/s prefix is reserved for the system"
+    )
+    .refine(
+      // Remix serves build artefacts like JS bundles from /build
+      // And we cannot customize it due to bug in Remix: https://github.com/remix-run/remix/issues/2933
+      (path) => path !== "/build" && path.startsWith("/build/") === false,
+      "/build prefix is reserved for the system"
+    );
+
+const Page = z.object({
+  ...commonPageFields,
+  path: pathValidators(z.string()),
+});
+
+export type Page = z.infer<typeof Page>;
+
+export const Pages: z.ZodType<{ homePage: Page; pages: Array<Page> }> =
+  z.object({
+    homePage: HomePage,
+    pages: z
+      .array(Page)
+      .refine(
+        (array) =>
+          new Set(array.map((page) => page.path)).size === array.length,
+        "All paths must be unique"
+      ),
+  });
+
+export type Pages = z.infer<typeof Pages>;

--- a/packages/project-build/src/types.ts
+++ b/packages/project-build/src/types.ts
@@ -1,6 +1,22 @@
+import type { Pages } from "./schema/pages";
+import type { Breakpoint } from "./schema/breakpoints";
+import type { StyleDecl, StyleDeclKey } from "./schema/styles";
+import type { StyleSource } from "./schema/style-sources";
 import type { Instance } from "./schema/instances";
 import type { Prop } from "./schema/props";
 import type { StyleSourceSelection } from "./schema/style-source-selections";
+
+export type Build = {
+  id: string;
+  projectId: string;
+  createdAt: string;
+  isDev: boolean;
+  isProd: boolean;
+  pages: Pages;
+  breakpoints: [Breakpoint["id"], Breakpoint][];
+  styles: [StyleDeclKey, StyleDecl][];
+  styleSources: [StyleSource["id"], StyleSource][];
+};
 
 export type Tree = {
   id: string;

--- a/packages/project/src/db/breakpoints.ts
+++ b/packages/project/src/db/breakpoints.ts
@@ -1,16 +1,13 @@
 import { nanoid } from "nanoid";
 import { applyPatches, type Patch } from "immer";
 import { initialBreakpoints } from "@webstudio-is/react-sdk";
+import { type Project, prisma } from "@webstudio-is/prisma-client";
 import {
-  type Breakpoints as DbBreakpoints,
-  prisma,
-} from "@webstudio-is/prisma-client";
-import {
+  type Build,
   Breakpoint,
   Breakpoints,
   BreakpointsList,
 } from "@webstudio-is/project-build";
-import type { Project } from "../shared/schema";
 import {
   authorizeProject,
   type AppContext,
@@ -42,10 +39,7 @@ export const createValues = (): [Breakpoint["id"], Breakpoint][] => {
 };
 
 export const patch = async (
-  {
-    buildId,
-    projectId,
-  }: { buildId: DbBreakpoints["buildId"]; projectId: Project["id"] },
+  { buildId, projectId }: { buildId: Build["id"]; projectId: Project["id"] },
   patches: Array<Patch>,
   context: AppContext
 ) => {

--- a/packages/project/src/db/build.ts
+++ b/packages/project/src/db/build.ts
@@ -6,8 +6,8 @@ import {
   Project,
 } from "@webstudio-is/prisma-client";
 import type { AppContext } from "@webstudio-is/trpc-interface";
+import { type Build, type Page, Pages } from "@webstudio-is/project-build";
 import * as db from ".";
-import { Build, Page, Pages } from "../shared/schema";
 import * as pagesUtils from "../shared/pages";
 import { parseBreakpoints, serializeBreakpoints } from "./breakpoints";
 import { parseStyles, serializeStyles } from "./styles";

--- a/packages/project/src/db/props.ts
+++ b/packages/project/src/db/props.ts
@@ -1,7 +1,6 @@
 import { type Tree, Props, PropsList } from "@webstudio-is/project-build";
 import { applyPatches, type Patch } from "immer";
-import { prisma } from "@webstudio-is/prisma-client";
-import type { Project } from "../shared/schema";
+import { type Project, prisma } from "@webstudio-is/prisma-client";
 import {
   authorizeProject,
   type AppContext,

--- a/packages/project/src/db/style-source-selections.ts
+++ b/packages/project/src/db/style-source-selections.ts
@@ -1,5 +1,5 @@
 import { type Patch, applyPatches } from "immer";
-import { prisma } from "@webstudio-is/prisma-client";
+import { type Project, prisma } from "@webstudio-is/prisma-client";
 import {
   authorizeProject,
   type AppContext,
@@ -9,7 +9,6 @@ import {
   StyleSourceSelections,
   type Tree,
 } from "@webstudio-is/project-build";
-import type { Project } from "../shared/schema";
 
 export const parseStyleSourceSelections = (
   styleSourceSelectionsString: string

--- a/packages/project/src/db/style-sources.ts
+++ b/packages/project/src/db/style-sources.ts
@@ -1,11 +1,14 @@
 import { type Patch, applyPatches } from "immer";
-import { prisma } from "@webstudio-is/prisma-client";
+import { type Project, prisma } from "@webstudio-is/prisma-client";
 import {
   authorizeProject,
   type AppContext,
 } from "@webstudio-is/trpc-interface/server";
-import { StyleSourcesList, StyleSources } from "@webstudio-is/project-build";
-import type { Build, Project } from "../shared/schema";
+import {
+  type Build,
+  StyleSourcesList,
+  StyleSources,
+} from "@webstudio-is/project-build";
 
 export const parseStyleSources = (styleSourceString: string): StyleSources => {
   const styleSourcesList = StyleSourcesList.parse(

--- a/packages/project/src/db/styles.ts
+++ b/packages/project/src/db/styles.ts
@@ -1,16 +1,16 @@
 import warnOnce from "warn-once";
 import { type Patch, applyPatches } from "immer";
-import { prisma } from "@webstudio-is/prisma-client";
+import { type Project, prisma } from "@webstudio-is/prisma-client";
 import type { Asset } from "@webstudio-is/asset-uploader";
 import { formatAsset } from "@webstudio-is/asset-uploader/server";
 import {
+  type Build,
   type StoredStyleDecl,
   type StyleDecl,
   getStyleDeclKey,
   StoredStyles,
   Styles,
 } from "@webstudio-is/project-build";
-import type { Build, Project } from "../shared/schema";
 import {
   authorizeProject,
   type AppContext,

--- a/packages/project/src/db/tree.ts
+++ b/packages/project/src/db/tree.ts
@@ -7,10 +7,9 @@ import {
   Instance,
   Instances,
 } from "@webstudio-is/project-build";
-import { prisma, type Prisma } from "@webstudio-is/prisma-client";
+import { type Project, type Prisma, prisma } from "@webstudio-is/prisma-client";
 import { utils } from "../index";
 import { parseProps, serializeProps } from "./props";
-import type { Project } from "../shared/schema";
 import {
   authorizeProject,
   type AppContext,

--- a/packages/project/src/shared/pages/find-by-id-or-path.ts
+++ b/packages/project/src/shared/pages/find-by-id-or-path.ts
@@ -1,4 +1,4 @@
-import type { Pages, Page } from "../schema";
+import type { Pages, Page } from "@webstudio-is/project-build";
 
 export const findByIdOrPath = (
   pages: Pages,

--- a/packages/project/src/shared/schema.ts
+++ b/packages/project/src/shared/schema.ts
@@ -1,11 +1,6 @@
-import { z, type ZodType } from "zod";
-import type {
-  Breakpoint,
-  StyleDecl,
-  StyleDeclKey,
-  StyleSource,
-} from "@webstudio-is/project-build";
+import { z } from "zod";
 import type { Data } from "@webstudio-is/react-sdk";
+import type { Build, Page } from "@webstudio-is/project-build";
 
 const MIN_TITLE_LENGTH = 2;
 
@@ -28,84 +23,6 @@ export type Project = z.infer<typeof Project>;
 
 export const Projects = z.array(Project);
 export type Projects = z.infer<typeof Projects>;
-
-const commonPageFields = {
-  id: z.string(),
-  name: z.string().refine((val) => val !== "", "Can't be empty"),
-  title: Title,
-  meta: z.record(z.string(), z.string()),
-  treeId: z.string(),
-} as const;
-
-const HomePage = z.object({
-  ...commonPageFields,
-  path: z
-    .string()
-    .refine((path) => path === "", "Home page path must be empty"),
-});
-
-export const pathValidators = (
-  baseValidator: ZodType<string>
-): ZodType<string> =>
-  baseValidator
-    .refine((path) => path !== "", "Can't be empty")
-    .refine((path) => path !== "/", "Can't be just a /")
-    .refine(
-      (path) => path === "" || path.startsWith("/"),
-      "Must start with a /"
-    )
-    .refine((path) => path.endsWith("/") === false, "Can't end with a /")
-    .refine(
-      (path) => path.includes("//") === false,
-      "Can't contain repeating /"
-    )
-    .refine(
-      (path) => /^[-_a-z0-9\\/]*$/.test(path),
-      "Only a-z, 0-9, -, _ and / are allowed"
-    )
-    .refine(
-      // We use /s for our system stuff like /s/css or /s/uploads
-      (path) => path !== "/s" && path.startsWith("/s/") === false,
-      "/s prefix is reserved for the system"
-    )
-    .refine(
-      // Remix serves build artefacts like JS bundles from /build
-      // And we cannot customize it due to bug in Remix: https://github.com/remix-run/remix/issues/2933
-      (path) => path !== "/build" && path.startsWith("/build/") === false,
-      "/build prefix is reserved for the system"
-    );
-
-const Page = z.object({
-  ...commonPageFields,
-  path: pathValidators(z.string()),
-});
-
-export type Page = z.infer<typeof Page>;
-
-export const Pages: z.ZodType<{ homePage: Page; pages: Array<Page> }> =
-  z.object({
-    homePage: HomePage,
-    pages: z
-      .array(Page)
-      .refine(
-        (array) =>
-          new Set(array.map((page) => page.path)).size === array.length,
-        "All paths must be unique"
-      ),
-  });
-export type Pages = z.infer<typeof Pages>;
-
-export type Build = {
-  id: string;
-  projectId: string;
-  createdAt: string;
-  isDev: boolean;
-  isProd: boolean;
-  pages: Pages;
-  breakpoints: [Breakpoint["id"], Breakpoint][];
-  styles: [StyleDeclKey, StyleDecl][];
-  styleSources: [StyleSource["id"], StyleSource][];
-};
 
 export type CanvasData = Data & {
   build: null | Build;

--- a/packages/project/src/shared/styles/css.ts
+++ b/packages/project/src/shared/styles/css.ts
@@ -1,12 +1,11 @@
 import { createCssEngine } from "@webstudio-is/css-engine";
 import type { Asset } from "@webstudio-is/asset-uploader";
-import type { Tree } from "@webstudio-is/project-build";
+import type { Build, Tree } from "@webstudio-is/project-build";
 import {
   getComponentMeta,
   getComponentNames,
   idAttribute,
 } from "@webstudio-is/react-sdk";
-import type { Build } from "../schema";
 import { addGlobalRules } from "./global-rules";
 import { getStyleRules } from "./style-rules";
 


### PR DESCRIPTION
We are moving all build related code from project to project-build. Here moved pages schema and Build type.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
