### PR TITLE
Add token duplcate support in style sources

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
@@ -68,6 +68,7 @@ type TextFieldBaseWrapperProps<Item extends IntermediateItem> = Omit<
     disabled?: boolean;
     containerRef?: RefObject<HTMLDivElement>;
     inputRef?: RefObject<HTMLInputElement>;
+    onDuplicateItem: (id: Item["id"]) => void;
     onRemoveItem?: (item: Item) => void;
     onChangeItem?: (item: Item) => void;
     onDisableItem?: (item: Item) => void;
@@ -96,6 +97,7 @@ const TextFieldBase: ForwardRefRenderFunction<
     onKeyDown,
     label,
     value,
+    onDuplicateItem,
     onRemoveItem,
     onChangeItem,
     onDisableItem,
@@ -155,6 +157,7 @@ const TextFieldBase: ForwardRefRenderFunction<
             onEditItem?.();
             onChangeItem?.({ ...item, label });
           }}
+          onDuplicate={() => onDuplicateItem?.(item.id)}
           onRemove={() => {
             onRemoveItem?.(item);
           }}
@@ -172,7 +175,6 @@ const TextFieldBase: ForwardRefRenderFunction<
           disabled={disabled}
           onClick={onClick}
           ref={mergeRefs(internalInputRef, inputRef ?? null)}
-          autoFocus
           aria-label="New Style Source Input"
         />
       )}
@@ -189,6 +191,7 @@ type StyleSourceInputProps<Item extends IntermediateItem> = {
   editingItemId?: Item["id"];
   onSelectAutocompleteItem?: (item: Item) => void;
   onRemoveItem?: (item: Item) => void;
+  onDuplicateItem?: (id: Item["id"]) => void;
   onCreateItem?: (label: string) => void;
   onChangeItem?: (item: Item) => void;
   onSelectItem?: (item?: Item) => void;
@@ -284,7 +287,10 @@ export const StyleSourceInput = <Item extends IntermediateItem>(
         label === "" &&
         props.editingItemId === undefined
       ) {
-        props.onRemoveItem?.(value[value.length - 1]);
+        const item = value[value.length - 1];
+        if (item.source !== "local") {
+          props.onRemoveItem?.(item);
+        }
       }
     },
   });
@@ -298,6 +304,7 @@ export const StyleSourceInput = <Item extends IntermediateItem>(
           <TextField
             {...inputProps}
             onRemoveItem={props.onRemoveItem}
+            onDuplicateItem={props.onDuplicateItem}
             onChangeItem={props.onChangeItem}
             onSelectItem={props.onSelectItem}
             onEditItem={props.onEditItem}

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
@@ -136,6 +136,7 @@ type MenuProps = {
   source: ItemSource;
   state: ItemState;
   onEdit: () => void;
+  onDuplicate: () => void;
   onDisable: () => void;
   onEnable: () => void;
   onRemove: () => void;
@@ -144,6 +145,7 @@ type MenuProps = {
 const Menu = (props: MenuProps) => {
   const scheduler = useCallScheduler();
   const canEdit = props.source !== "local";
+  const canDuplicate = props.source !== "local";
   const canDisable = props.state !== "disabled";
   const canEnable = props.state === "disabled";
   const canRemove = props.source !== "local";
@@ -160,6 +162,11 @@ const Menu = (props: MenuProps) => {
           {canEdit && (
             <DropdownMenuItem onSelect={scheduler.set(props.onEdit)}>
               Edit Name
+            </DropdownMenuItem>
+          )}
+          {canDuplicate && (
+            <DropdownMenuItem onSelect={scheduler.set(props.onDuplicate)}>
+              Duplicate
             </DropdownMenuItem>
           )}
           {canEnable && (
@@ -404,6 +411,7 @@ type StyleSourceProps = {
   source: ItemSource;
   onChangeState: (state: ItemState) => void;
   onSelect: () => void;
+  onDuplicate: () => void;
   onRemove: () => void;
   onChangeValue: (value: string) => void;
   onChangeEditing: (isEditing: boolean) => void;
@@ -421,6 +429,7 @@ export const StyleSource = ({
   onChangeEditing,
   onChangeState,
   onSelect,
+  onDuplicate,
   onRemove,
 }: StyleSourceProps) => {
   const ref = useForceRecalcStyle<HTMLDivElement>("max-width", isEditing);
@@ -444,6 +453,7 @@ export const StyleSource = ({
         <Menu
           source={source}
           state={state}
+          onDuplicate={onDuplicate}
           onRemove={onRemove}
           onEnable={() => {
             onChangeState("unselected");

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -277,9 +277,9 @@ export const selectedInstanceStyleSourcesStore = computed(
       }
     }
     // generate style source when selection has not local style sources
-    // it is synchronized whenever instance style sources or styles are updated
+    // it is synchronized whenever styles are updated
     if (hasLocal === false && treeId !== undefined) {
-      selectedInstanceStyleSources.push({
+      selectedInstanceStyleSources.unshift({
         type: "local",
         treeId,
         id: nanoid(),


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/807

- support duplicating tokens
- removed autofocus to not block instance deleting right after instance selection
- prevent removing local style source
- refactored all operations to write generated local style source only on reorder
- select token when create
- select token when add

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
