### PR TITLE
Use nanoid for pagse

### DIFF
--- a/packages/project-build/src/db/build.ts
+++ b/packages/project-build/src/db/build.ts
@@ -1,4 +1,4 @@
-import { v4 as uuid } from "uuid";
+import { nanoid } from "nanoid";
 import {
   prisma,
   Build as DbBuild,
@@ -99,7 +99,7 @@ const updatePages = async (
   updater: (currentPages: Pages) => Promise<Pages>
 ) => {
   const build = await loadBuildById({ projectId, buildId });
-  const updatedPages = Pages.parse(await updater(build.pages));
+  const updatedPages: Pages = await updater(build.pages);
   const updatedBuild = await prisma.build.update({
     where: {
       id_projectId: { projectId, id: buildId },
@@ -129,7 +129,7 @@ export const addPage = async ({
       pages: [
         ...currentPages.pages,
         {
-          id: uuid(),
+          id: nanoid(),
           treeId: tree.id,
           name: data.name,
           path: data.path,
@@ -216,9 +216,9 @@ const createPages = async (
     createNewTreeData({ projectId, buildId }),
     client
   );
-  return Pages.parse({
+  const pages: Pages = {
     homePage: {
-      id: uuid(),
+      id: nanoid(),
       name: "Home",
       path: "",
       title: "Home",
@@ -226,7 +226,8 @@ const createPages = async (
       treeId: tree.id,
     },
     pages: [],
-  });
+  };
+  return pages;
 };
 
 const clonePage = async (
@@ -241,7 +242,7 @@ const clonePage = async (
     context,
     client
   );
-  return { ...from.page, id: uuid(), treeId: tree.id };
+  return { ...from.page, id: nanoid(), treeId: tree.id };
 };
 
 const clonePages = async (
@@ -256,7 +257,7 @@ const clonePages = async (
       await clonePage({ projectId: from.projectId, page }, to, context, client)
     );
   }
-  return Pages.parse({
+  const pages: Pages = {
     homePage: await clonePage(
       { projectId: from.projectId, page: from.pages.homePage },
       to,
@@ -264,7 +265,8 @@ const clonePages = async (
       client
     ),
     pages: clones,
-  });
+  };
+  return pages;
 };
 
 /*

--- a/packages/project-build/src/db/build.ts
+++ b/packages/project-build/src/db/build.ts
@@ -99,7 +99,7 @@ const updatePages = async (
   updater: (currentPages: Pages) => Promise<Pages>
 ) => {
   const build = await loadBuildById({ projectId, buildId });
-  const updatedPages: Pages = await updater(build.pages);
+  const updatedPages = Pages.parse(await updater(build.pages));
   const updatedBuild = await prisma.build.update({
     where: {
       id_projectId: { projectId, id: buildId },
@@ -216,7 +216,7 @@ const createPages = async (
     createNewTreeData({ projectId, buildId }),
     client
   );
-  const pages: Pages = {
+  return Pages.parse({
     homePage: {
       id: nanoid(),
       name: "Home",
@@ -226,8 +226,7 @@ const createPages = async (
       treeId: tree.id,
     },
     pages: [],
-  };
-  return pages;
+  });
 };
 
 const clonePage = async (
@@ -257,7 +256,7 @@ const clonePages = async (
       await clonePage({ projectId: from.projectId, page }, to, context, client)
     );
   }
-  const pages: Pages = {
+  return Pages.parse({
     homePage: await clonePage(
       { projectId: from.projectId, page: from.pages.homePage },
       to,
@@ -265,8 +264,7 @@ const clonePages = async (
       client
     ),
     pages: clones,
-  };
-  return pages;
+  });
 };
 
 /*


### PR DESCRIPTION
We already migrated all json ids from bson-objectid to nanoid. Looks like pages can be also migrated from nanoid since not stored directly in db.

Also removed unnecessary zod parses.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
