### PR TITLE
Better page name layout and correct variable

### DIFF
--- a/apps/builder/app/builder/features/topbar/topbar.tsx
+++ b/apps/builder/app/builder/features/topbar/topbar.tsx
@@ -49,10 +49,10 @@ export const Topbar = ({ gridArea, project, page, publish }: TopbarProps) => {
         <Text
           variant="labelTitleCase"
           color="contrast"
-          css={{ maxWidth: theme.spacing[20] }}
+          css={{ minWidth: theme.spacing[15], maxWidth: "80%" }}
           truncate
         >
-          {page.title}
+          {page.name}
         </Text>
       </Flex>
       <Flex grow align="center" justify="center">


### PR DESCRIPTION
## Description

Page name had too little space even though we had plenty in the title, so I switched to min and max values and using name now instead of title, title can be SEO optimized, its not useful for builder


## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
