### PR TITLE
Exclude zod parse and exports from read-sdk

### DIFF
--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -10,7 +10,7 @@
     "build": "build-package",
     "build:args": "generate-arg-types './src/components/*.tsx !./src/**/*.stories.tsx !./src/**/*.ws.tsx' && prettier --write \"**/*.props.json\"",
     "typecheck": "tsc --noEmit",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0",
     "checks": "pnpm typecheck && pnpm lint && pnpm test",
     "storybook:run": "start-storybook -p 6006",

--- a/packages/react-sdk/src/app/custom-components/index.ts
+++ b/packages/react-sdk/src/app/custom-components/index.ts
@@ -2,7 +2,7 @@ import { Image } from "./image";
 import { Link } from "./link";
 import { RichTextLink } from "./rich-text-link";
 import { imageProps } from "@webstudio-is/image";
-import { WsComponentPropsMeta } from "../../components/component-type";
+import type { WsComponentPropsMeta } from "../../components/component-type";
 
 export const customComponents = {
   Image,
@@ -11,12 +11,12 @@ export const customComponents = {
 };
 
 export const customComponentPropsMetas = {
-  Image: WsComponentPropsMeta.parse({
+  Image: {
     props: {
       ...imageProps,
       src: { ...imageProps.src, control: "file-image", name: "Source" },
     },
-  }),
+  } as WsComponentPropsMeta,
 };
 
 // just for completeness, maybe we add soemthing here later

--- a/packages/react-sdk/src/components/body.ws.tsx
+++ b/packages/react-sdk/src/components/body.ws.tsx
@@ -1,5 +1,5 @@
 import { BodyIcon } from "@webstudio-is/icons";
-import { type WsComponentMeta, WsComponentPropsMeta } from "./component-type";
+import type { WsComponentMeta, WsComponentPropsMeta } from "./component-type";
 import props from "./__generated__/body.props.json";
 
 const presetStyle = {
@@ -59,6 +59,6 @@ export const meta: WsComponentMeta = {
   presetStyle,
 };
 
-export const propsMeta = WsComponentPropsMeta.parse({
+export const propsMeta = {
   props,
-});
+} as WsComponentPropsMeta;

--- a/packages/react-sdk/src/components/bold.ws.tsx
+++ b/packages/react-sdk/src/components/bold.ws.tsx
@@ -1,5 +1,5 @@
 import { FontBoldIcon } from "@webstudio-is/icons";
-import { type WsComponentMeta, WsComponentPropsMeta } from "./component-type";
+import type { WsComponentMeta, WsComponentPropsMeta } from "./component-type";
 import props from "./__generated__/bold.props.json";
 
 export const meta: WsComponentMeta = {
@@ -8,6 +8,6 @@ export const meta: WsComponentMeta = {
   Icon: FontBoldIcon,
 };
 
-export const propsMeta = WsComponentPropsMeta.parse({
+export const propsMeta = {
   props,
-});
+} as WsComponentPropsMeta;

--- a/packages/react-sdk/src/components/box.ws.ts
+++ b/packages/react-sdk/src/components/box.ws.ts
@@ -1,5 +1,5 @@
 import { SquareIcon } from "@webstudio-is/icons";
-import { type WsComponentMeta, WsComponentPropsMeta } from "./component-type";
+import type { WsComponentMeta, WsComponentPropsMeta } from "./component-type";
 import props from "./__generated__/box.props.json";
 
 const presetStyle = {
@@ -16,7 +16,7 @@ export const meta: WsComponentMeta = {
   presetStyle,
 };
 
-export const propsMeta = WsComponentPropsMeta.parse({
+export const propsMeta = {
   props,
   initialProps: ["tag"],
-});
+} as WsComponentPropsMeta;

--- a/packages/react-sdk/src/components/button.ws.tsx
+++ b/packages/react-sdk/src/components/button.ws.tsx
@@ -1,5 +1,5 @@
 import { ButtonIcon } from "@webstudio-is/icons";
-import { type WsComponentMeta, WsComponentPropsMeta } from "./component-type";
+import type { WsComponentMeta, WsComponentPropsMeta } from "./component-type";
 import props from "./__generated__/button.props.json";
 
 export const meta: WsComponentMeta = {
@@ -9,7 +9,7 @@ export const meta: WsComponentMeta = {
   children: ["Button text you can edit"],
 };
 
-export const propsMeta = WsComponentPropsMeta.parse({
+export const propsMeta = {
   props,
   initialProps: ["type"],
-});
+} as WsComponentPropsMeta;

--- a/packages/react-sdk/src/components/component-type.ts
+++ b/packages/react-sdk/src/components/component-type.ts
@@ -6,7 +6,7 @@ import { PropMeta } from "@webstudio-is/generate-arg-types";
 
 // props are separated from the rest of the meta
 // so they can be exported separately and potentially tree-shaken
-export const WsComponentPropsMeta = z.object({
+const WsComponentPropsMeta = z.object({
   props: z.record(PropMeta),
   initialProps: z.array(z.string()).optional(),
 });
@@ -35,7 +35,7 @@ export type WsComponentMeta = {
   children?: Array<string>;
 };
 
-export const WsComponentMeta = z.object({
+const WsComponentMeta = z.object({
   type: z.enum([
     "body",
     "container",

--- a/packages/react-sdk/src/components/form.ws.tsx
+++ b/packages/react-sdk/src/components/form.ws.tsx
@@ -1,5 +1,5 @@
 import { FormIcon } from "@webstudio-is/icons";
-import { type WsComponentMeta, WsComponentPropsMeta } from "./component-type";
+import type { WsComponentMeta, WsComponentPropsMeta } from "./component-type";
 import props from "./__generated__/form.props.json";
 
 const presetStyle = {
@@ -21,6 +21,6 @@ export const meta: WsComponentMeta = {
   presetStyle,
 };
 
-export const propsMeta = WsComponentPropsMeta.parse({
+export const propsMeta = {
   props,
-});
+} as WsComponentPropsMeta;

--- a/packages/react-sdk/src/components/heading.ws.tsx
+++ b/packages/react-sdk/src/components/heading.ws.tsx
@@ -1,5 +1,5 @@
 import { HeadingIcon } from "@webstudio-is/icons";
-import { type WsComponentMeta, WsComponentPropsMeta } from "./component-type";
+import type { WsComponentMeta, WsComponentPropsMeta } from "./component-type";
 import props from "./__generated__/heading.props.json";
 
 export const meta: WsComponentMeta = {
@@ -9,7 +9,7 @@ export const meta: WsComponentMeta = {
   children: ["Heading you can edit"],
 };
 
-export const propsMeta = WsComponentPropsMeta.parse({
+export const propsMeta = {
   props,
   initialProps: ["tag"],
-});
+} as WsComponentPropsMeta;

--- a/packages/react-sdk/src/components/image.ws.tsx
+++ b/packages/react-sdk/src/components/image.ws.tsx
@@ -1,5 +1,5 @@
 import { ImageIcon } from "@webstudio-is/icons";
-import { type WsComponentMeta, WsComponentPropsMeta } from "./component-type";
+import type { WsComponentMeta, WsComponentPropsMeta } from "./component-type";
 import props from "./__generated__/image.props.json";
 
 const presetStyle = {
@@ -24,10 +24,10 @@ export const meta: WsComponentMeta = {
   presetStyle,
 };
 
-export const propsMeta = WsComponentPropsMeta.parse({
+export const propsMeta = {
   props: {
     ...props,
     src: { ...props.src, control: "file-image", name: "Source" },
   },
   initialProps: ["src", "width", "height", "alt", "loading"],
-});
+} as WsComponentPropsMeta;

--- a/packages/react-sdk/src/components/index.test.ts
+++ b/packages/react-sdk/src/components/index.test.ts
@@ -1,7 +1,0 @@
-import { test } from "@jest/globals";
-import { getComponentNames, getComponentMeta } from "./index";
-import { WsComponentMeta } from "./component-type";
-
-test.each(getComponentNames())("validating meta definition of %s", (name) => {
-  WsComponentMeta.parse(getComponentMeta(name));
-});

--- a/packages/react-sdk/src/components/input.ws.tsx
+++ b/packages/react-sdk/src/components/input.ws.tsx
@@ -1,5 +1,5 @@
 import { InputIcon } from "@webstudio-is/icons";
-import { type WsComponentMeta, WsComponentPropsMeta } from "./component-type";
+import type { WsComponentMeta, WsComponentPropsMeta } from "./component-type";
 import props from "./__generated__/input.props.json";
 
 export const meta: WsComponentMeta = {
@@ -8,6 +8,6 @@ export const meta: WsComponentMeta = {
   Icon: InputIcon,
 };
 
-export const propsMeta = WsComponentPropsMeta.parse({
+export const propsMeta = {
   props,
-});
+} as WsComponentPropsMeta;

--- a/packages/react-sdk/src/components/italic.ws.tsx
+++ b/packages/react-sdk/src/components/italic.ws.tsx
@@ -1,5 +1,5 @@
 import { FontItalicIcon } from "@webstudio-is/icons";
-import { type WsComponentMeta, WsComponentPropsMeta } from "./component-type";
+import type { WsComponentMeta, WsComponentPropsMeta } from "./component-type";
 import props from "./__generated__/italic.props.json";
 
 const presetStyle = {
@@ -16,6 +16,6 @@ export const meta: WsComponentMeta = {
   presetStyle,
 };
 
-export const propsMeta = WsComponentPropsMeta.parse({
+export const propsMeta = {
   props,
-});
+} as WsComponentPropsMeta;

--- a/packages/react-sdk/src/components/link.ws.tsx
+++ b/packages/react-sdk/src/components/link.ws.tsx
@@ -1,5 +1,5 @@
 import { Link2Icon } from "@webstudio-is/icons";
-import { type WsComponentMeta, WsComponentPropsMeta } from "./component-type";
+import type { WsComponentMeta, WsComponentPropsMeta } from "./component-type";
 import props from "./__generated__/link.props.json";
 
 const presetStyle = {
@@ -22,7 +22,7 @@ export const meta: WsComponentMeta = {
   children: ["Link text you can edit"],
 };
 
-export const propsMeta = WsComponentPropsMeta.parse({
+export const propsMeta = {
   props,
   initialProps: ["href"],
-});
+} as WsComponentPropsMeta;

--- a/packages/react-sdk/src/components/paragraph.ws.tsx
+++ b/packages/react-sdk/src/components/paragraph.ws.tsx
@@ -1,5 +1,5 @@
 import { TextAlignLeftIcon } from "@webstudio-is/icons";
-import { type WsComponentMeta, WsComponentPropsMeta } from "./component-type";
+import type { WsComponentMeta, WsComponentPropsMeta } from "./component-type";
 import props from "./__generated__/paragraph.props.json";
 
 export const meta: WsComponentMeta = {
@@ -9,6 +9,6 @@ export const meta: WsComponentMeta = {
   children: ["Pragraph you can edit"],
 };
 
-export const propsMeta = WsComponentPropsMeta.parse({
+export const propsMeta = {
   props,
-});
+} as WsComponentPropsMeta;

--- a/packages/react-sdk/src/components/rich-text-link.ws.tsx
+++ b/packages/react-sdk/src/components/rich-text-link.ws.tsx
@@ -1,5 +1,5 @@
 import { Link2Icon } from "@webstudio-is/icons";
-import { type WsComponentMeta, WsComponentPropsMeta } from "./component-type";
+import type { WsComponentMeta, WsComponentPropsMeta } from "./component-type";
 import props from "./__generated__/rich-text-link.props.json";
 
 export const meta: WsComponentMeta = {
@@ -8,6 +8,6 @@ export const meta: WsComponentMeta = {
   Icon: Link2Icon,
 };
 
-export const propsMeta = WsComponentPropsMeta.parse({
+export const propsMeta = {
   props,
-});
+} as WsComponentPropsMeta;

--- a/packages/react-sdk/src/components/span.ws.tsx
+++ b/packages/react-sdk/src/components/span.ws.tsx
@@ -1,5 +1,5 @@
 import { BrushIcon } from "@webstudio-is/icons";
-import { type WsComponentMeta, WsComponentPropsMeta } from "./component-type";
+import type { WsComponentMeta, WsComponentPropsMeta } from "./component-type";
 import props from "./__generated__/span.props.json";
 
 export const meta: WsComponentMeta = {
@@ -8,6 +8,6 @@ export const meta: WsComponentMeta = {
   Icon: BrushIcon,
 };
 
-export const propsMeta = WsComponentPropsMeta.parse({
+export const propsMeta = {
   props,
-});
+} as WsComponentPropsMeta;

--- a/packages/react-sdk/src/components/subscript.ws.tsx
+++ b/packages/react-sdk/src/components/subscript.ws.tsx
@@ -1,5 +1,5 @@
 import { SubscriptIcon } from "@webstudio-is/icons";
-import { type WsComponentMeta, WsComponentPropsMeta } from "./component-type";
+import type { WsComponentMeta, WsComponentPropsMeta } from "./component-type";
 import props from "./__generated__/subscript.props.json";
 
 export const meta: WsComponentMeta = {
@@ -8,6 +8,6 @@ export const meta: WsComponentMeta = {
   Icon: SubscriptIcon,
 };
 
-export const propsMeta = WsComponentPropsMeta.parse({
+export const propsMeta = {
   props,
-});
+} as WsComponentPropsMeta;

--- a/packages/react-sdk/src/components/superscript.ws.tsx
+++ b/packages/react-sdk/src/components/superscript.ws.tsx
@@ -1,5 +1,5 @@
 import { SuperscriptIcon } from "@webstudio-is/icons";
-import { type WsComponentMeta, WsComponentPropsMeta } from "./component-type";
+import type { WsComponentMeta, WsComponentPropsMeta } from "./component-type";
 import props from "./__generated__/superscript.props.json";
 
 export const meta: WsComponentMeta = {
@@ -8,6 +8,6 @@ export const meta: WsComponentMeta = {
   Icon: SuperscriptIcon,
 };
 
-export const propsMeta = WsComponentPropsMeta.parse({
+export const propsMeta = {
   props,
-});
+} as WsComponentPropsMeta;

--- a/packages/react-sdk/src/components/text-block.ws.tsx
+++ b/packages/react-sdk/src/components/text-block.ws.tsx
@@ -1,5 +1,5 @@
 import { TextIcon } from "@webstudio-is/icons";
-import { type WsComponentMeta, WsComponentPropsMeta } from "./component-type";
+import type { WsComponentMeta, WsComponentPropsMeta } from "./component-type";
 import props from "./__generated__/text-block.props.json";
 
 const presetStyle = {
@@ -18,6 +18,6 @@ export const meta: WsComponentMeta = {
   children: ["Block of text you can edit"],
 };
 
-export const propsMeta = WsComponentPropsMeta.parse({
+export const propsMeta = {
   props,
-});
+} as WsComponentPropsMeta;


### PR DESCRIPTION
## Description

Partial fix for #1051
The full fix must include validating during props generation. Probably we could generate ts files with all 
typeinfo inside.
cc @rpominov 

Also I excluded Zod exports, only types https://github.com/webstudio-is/webstudio-builder/pull/1052/files#diff-5659b16effbbb5a7214ce728cf281efa2f2cac4332d31685b78ecb1b27ab0502


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
