### PR TITLE
Prevent instance cut in contenteditable

### DIFF
--- a/apps/builder/app/shared/copy-paste/copy-paste-instance.ts
+++ b/apps/builder/app/shared/copy-paste/copy-paste-instance.ts
@@ -131,7 +131,6 @@ const startCopyPasteInstance = () => {
   return startCopyPaste({
     version: "@webstudio/instance/v0.1",
     type: InstanceData,
-    allowAnyTarget: false,
 
     onCopy: () => {
       const selectedInstanceId = selectedInstanceIdStore.get();

--- a/apps/builder/app/shared/copy-paste/copy-paste.ts
+++ b/apps/builder/app/shared/copy-paste/copy-paste.ts
@@ -1,9 +1,6 @@
 import { z } from "zod";
 
-const isValidClipboardEvent = (
-  event: ClipboardEvent,
-  options: { allowAnyTarget: boolean }
-) => {
+const isValidClipboardEvent = (event: ClipboardEvent) => {
   const selection = document.getSelection();
   if (selection?.type === "Range") {
     return false;
@@ -22,9 +19,10 @@ const isValidClipboardEvent = (
   // If cursor is in input,
   // don't copy (we may want to add more exceptions here in the future)
   if (
-    options.allowAnyTarget === false &&
-    (event.target instanceof HTMLInputElement ||
-      event.target instanceof HTMLTextAreaElement)
+    event.target instanceof HTMLInputElement ||
+    event.target instanceof HTMLTextAreaElement ||
+    (event.target instanceof HTMLElement &&
+      event.target.closest("[contenteditable]"))
   ) {
     return false;
   }
@@ -35,14 +33,13 @@ const isValidClipboardEvent = (
 type Props<Data> = {
   version: string;
   type: z.ZodType<Data>;
-  allowAnyTarget?: boolean;
   onCopy: () => undefined | Data;
   onCut: () => undefined | Data;
   onPaste: (data: Data) => void;
 };
 
 export const startCopyPaste = <Type>(props: Props<Type>) => {
-  const { version, type, allowAnyTarget = false } = props;
+  const { version, type } = props;
   const versionLiteral = version;
 
   const DataType = z.object({ [versionLiteral]: type });
@@ -65,7 +62,7 @@ export const startCopyPaste = <Type>(props: Props<Type>) => {
   const handleCopy = (event: ClipboardEvent) => {
     if (
       event.clipboardData === null ||
-      isValidClipboardEvent(event, { allowAnyTarget }) === false
+      isValidClipboardEvent(event) === false
     ) {
       return;
     }
@@ -83,7 +80,7 @@ export const startCopyPaste = <Type>(props: Props<Type>) => {
   const handleCut = (event: ClipboardEvent) => {
     if (
       event.clipboardData === null ||
-      isValidClipboardEvent(event, { allowAnyTarget }) === false
+      isValidClipboardEvent(event) === false
     ) {
       return;
     }
@@ -103,7 +100,7 @@ export const startCopyPaste = <Type>(props: Props<Type>) => {
       event.clipboardData === null ||
       // we might want a separate predicate for paste,
       // but for now the logic is the same
-      isValidClipboardEvent(event, { allowAnyTarget }) === false
+      isValidClipboardEvent(event) === false
     ) {
       return;
     }


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1057

Checks are now similar to those we use in shortcuts.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
