### PR TITLE
Rename origin to webstudioApi in publish request to the new deployment process

### DIFF
--- a/apps/builder/app/routes/rest/publish.ts
+++ b/apps/builder/app/routes/rest/publish.ts
@@ -25,7 +25,7 @@ export const action = async ({ request }: ActionArgs) => {
         method: "PUT",
         headers,
         body: JSON.stringify({
-          origin: url.origin,
+          webstudioApi: url.origin,
           projectId,
           domain,
         }),

--- a/apps/builder/app/routes/rest/publish.ts
+++ b/apps/builder/app/routes/rest/publish.ts
@@ -25,7 +25,7 @@ export const action = async ({ request }: ActionArgs) => {
         method: "PUT",
         headers,
         body: JSON.stringify({
-          builderApiUrl: url.origin,
+          builderApiOrigin: url.origin,
           projectId,
           domain,
         }),

--- a/apps/builder/app/routes/rest/publish.ts
+++ b/apps/builder/app/routes/rest/publish.ts
@@ -25,7 +25,7 @@ export const action = async ({ request }: ActionArgs) => {
         method: "PUT",
         headers,
         body: JSON.stringify({
-          webstudioApi: url.origin,
+          builderApiUrl: url.origin,
           projectId,
           domain,
         }),

--- a/apps/builder/app/routes/rest/publish.ts
+++ b/apps/builder/app/routes/rest/publish.ts
@@ -27,7 +27,7 @@ export const action = async ({ request }: ActionArgs) => {
         body: JSON.stringify({
           builderApiOrigin: url.origin,
           projectId,
-          domain,
+          projectName: domain,
         }),
       });
       const text = await response.text();


### PR DESCRIPTION
## Description

1. What is this PR about (link the issue and add a short description)
Just renaming one of the payloads to our publisher API to be consistent.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
