### PR TITLE
Add "convert to token" for local style sources

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.tsx
@@ -2,7 +2,12 @@ import { useState } from "react";
 import store from "immerhin";
 import { nanoid } from "nanoid";
 import { theme, DeprecatedText2 } from "@webstudio-is/design-system";
-import { getStyleDeclKey, type StyleSource } from "@webstudio-is/project-build";
+import {
+  type Instance,
+  type StyleSource,
+  type StyleSourceSelections,
+  getStyleDeclKey,
+} from "@webstudio-is/project-build";
 import {
   type ItemSource,
   type ItemState,
@@ -23,6 +28,21 @@ import {
 import { removeByMutable } from "~/shared/array-utils";
 import { cloneStyles } from "~/shared/tree-utils";
 
+const getOrCreateStyleSourceSelectionMutable = (
+  styleSourceSelections: StyleSourceSelections,
+  selectedInstanceId: Instance["id"]
+) => {
+  let styleSourceSelection = styleSourceSelections.get(selectedInstanceId);
+  if (styleSourceSelection === undefined) {
+    styleSourceSelection = {
+      instanceId: selectedInstanceId,
+      values: [],
+    };
+    styleSourceSelections.set(selectedInstanceId, styleSourceSelection);
+  }
+  return styleSourceSelection;
+};
+
 const createStyleSource = (name: string) => {
   const selectedInstanceId = selectedInstanceIdStore.get();
   if (selectedInstanceId === undefined) {
@@ -36,14 +56,10 @@ const createStyleSource = (name: string) => {
   store.createTransaction(
     [styleSourcesStore, styleSourceSelectionsStore],
     (styleSources, styleSourceSelections) => {
-      let styleSourceSelection = styleSourceSelections.get(selectedInstanceId);
-      if (styleSourceSelection === undefined) {
-        styleSourceSelection = {
-          instanceId: selectedInstanceId,
-          values: [],
-        };
-        styleSourceSelections.set(selectedInstanceId, styleSourceSelection);
-      }
+      const styleSourceSelection = getOrCreateStyleSourceSelectionMutable(
+        styleSourceSelections,
+        selectedInstanceId
+      );
       styleSourceSelection.values.push(newStyleSource.id);
       styleSources.set(newStyleSource.id, newStyleSource);
     }
@@ -59,14 +75,10 @@ const addStyleSourceToInstace = (newStyleSourceId: StyleSource["id"]) => {
   store.createTransaction(
     [styleSourceSelectionsStore],
     (styleSourceSelections) => {
-      let styleSourceSelection = styleSourceSelections.get(selectedInstanceId);
-      if (styleSourceSelection === undefined) {
-        styleSourceSelection = {
-          instanceId: selectedInstanceId,
-          values: [],
-        };
-        styleSourceSelections.set(selectedInstanceId, styleSourceSelection);
-      }
+      const styleSourceSelection = getOrCreateStyleSourceSelectionMutable(
+        styleSourceSelections,
+        selectedInstanceId
+      );
       if (styleSourceSelection.values.includes(newStyleSourceId) === false) {
         styleSourceSelection.values.push(newStyleSourceId);
       }
@@ -155,14 +167,10 @@ const convertLocalStyleSourceToToken = (styleSourceId: StyleSource["id"]) => {
   store.createTransaction(
     [styleSourcesStore, styleSourceSelectionsStore],
     (styleSources, styleSourceSelections) => {
-      let styleSourceSelection = styleSourceSelections.get(selectedInstanceId);
-      if (styleSourceSelection === undefined) {
-        styleSourceSelection = {
-          instanceId: selectedInstanceId,
-          values: [],
-        };
-        styleSourceSelections.set(selectedInstanceId, styleSourceSelection);
-      }
+      const styleSourceSelection = getOrCreateStyleSourceSelectionMutable(
+        styleSourceSelections,
+        selectedInstanceId
+      );
       // generated local style source was not applied so put first
       if (styleSourceSelection.values.includes(newStyleSource.id) === false) {
         styleSourceSelection.values.unshift(newStyleSource.id);

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
@@ -69,6 +69,7 @@ type TextFieldBaseWrapperProps<Item extends IntermediateItem> = Omit<
     containerRef?: RefObject<HTMLDivElement>;
     inputRef?: RefObject<HTMLInputElement>;
     onDuplicateItem: (id: Item["id"]) => void;
+    onConvertToToken: (id: Item["id"]) => void;
     onRemoveItem?: (item: Item) => void;
     onChangeItem?: (item: Item) => void;
     onDisableItem?: (item: Item) => void;
@@ -98,6 +99,7 @@ const TextFieldBase: ForwardRefRenderFunction<
     label,
     value,
     onDuplicateItem,
+    onConvertToToken,
     onRemoveItem,
     onChangeItem,
     onDisableItem,
@@ -158,6 +160,7 @@ const TextFieldBase: ForwardRefRenderFunction<
             onChangeItem?.({ ...item, label });
           }}
           onDuplicate={() => onDuplicateItem?.(item.id)}
+          onConvertToToken={() => onConvertToToken?.(item.id)}
           onRemove={() => {
             onRemoveItem?.(item);
           }}
@@ -192,6 +195,7 @@ type StyleSourceInputProps<Item extends IntermediateItem> = {
   onSelectAutocompleteItem?: (item: Item) => void;
   onRemoveItem?: (item: Item) => void;
   onDuplicateItem?: (id: Item["id"]) => void;
+  onConvertToToken?: (id: Item["id"]) => void;
   onCreateItem?: (label: string) => void;
   onChangeItem?: (item: Item) => void;
   onSelectItem?: (item?: Item) => void;
@@ -305,6 +309,7 @@ export const StyleSourceInput = <Item extends IntermediateItem>(
             {...inputProps}
             onRemoveItem={props.onRemoveItem}
             onDuplicateItem={props.onDuplicateItem}
+            onConvertToToken={props.onConvertToToken}
             onChangeItem={props.onChangeItem}
             onSelectItem={props.onSelectItem}
             onEditItem={props.onEditItem}

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
@@ -137,6 +137,7 @@ type MenuProps = {
   state: ItemState;
   onEdit: () => void;
   onDuplicate: () => void;
+  onConvertToToken: () => void;
   onDisable: () => void;
   onEnable: () => void;
   onRemove: () => void;
@@ -146,6 +147,7 @@ const Menu = (props: MenuProps) => {
   const scheduler = useCallScheduler();
   const canEdit = props.source !== "local";
   const canDuplicate = props.source !== "local";
+  const canConvertToToken = props.source === "local";
   const canDisable = props.state !== "disabled";
   const canEnable = props.state === "disabled";
   const canRemove = props.source !== "local";
@@ -167,6 +169,11 @@ const Menu = (props: MenuProps) => {
           {canDuplicate && (
             <DropdownMenuItem onSelect={scheduler.set(props.onDuplicate)}>
               Duplicate
+            </DropdownMenuItem>
+          )}
+          {canConvertToToken && (
+            <DropdownMenuItem onSelect={scheduler.set(props.onConvertToToken)}>
+              Convert to token
             </DropdownMenuItem>
           )}
           {canEnable && (
@@ -412,6 +419,7 @@ type StyleSourceProps = {
   onChangeState: (state: ItemState) => void;
   onSelect: () => void;
   onDuplicate: () => void;
+  onConvertToToken: () => void;
   onRemove: () => void;
   onChangeValue: (value: string) => void;
   onChangeEditing: (isEditing: boolean) => void;
@@ -430,6 +438,7 @@ export const StyleSource = ({
   onChangeState,
   onSelect,
   onDuplicate,
+  onConvertToToken,
   onRemove,
 }: StyleSourceProps) => {
   const ref = useForceRecalcStyle<HTMLDivElement>("max-width", isEditing);
@@ -454,6 +463,7 @@ export const StyleSource = ({
           source={source}
           state={state}
           onDuplicate={onDuplicate}
+          onConvertToToken={onConvertToToken}
           onRemove={onRemove}
           onEnable={() => {
             onChangeState("unselected");


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/807

User may not want to create necessary tokens but start styling right after dropping component and later may want to create token from local style source.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
