### PR TITLE
Move tree db utils to project-build

### DIFF
--- a/apps/builder/app/routes/rest/patch.ts
+++ b/apps/builder/app/routes/rest/patch.ts
@@ -1,6 +1,7 @@
 import type { ActionArgs } from "@remix-run/node";
 import type { SyncItem } from "immerhin";
 import type { Build, Tree } from "@webstudio-is/project-build";
+import * as buildDb from "@webstudio-is/project-build/server";
 import type { Project } from "@webstudio-is/project";
 import { db as projectDb } from "@webstudio-is/project/server";
 import { createContext } from "~/shared/context.server";
@@ -35,9 +36,9 @@ export const action = async ({ request }: ActionArgs) => {
       const { namespace, patches } = change;
 
       if (namespace === "root") {
-        await projectDb.tree.patch({ treeId, projectId }, patches, context);
+        await buildDb.patchTree({ treeId, projectId }, patches, context);
       } else if (namespace === "styleSourceSelections") {
-        await projectDb.styleSourceSelections.patch(
+        await buildDb.patchStyleSourceSelections(
           { treeId, projectId },
           patches,
           context
@@ -51,7 +52,7 @@ export const action = async ({ request }: ActionArgs) => {
       } else if (namespace === "styles") {
         await projectDb.styles.patch({ buildId, projectId }, patches, context);
       } else if (namespace === "props") {
-        await projectDb.props.patch({ treeId, projectId }, patches, context);
+        await buildDb.patchProps({ treeId, projectId }, patches, context);
       } else if (namespace === "breakpoints") {
         await projectDb.breakpoints.patch(
           { buildId, projectId },

--- a/apps/builder/app/shared/db/canvas.server.ts
+++ b/apps/builder/app/shared/db/canvas.server.ts
@@ -1,6 +1,7 @@
 import type { CanvasData, Project } from "@webstudio-is/project";
-import { db as projectDb } from "@webstudio-is/project/server";
+import * as buildDb from "@webstudio-is/project-build/server";
 import { utils } from "@webstudio-is/project";
+import { db as projectDb } from "@webstudio-is/project/server";
 import { loadByProject } from "@webstudio-is/asset-uploader/server";
 import type { AppContext } from "@webstudio-is/trpc-interface/server";
 
@@ -79,7 +80,7 @@ export const loadCanvasData = async (
   }
 
   const [tree, assets] = await Promise.all([
-    projectDb.tree.loadById(
+    buildDb.loadTreeById(
       {
         projectId: props.project.id,
         treeId: page.treeId,

--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -10,7 +10,8 @@
     ".": {
       "import": "./lib/index.js",
       "require": "./lib/cjs/index.cjs"
-    }
+    },
+    "./server": "./server.js"
   },
   "types": "src/index.ts",
   "files": [
@@ -28,6 +29,8 @@
   "dependencies": {
     "@webstudio-is/asset-uploader": "workspace:^",
     "@webstudio-is/css-data": "workspace:^",
+    "@webstudio-is/prisma-client": "workspace:^",
+    "nanoid": "^3.2.0",
     "zod": "^3.19.1"
   },
   "devDependencies": {

--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -30,6 +30,8 @@
     "@webstudio-is/asset-uploader": "workspace:^",
     "@webstudio-is/css-data": "workspace:^",
     "@webstudio-is/prisma-client": "workspace:^",
+    "@webstudio-is/trpc-interface": "workspace:^",
+    "immer": "^9.0.12",
     "nanoid": "^3.2.0",
     "zod": "^3.19.1"
   },

--- a/packages/project-build/server.d.ts
+++ b/packages/project-build/server.d.ts
@@ -1,0 +1,1 @@
+export * from "./src/index.server";

--- a/packages/project-build/server.js
+++ b/packages/project-build/server.js
@@ -1,0 +1,1 @@
+export * from "./lib/index.server";

--- a/packages/project-build/src/db/props.ts
+++ b/packages/project-build/src/db/props.ts
@@ -1,10 +1,11 @@
-import { type Tree, Props, PropsList } from "@webstudio-is/project-build";
 import { applyPatches, type Patch } from "immer";
 import { type Project, prisma } from "@webstudio-is/prisma-client";
 import {
   authorizeProject,
   type AppContext,
 } from "@webstudio-is/trpc-interface/server";
+import type { Tree } from "../types";
+import { Props, PropsList } from "../schema/props";
 
 export const parseProps = (propsString: string): Props => {
   const propsList = PropsList.parse(JSON.parse(propsString));
@@ -16,7 +17,7 @@ export const serializeProps = (props: Props) => {
   return JSON.stringify(propsList);
 };
 
-export const patch = async (
+export const patchProps = async (
   { treeId, projectId }: { treeId: Tree["id"]; projectId: Project["id"] },
   patches: Array<Patch>,
   context: AppContext

--- a/packages/project-build/src/db/style-source-selections.ts
+++ b/packages/project-build/src/db/style-source-selections.ts
@@ -4,11 +4,11 @@ import {
   authorizeProject,
   type AppContext,
 } from "@webstudio-is/trpc-interface/server";
+import type { Tree } from "../types";
 import {
   StyleSourceSelectionsList,
   StyleSourceSelections,
-  type Tree,
-} from "@webstudio-is/project-build";
+} from "../schema/style-source-selections";
 
 export const parseStyleSourceSelections = (
   styleSourceSelectionsString: string
@@ -30,7 +30,7 @@ export const serializeStyleSourceSelections = (
   return JSON.stringify(styleSourceSelectionsList);
 };
 
-export const patch = async (
+export const patchStyleSourceSelections = async (
   { treeId, projectId }: { treeId: Tree["id"]; projectId: Project["id"] },
   patches: Array<Patch>,
   context: AppContext

--- a/packages/project-build/src/index.server.ts
+++ b/packages/project-build/src/index.server.ts
@@ -1,0 +1,3 @@
+export * from "./db/tree";
+export * from "./db/props";
+export * from "./db/style-source-selections";

--- a/packages/project/src/db/build.ts
+++ b/packages/project/src/db/build.ts
@@ -7,7 +7,7 @@ import {
 } from "@webstudio-is/prisma-client";
 import type { AppContext } from "@webstudio-is/trpc-interface";
 import { type Build, type Page, Pages } from "@webstudio-is/project-build";
-import buildDb from "@webstudio-is/project-build/server";
+import * as buildDb from "@webstudio-is/project-build/server";
 import * as db from ".";
 import * as pagesUtils from "../shared/pages";
 import { parseBreakpoints, serializeBreakpoints } from "./breakpoints";

--- a/packages/project/src/db/build.ts
+++ b/packages/project/src/db/build.ts
@@ -7,6 +7,7 @@ import {
 } from "@webstudio-is/prisma-client";
 import type { AppContext } from "@webstudio-is/trpc-interface";
 import { type Build, type Page, Pages } from "@webstudio-is/project-build";
+import buildDb from "@webstudio-is/project-build/server";
 import * as db from ".";
 import * as pagesUtils from "../shared/pages";
 import { parseBreakpoints, serializeBreakpoints } from "./breakpoints";
@@ -112,8 +113,8 @@ export const addPage = async ({
     Partial<Omit<Page, "id" | "treeId" | "name" | "path">>;
 }) => {
   return updatePages({ projectId, buildId }, async (currentPages) => {
-    const tree = await db.tree.create(
-      db.tree.createTree({ projectId, buildId })
+    const tree = await buildDb.createTree(
+      buildDb.createNewTreeData({ projectId, buildId })
     );
 
     return {
@@ -190,7 +191,7 @@ export const deletePage = async ({
       throw new Error(`Page with id "${pageId}" not found`);
     }
 
-    await db.tree.deleteById({ projectId, treeId: page.treeId });
+    await buildDb.deleteTreeById({ projectId, treeId: page.treeId });
 
     return {
       homePage: currentPages.homePage,
@@ -204,8 +205,8 @@ const createPages = async (
   _context: AppContext,
   client: Prisma.TransactionClient = prisma
 ) => {
-  const tree = await db.tree.create(
-    db.tree.createTree({ projectId, buildId }),
+  const tree = await buildDb.createTree(
+    buildDb.createNewTreeData({ projectId, buildId }),
     client
   );
   return Pages.parse({
@@ -227,7 +228,7 @@ const clonePage = async (
   context: AppContext,
   client: Prisma.TransactionClient = prisma
 ) => {
-  const tree = await db.tree.clone(
+  const tree = await buildDb.cloneTree(
     { projectId: from.projectId, treeId: from.page.treeId },
     to,
     context,

--- a/packages/project/src/db/index.ts
+++ b/packages/project/src/db/index.ts
@@ -1,18 +1,6 @@
 import * as project from "./project";
-import * as tree from "./tree";
 import * as styles from "./styles";
 import * as styleSources from "./style-sources";
-import * as styleSourceSelections from "./style-source-selections";
-import * as props from "./props";
 import * as breakpoints from "./breakpoints";
 import * as build from "./build";
-export {
-  project,
-  tree,
-  breakpoints,
-  styles,
-  styleSources,
-  styleSourceSelections,
-  props,
-  build,
-};
+export { project, breakpoints, styles, styleSources, build };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -827,13 +827,17 @@ importers:
     specifiers:
       '@webstudio-is/asset-uploader': workspace:^
       '@webstudio-is/css-data': workspace:^
+      '@webstudio-is/prisma-client': workspace:^
       '@webstudio-is/scripts': workspace:^
       '@webstudio-is/tsconfig': workspace:^
+      nanoid: ^3.2.0
       typescript: 4.9.5
       zod: ^3.19.1
     dependencies:
       '@webstudio-is/asset-uploader': link:../asset-uploader
       '@webstudio-is/css-data': link:../css-data
+      '@webstudio-is/prisma-client': link:../prisma-client
+      nanoid: 3.3.4
       zod: 3.19.1
     devDependencies:
       '@webstudio-is/scripts': link:../scripts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -829,7 +829,9 @@ importers:
       '@webstudio-is/css-data': workspace:^
       '@webstudio-is/prisma-client': workspace:^
       '@webstudio-is/scripts': workspace:^
+      '@webstudio-is/trpc-interface': workspace:^
       '@webstudio-is/tsconfig': workspace:^
+      immer: ^9.0.12
       nanoid: ^3.2.0
       typescript: 4.9.5
       zod: ^3.19.1
@@ -837,6 +839,8 @@ importers:
       '@webstudio-is/asset-uploader': link:../asset-uploader
       '@webstudio-is/css-data': link:../css-data
       '@webstudio-is/prisma-client': link:../prisma-client
+      '@webstudio-is/trpc-interface': link:../trpc-interface
+      immer: 9.0.15
       nanoid: 3.3.4
       zod: 3.19.1
     devDependencies:
@@ -13178,10 +13182,6 @@ packages:
     resolution: {integrity: sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==}
     dev: false
 
-  /diff-sequences/29.3.1:
-    resolution: {integrity: sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
   /diff-sequences/29.4.2:
     resolution: {integrity: sha512-R6P0Y6PrsH3n4hUXxL3nns0rbRk6Q33js3ygJBeEpbzLzgcNuJ61+u0RXasFpTKISw99TxUzFnumSnRLsjhLaw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -16351,7 +16351,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       chalk: 4.1.2
-      diff-sequences: 29.3.1
+      diff-sequences: 29.4.2
       jest-get-type: 29.4.2
       pretty-format: 29.4.2
 
@@ -16452,7 +16452,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       chalk: 4.1.2
-      jest-diff: 29.3.1
+      jest-diff: 29.4.2
       jest-get-type: 29.4.2
       pretty-format: 29.4.2
 


### PR DESCRIPTION
We are moving all build related stuff to project-build package including tree schema and db utils.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
