### PR TITLE
Typing "-" in unitless value types should select the unitless

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -35,6 +35,7 @@ import { useDebouncedCallback } from "use-debounce";
 import type { StyleSource } from "../style-info";
 import { toPascalCase } from "../keyword-utils";
 import { theme } from "@webstudio-is/design-system";
+import { isValid } from "../parse-css-value";
 
 // We increment by 10 when shift is pressed, by 0.1 when alt/option is pressed and by 1 by default.
 const calcNumberChange = (
@@ -357,6 +358,10 @@ export const CssValueInput = ({
 
   const [isUnitsOpen, unitSelectElement] = useUnitSelect({
     property,
+    showUnitless:
+      value.type === "unit" || value.type === "intermediate"
+        ? isValid(property, `${value.value}`)
+        : false,
     value:
       value.type === "unit" || value.type === "intermediate"
         ? value.unit

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts.test.ts
@@ -209,3 +209,116 @@ describe("Returns invalid if can't parse", () => {
     });
   });
 });
+
+describe("Value ending with `-` should be considered unitless", () => {
+  test("Unitless intermediate transformed to unitless", () => {
+    const result = parseIntermediateOrInvalidValue("lineHeight", {
+      type: "intermediate",
+      value: "10-",
+    });
+
+    expect(result).toEqual({
+      type: "unit",
+      value: 10,
+      unit: "number",
+    });
+  });
+
+  test("Unit intermediate transformed to unitless", () => {
+    const result = parseIntermediateOrInvalidValue("lineHeight", {
+      type: "intermediate",
+      value: "10-",
+      unit: "em",
+    });
+
+    expect(result).toEqual({
+      type: "unit",
+      value: 10,
+      unit: "number",
+    });
+  });
+
+  test("Unit intermediate with space transformed to unitless", () => {
+    const result = parseIntermediateOrInvalidValue("lineHeight", {
+      type: "intermediate",
+      value: "10 -",
+      unit: "em",
+    });
+
+    expect(result).toEqual({
+      type: "unit",
+      value: 10,
+      unit: "number",
+    });
+  });
+
+  test("Unit number intermediate transformed to unitless", () => {
+    const result = parseIntermediateOrInvalidValue("lineHeight", {
+      type: "intermediate",
+      value: "10",
+      unit: "number",
+    });
+
+    expect(result).toEqual({
+      type: "unit",
+      value: 10,
+      unit: "number",
+    });
+  });
+
+  test("Unitless expression transformed to unitless", () => {
+    const result = parseIntermediateOrInvalidValue("lineHeight", {
+      type: "intermediate",
+      value: "10 + 20 -",
+      unit: "px",
+    });
+
+    expect(result).toEqual({
+      type: "unit",
+      value: 30,
+      unit: "number",
+    });
+  });
+
+  test("Expression containing unit and unitless must be a unit", () => {
+    const result = parseIntermediateOrInvalidValue("lineHeight", {
+      type: "intermediate",
+      value: "10px + 20 -",
+      unit: "px",
+    });
+
+    expect(result).toEqual({
+      type: "unit",
+      value: 30,
+      unit: "px",
+    });
+  });
+
+  test("top with 0 should be unitless", () => {
+    const result = parseIntermediateOrInvalidValue("top", {
+      type: "intermediate",
+      value: "0-",
+      unit: "em",
+    });
+
+    expect(result).toEqual({
+      type: "unit",
+      value: 0,
+      unit: "number",
+    });
+  });
+
+  test("top with value 10 should have unit px", () => {
+    const result = parseIntermediateOrInvalidValue("top", {
+      type: "intermediate",
+      value: "10",
+      unit: "number",
+    });
+
+    expect(result).toEqual({
+      type: "unit",
+      value: 10,
+      unit: "px",
+    });
+  });
+});

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/unit-select.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/unit-select.tsx
@@ -24,6 +24,7 @@ const visibleLengthUnits = ["px", "em", "rem", "ch", "vw", "vh"] as const;
 type UseUnitSelectType = {
   property: string;
   value?: Unit;
+  showUnitless: boolean;
   onChange: (value: Unit) => void;
   onCloseAutoFocus: (event: Event) => void;
 };
@@ -31,6 +32,8 @@ type UseUnitSelectType = {
 export const useUnitSelect = ({
   property,
   value,
+  // edge-case, most css properties accept unitless value 0
+  showUnitless,
   onChange,
   onCloseAutoFocus,
 }: UseUnitSelectType): [boolean, JSX.Element | null] => {
@@ -50,8 +53,13 @@ export const useUnitSelect = ({
         options.push({ id: unit, label: unit.toLocaleUpperCase() });
       }
     }
+
+    if (showUnitless && !options.some((o) => o.id === "number")) {
+      options.push({ id: "number", label: "—" });
+    }
+
     return options;
-  }, [property]);
+  }, [property, showUnitless]);
 
   if (
     options.length === 0 ||
@@ -107,8 +115,9 @@ const UnitSelect = ({
       <SelectPrimitive.SelectTrigger asChild>
         <StyledTrigger variant="unit">
           <SelectPrimitive.Value>
-            {/* fallback to uppercased value for not listed units */}
-            {matchedOption?.label ?? value.toLocaleUpperCase()}
+            {/* fallback to uppercased value for not listed units, show - for number unit */}
+            {matchedOption?.label ??
+              (value === "number" ? "—" : value.toLocaleUpperCase())}
           </SelectPrimitive.Value>
         </StyledTrigger>
       </SelectPrimitive.SelectTrigger>

--- a/apps/builder/app/builder/features/style-panel/shared/parse-css-value.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/parse-css-value.ts
@@ -1,12 +1,7 @@
 import * as csstree from "css-tree";
 import hyphenate from "hyphenate-style-name";
-import type {
-  StyleProperty,
-  StyleValue,
-  Unit,
-  UnitGroup,
-} from "@webstudio-is/css-data";
-import { units, properties, keywordValues } from "@webstudio-is/css-data";
+import type { StyleProperty, StyleValue, Unit } from "@webstudio-is/css-data";
+import { units, keywordValues } from "@webstudio-is/css-data";
 import warnOnce from "warn-once";
 
 const cssTryParseValue = (input: string) => {
@@ -82,25 +77,20 @@ export const parseCssValue = (
   ) {
     // Try extract units from 1st children
     const first = ast.children.first;
-    const unitGroups = properties[property as keyof typeof properties]
-      .unitGroups as ReadonlyArray<UnitGroup>;
 
     if (first?.type === "Number") {
-      if (unitGroups.includes("number")) {
-        return {
-          type: "unit",
-          unit: "number",
-          value: Number(first.value),
-        };
-      }
-      return invalidValue;
+      return {
+        type: "unit",
+        unit: "number",
+        value: Number(first.value),
+      };
     }
 
     if (first?.type === "Dimension") {
       const unit = first.unit as typeof units[keyof typeof units][number];
-      for (const unitGroup of unitGroups) {
-        const possibleUnits = units[unitGroup] as ReadonlyArray<typeof unit>;
-        if (possibleUnits.includes(unit)) {
+
+      for (const unitGroup of Object.values(units)) {
+        if (unitGroup.includes(unit as never)) {
           return {
             type: "unit",
             unit: unit as Unit,
@@ -112,15 +102,13 @@ export const parseCssValue = (
     }
 
     if (first?.type === "Percentage") {
-      if (unitGroups.includes("percentage")) {
-        return {
-          type: "unit",
-          unit: "%",
-          value: Number(first.value),
-        };
-      }
-      return invalidValue;
+      return {
+        type: "unit",
+        unit: "%",
+        value: Number(first.value),
+      };
     }
+
     if (first?.type === "Identifier") {
       const values = keywordValues[
         property as keyof typeof keywordValues
@@ -131,7 +119,6 @@ export const parseCssValue = (
           value: input,
         };
       }
-      return invalidValue;
     }
   }
 


### PR DESCRIPTION
## Description

1. What is this PR about (link the issue and add a short description)

closes #1033
Also fixes that 0 for props like top, left etc showed as 

<img width="225" alt="image" src="https://user-images.githubusercontent.com/5077042/219710181-a8e7ecf4-638f-459a-a8b7-0dcd879768a2.png">

Now 

<img width="219" alt="image" src="https://user-images.githubusercontent.com/5077042/219710399-afa8af98-d8f9-4328-8bf5-083e6be2d6ba.png">

Also now if the property allows `unitless` we allow the selection of `-` unit from UnitSelect _(top can be unitless if value is 0)_

<img width="230" alt="image" src="https://user-images.githubusercontent.com/5077042/219710645-a91a05d3-0f2f-4fc8-b0b2-ede9a7c8e058.png">

And not if not _(top can't be unitless if value is not 0)_

<img width="141" alt="image" src="https://user-images.githubusercontent.com/5077042/219710884-74af7cba-76d0-4e5e-a6e4-ab2c7f910c45.png">








## Steps for reproduction

See tests what's accepted, for unitless properties, it's allowed to enter for lineHeight

`10-`
`20 -`
`10 + 20-`

All become unitless.


For `top` you can enter `0-` it becomes unitless 0
then for example `10` it becomes `10px` as `top does not support unitless 10



## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)

- [ ] hi @TrySound , I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [x] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
