### PR TITLE
Make css helper tool for collapsing prevention on canvas really smart

### DIFF
--- a/apps/builder/app/canvas/features/wrapper-component/wrapper-component.tsx
+++ b/apps/builder/app/canvas/features/wrapper-component/wrapper-component.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent, FormEvent } from "react";
+import { MouseEvent, FormEvent, useLayoutEffect } from "react";
 import { Suspense, lazy, useCallback, useMemo, useRef } from "react";
 import { useStore } from "@nanostores/react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
@@ -8,6 +8,7 @@ import {
   renderWrapperComponentChildren,
   getComponent,
   idAttribute,
+  collapsedAttribute,
 } from "@webstudio-is/react-sdk";
 import {
   selectedInstanceIdStore,
@@ -41,6 +42,24 @@ const ContentEditable = ({
   return <Component ref={ref} {...props} contentEditable={true} />;
 };
 
+const setDataCollapsed = (element?: HTMLElement) => {
+  if (element === undefined) {
+    return;
+  }
+  // When we remove this attribute, artifical helper spacers will be removed,
+  // then we synchronously calculate height/width to see if element would collapse
+  // then we add spacers back on the side that requires them right away.
+  // The idea is to not trigger a reflow while we are calculating offsets before we know
+  // if the elmenent needs spacers, because this is going to happen every time elemnt updates and
+  // we don't want to trigger a reflow every time.
+  element.removeAttribute(collapsedAttribute);
+  const collapsedHeight = element.offsetHeight === 0 ? "h" : "";
+  const collapsedWidth = element.offsetWidth === 0 ? "w" : "";
+  if (collapsedHeight || collapsedWidth) {
+    element.setAttribute(collapsedAttribute, collapsedHeight + collapsedWidth);
+  }
+};
+
 type UserProps = Record<Prop["name"], string | number | boolean>;
 
 type WrapperComponentDevProps = {
@@ -55,7 +74,7 @@ export const WrapperComponentDev = ({
   onChangeChildren,
 }: WrapperComponentDevProps) => {
   const instanceId = instance.id;
-
+  const instanceElementRef = useRef<HTMLElement>();
   const instanceStyles = useInstanceStyles(instanceId);
   useCssRules({ instanceId: instance.id, instanceStyles });
 
@@ -77,7 +96,9 @@ export const WrapperComponentDev = ({
     return result;
   }, [instanceProps]);
 
-  const instanceElementRef = useRef<HTMLElement>();
+  useLayoutEffect(() => {
+    setDataCollapsed(instanceElementRef.current);
+  });
 
   const readonlyProps =
     instance.component === "Input" ? { readOnly: true } : undefined;

--- a/apps/builder/app/canvas/features/wrapper-component/wrapper-component.tsx
+++ b/apps/builder/app/canvas/features/wrapper-component/wrapper-component.tsx
@@ -53,10 +53,10 @@ const setDataCollapsed = (element?: HTMLElement) => {
   // if the elmenent needs spacers, because this is going to happen every time elemnt updates and
   // we don't want to trigger a reflow every time.
   element.removeAttribute(collapsedAttribute);
-  const collapsedHeight = element.offsetHeight === 0 ? "h" : "";
   const collapsedWidth = element.offsetWidth === 0 ? "w" : "";
+  const collapsedHeight = element.offsetHeight === 0 ? "h" : "";
   if (collapsedHeight || collapsedWidth) {
-    element.setAttribute(collapsedAttribute, collapsedHeight + collapsedWidth);
+    element.setAttribute(collapsedAttribute, collapsedWidth + collapsedHeight);
   }
 };
 

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -9,6 +9,7 @@ import {
 } from "~/shared/nano-states";
 import type { StyleDecl } from "@webstudio-is/project-build";
 import {
+  collapsedAttribute,
   getComponentMeta,
   getComponentNames,
   idAttribute,
@@ -31,22 +32,6 @@ import { useSubscribe } from "~/shared/pubsub";
 
 const cssEngine = createCssEngine({ name: "user-styles" });
 
-const voidElements = [
-  "area",
-  "base",
-  "br",
-  "col",
-  "embed",
-  "hr",
-  "img",
-  "input",
-  "link",
-  "meta",
-  "source",
-  "track",
-  "wbr",
-];
-
 // Helper styles on for canvas in design mode
 const helperStyles = [
   // When double clicking into an element to edit text, it should not select the word.
@@ -54,11 +39,17 @@ const helperStyles = [
     user-select: none;
   }`,
   // Using :where allows to prevent increasing specificity, so that helper is overwritten by user styles.
-  `[${idAttribute}]:where(:not(${[...voidElements, "body"]}):empty) {
+  `[${idAttribute}]:where([${collapsedAttribute}]:not(body)) {
     outline: 1px dashed #555;
     outline-offset: -1px;
-    padding-top: 50px;
+  }`,
+  // Has no width, will collapse
+  `[${idAttribute}]:where(:not(body)[${collapsedAttribute}~=w]) {
     padding-right: 50px;
+  }`,
+  // Has no height, will collapse
+  `[${idAttribute}]:where(:not(body)[${collapsedAttribute}~=h]) {
+    padding-top: 50px;
   }`,
   `[${idAttribute}][contenteditable], [${idAttribute}]:focus {
     outline: 0;

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -39,6 +39,17 @@ const fontsAndDefaultsCssEngine = createCssEngine({
 const presetStylesEngine = createCssEngine({ name: "presetStyles" });
 
 // Helper styles on for canvas in design mode
+// - Only instances that would collapse without helper should receive helper
+// - Helper is removed when any CSS property is changed on that instance that would prevent collapsing, so that helper is not needed
+// - Helper doesn't show on the preview or publish
+// - Helper goes away if an instance inserted as a child
+// - There is no need to set padding-right or padding-bottom if you just need a small div with a defined or layout-based size, as soon as div is not collapsing, helper should not apply
+// - Padding will be only added on the side that would collapse otherwise
+//
+// For example when I add a div, it is a block element, it grows automatically full width but has 0 height, in this case spacing helper with padidng-top: 50px should apply, so that it doesn't collapse.
+// If user sets `height: 100px` or does anything that would give it a height - we remove the helper padding right away, so user can actually see the height they set
+//
+// In other words we prevent elements from collapsing when they have 0 height or width by making them non-zero on canvas, but then we remove those paddings as soon as element doesn't collapse.
 const helperStyles = [
   // When double clicking into an element to edit text, it should not select the word.
   `[${idAttribute}] {

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -31,8 +31,21 @@ import { useSubscribe } from "~/shared/pubsub";
 
 const cssEngine = createCssEngine({ name: "user-styles" });
 
-const voidElements =
-  "area, base, br, col, embed, hr, img, input, link, meta, source, track, wbr";
+const voidElements = [
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "source",
+  "track",
+  "wbr",
+];
 
 // Helper styles on for canvas in design mode
 const helperStyles = [
@@ -40,7 +53,8 @@ const helperStyles = [
   `[${idAttribute}] {
     user-select: none;
   }`,
-  `[${idAttribute}]:not(${voidElements}):not(body):empty {
+  // Using :where allows to prevent increasing specificity, so that helper is overwritten by user styles.
+  `[${idAttribute}]:where(:not(${[...voidElements, "body"]}):empty) {
     outline: 1px dashed #555;
     outline-offset: -1px;
     padding-top: 50px;

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -44,11 +44,16 @@ const helperStyles = [
     outline-offset: -1px;
   }`,
   // Has no width, will collapse
-  `[${idAttribute}]:where(:not(body)[${collapsedAttribute}~=w]) {
+  `[${idAttribute}]:where(:not(body)[${collapsedAttribute}="w"]) {
     padding-right: 50px;
   }`,
   // Has no height, will collapse
-  `[${idAttribute}]:where(:not(body)[${collapsedAttribute}~=h]) {
+  `[${idAttribute}]:where(:not(body)[${collapsedAttribute}="h"]) {
+    padding-top: 50px;
+  }`,
+  // Has no width, will collapse
+  `[${idAttribute}]:where(:not(body)[${collapsedAttribute}="wh"]) {
+    padding-right: 50px;
     padding-top: 50px;
   }`,
   `[${idAttribute}][contenteditable], [${idAttribute}]:focus {

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -57,7 +57,7 @@ const helperStyles = [
   `[${idAttribute}]:where(:not(body)[${collapsedAttribute}="h"]) {
     padding-top: 50px;
   }`,
-  // Has no width, will collapse
+  // Has no width or height, will collapse
   `[${idAttribute}]:where(:not(body)[${collapsedAttribute}="wh"]) {
     padding-right: 50px;
     padding-top: 50px;
@@ -71,18 +71,25 @@ const helperStyles = [
 ];
 
 const subscribePreviewMode = () => {
-  return isPreviewModeStore.subscribe((isPreviewMode) => {
-    if (isPreviewMode) {
-      helpersCssEngine.clear();
-      helpersCssEngine.render();
-      return;
-    }
+  let isRendered = false;
 
-    for (const style of helperStyles) {
-      helpersCssEngine.addPlaintextRule(style);
+  const unsubscribe = isPreviewModeStore.subscribe((isPreviewMode) => {
+    helpersCssEngine.setAttribute("media", isPreviewMode ? "not all" : "all");
+    if (isRendered === false) {
+      for (const style of helperStyles) {
+        helpersCssEngine.addPlaintextRule(style);
+      }
+      helpersCssEngine.render();
+      isRendered = true;
     }
-    helpersCssEngine.render();
   });
+
+  return () => {
+    helpersCssEngine.clear();
+    helpersCssEngine.render();
+    unsubscribe();
+    isRendered = false;
+  };
 };
 
 export const useManageDesignModeStyles = () => {

--- a/packages/css-engine/src/core/css-engine.ts
+++ b/packages/css-engine/src/core/css-engine.ts
@@ -73,6 +73,12 @@ export class CssEngine {
   unmount() {
     this.#element.unmount();
   }
+  setAttribute() {
+    this.#element.setAttribute(...arguments);
+  }
+  getAttribute() {
+    this.#element.getAttribute(...arguments);
+  }
   get cssText() {
     if (this.#isDirty === false) {
       return this.#cssText;

--- a/packages/css-engine/src/core/css-engine.ts
+++ b/packages/css-engine/src/core/css-engine.ts
@@ -73,11 +73,11 @@ export class CssEngine {
   unmount() {
     this.#element.unmount();
   }
-  setAttribute() {
-    this.#element.setAttribute(...arguments);
+  setAttribute(name: string, value: string) {
+    this.#element.setAttribute(name, value);
   }
-  getAttribute() {
-    this.#element.getAttribute(...arguments);
+  getAttribute(name: string) {
+    return this.#element.getAttribute(name);
   }
   get cssText() {
     if (this.#isDirty === false) {

--- a/packages/css-engine/src/core/style-element.ts
+++ b/packages/css-engine/src/core/style-element.ts
@@ -25,4 +25,14 @@ export class StyleElement {
       this.#element.textContent = cssText;
     }
   }
+  setAttribute(name: string, value: string) {
+    if (this.#element) {
+      this.#element.setAttribute(name, value);
+    }
+  }
+  getAttribute(name: string) {
+    if (this.#element) {
+      return this.#element.getAttribute(name);
+    }
+  }
 }

--- a/packages/react-sdk/src/tree/wrapper-component.tsx
+++ b/packages/react-sdk/src/tree/wrapper-component.tsx
@@ -57,3 +57,4 @@ export const WrapperComponent = ({
 
 export const idAttribute = "data-ws-id";
 export const componentAttribute = "data-ws-component";
+export const collapsedAttribute = "data-ws-collapsed";


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio-builder/issues/604

## Description

-  User can now override helper definitions on canvas
- only boxes that would collapse without helper -  receive helper
- helper is removed when any CSS property is changed on that instance that would prevent collapsing, so that helper can be removed
- Helper doesn't show on the preview or publish
- Helper goes away if an instance inserted as a child
- There is no need to set padding-right or padding-bottom if you just need a small div with a defined or layout-based size, as soon as div is not collapsing, helper is not applied

More: padding will be only added on the side that would collapse otherwise. 
For example when I add a div, it is a block element, it grows automatically full width but has 0 height, in this case spacing heloper with padidng-top: 50px will apply, so that it doesn't collapse.
If user sets height: 100px or does anything that would give it a height - we remove the helper padding right away, so user can actually see the height they set

In other words we prevent elements from collapsing when they have 0 height or width by making them non-zero on canvas, but then we remove those padding universally without shortlists as soon as element doesn't collapse.

## Steps for reproduction

1. add a box
2. set padding-top
3. see it applies on canvas

1. add a box
2. set width
3. see the exact width on canvas, no helper padding


1. add a box
2. set height
3. see the exact height on canvas, no helper padding

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
