### PR TITLE
Enable style source input for all users

### DIFF
--- a/packages/feature-flags/src/flags.ts
+++ b/packages/feature-flags/src/flags.ts
@@ -3,4 +3,4 @@ export const example = false;
 export const dark = false;
 export const propertyReset = false;
 export const share2 = false;
-export const styleSourceInput = false;
+export const styleSourceInput = true;


### PR DESCRIPTION
Style source input is getting usable so we can enable it by default.

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
