### PR TITLE
Reflect preset style in style panel ui

### DIFF
--- a/apps/builder/app/builder/features/style-panel/controls/menu/menu-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/menu/menu-control.tsx
@@ -41,12 +41,15 @@ export const MenuControl = ({
       };
     })
     .filter((item) => item.icon);
-  let variant: "default" | "set" | "inherited" = "default";
+  let variant: "default" | "set" | "inherited" | "preset" = "default";
   if (styleSource === "local") {
     variant = "set";
   }
   if (styleSource === "remote") {
     variant = "inherited";
+  }
+  if (styleSource === "preset") {
+    variant = "preset";
   }
   return (
     <IconButtonWithMenu

--- a/apps/builder/app/builder/features/style-panel/sections/space/space.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/space/space.tsx
@@ -39,12 +39,15 @@ const Cell = ({
     return null;
   }
 
-  let origin: "set" | "inherited" | "unset" = "unset";
+  let origin: "set" | "inherited" | "preset" | "unset" = "unset";
   if (styleSource === "local") {
     origin = "set";
   }
   if (styleSource === "remote") {
     origin = "inherited";
+  }
+  if (styleSource === "preset") {
+    origin = "preset";
   }
 
   return (

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
@@ -62,7 +62,7 @@ cascadingStylesByInstanceId.set(selectedInstanceId, [
 const rootInstance: Instance = {
   type: "instance",
   id: "1",
-  component: "Body",
+  component: "Box",
   children: [
     {
       type: "instance",
@@ -157,6 +157,13 @@ test("compute inherited styles", () => {
     )
   ).toMatchInlineSnapshot(`
     {
+      "boxSizing": {
+        "instanceId": "2",
+        "value": {
+          "type": "keyword",
+          "value": "border-box",
+        },
+      },
       "fontSize": {
         "instanceId": "1",
         "value": {

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.ts
@@ -316,7 +316,7 @@ export const useStyleInfo = () => {
       }
     }
     return styleInfoData;
-  }, [browserStyle, inheritedInfo, cascadedInfo, selectedStyle]);
+  }, [browserStyle, presetStyle, inheritedInfo, cascadedInfo, selectedStyle]);
 
   return styleInfoData;
 };

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.ts
@@ -22,6 +22,7 @@ import {
   type InstancesIndex,
   getInstanceAncestorsAndSelf,
 } from "~/shared/tree-utils";
+import { getComponentMeta } from "@webstudio-is/react-sdk";
 
 type CascadedValueInfo = {
   breakpointId: string;
@@ -46,6 +47,7 @@ export type StyleValueInfo = {
   local?: StyleValue;
   cascaded?: CascadedValueInfo;
   inherited?: InheritedValueInfo;
+  preset?: StyleValue;
 };
 
 export type StyleInfo = {
@@ -69,6 +71,11 @@ export const getStyleSource = (
       return "remote";
     }
   }
+  for (const info of styleValueInfos) {
+    if (info?.preset !== undefined) {
+      return "preset";
+    }
+  }
   return "default";
 };
 
@@ -90,9 +97,9 @@ const getSelectedStyle = (
   if (instanceStyles === undefined) {
     return style;
   }
-  for (const styleItem of instanceStyles) {
-    if (styleItem.breakpointId === breakpointId) {
-      style[styleItem.property] = styleItem.value;
+  for (const styleDecl of instanceStyles) {
+    if (styleDecl.breakpointId === breakpointId) {
+      style[styleDecl.property] = styleDecl.value;
     }
   }
   return style;
@@ -131,16 +138,30 @@ export const getCascadedInfo = (
     return cascadedStyle;
   }
   for (const breakpointId of cascadedBreakpointIds) {
-    for (const styleItem of instanceStyles) {
-      if (styleItem.breakpointId === breakpointId) {
-        cascadedStyle[styleItem.property] = {
+    for (const styleDecl of instanceStyles) {
+      if (styleDecl.breakpointId === breakpointId) {
+        cascadedStyle[styleDecl.property] = {
           breakpointId,
-          value: styleItem.value,
+          value: styleDecl.value,
         };
       }
     }
   }
   return cascadedStyle;
+};
+
+const getPresetStyle = (
+  instancesIndex: InstancesIndex,
+  instanceId: undefined | Instance["id"]
+) => {
+  if (instanceId === undefined) {
+    return;
+  }
+  const instance = instancesIndex.instancesById.get(instanceId);
+  if (instance === undefined) {
+    return;
+  }
+  return getComponentMeta(instance.component)?.presetStyle;
 };
 
 /**
@@ -174,16 +195,26 @@ export const getInheritedInfo = (
       continue;
     }
 
+    const presetStyle = getPresetStyle(instancesIndex, ancestorInstance.id);
+    if (presetStyle) {
+      for (const [styleProperty, styleValue] of Object.entries(presetStyle)) {
+        inheritedStyle[styleProperty as StyleProperty] = {
+          instanceId: ancestorInstance.id,
+          value: styleValue,
+        };
+      }
+    }
+
     // extract styles from all active breakpoints
     for (const breakpointId of cascadedAndSelectedBreakpointIds) {
-      for (const styleItem of ancestorInstanceStyles) {
+      for (const styleDecl of ancestorInstanceStyles) {
         if (
-          styleItem.breakpointId === breakpointId &&
-          inheritableProperties.has(styleItem.property)
+          styleDecl.breakpointId === breakpointId &&
+          inheritableProperties.has(styleDecl.property)
         ) {
-          inheritedStyle[styleItem.property] = {
+          inheritedStyle[styleDecl.property] = {
             instanceId: ancestorInstance.id,
-            value: styleItem.value,
+            value: styleDecl.value,
           };
         }
       }
@@ -259,21 +290,28 @@ export const useStyleInfo = () => {
     );
   }, [stylesByInstanceId, selectedInstanceId, cascadedBreakpointIds]);
 
+  const presetStyle = useMemo(() => {
+    return getPresetStyle(instancesIndex, selectedInstanceId);
+  }, [instancesIndex, selectedInstanceId]);
+
   const styleInfoData = useMemo(() => {
     const styleInfoData: StyleInfo = {};
     for (const property of styleProperties) {
       // temporary solution until we start computing all styles from data
       const computed = browserStyle?.[property];
+      const preset = presetStyle?.[property];
       const inherited = inheritedInfo[property];
       const cascaded = cascadedInfo[property];
       const local = selectedStyle?.[property];
-      const value = local ?? cascaded?.value ?? inherited?.value ?? computed;
+      const value =
+        local ?? cascaded?.value ?? inherited?.value ?? preset ?? computed;
       if (value) {
         styleInfoData[property] = {
           value,
           local,
           cascaded,
           inherited,
+          preset,
         };
       }
     }
@@ -291,6 +329,10 @@ export const useInstanceStyleData = (
   const [breakpoints] = useBreakpoints();
   const selectedBreakpoint = useStore(selectedBreakpointStore);
   const selectedBreakpointId = selectedBreakpoint?.id;
+
+  const presetStyle = useMemo(() => {
+    return getPresetStyle(instancesIndex, instanceId);
+  }, [instancesIndex, instanceId]);
 
   const cascadedBreakpointIds = useMemo(
     () => getCascadedBreakpointIds(breakpoints, selectedBreakpointId),
@@ -335,16 +377,17 @@ export const useInstanceStyleData = (
     const styleData: Style = {};
     for (const property of styleProperties) {
       // temporary solution until we start computing all styles from data
+      const preset = presetStyle?.[property];
       const inherited = inheritedInfo[property];
       const cascaded = selfAndCascadeInfo[property];
-      const value = cascaded?.value ?? inherited?.value;
+      const value = cascaded?.value ?? inherited?.value ?? preset;
 
       if (value) {
         styleData[property] = value;
       }
     }
     return styleData;
-  }, [selfAndCascadeInfo, inheritedInfo]);
+  }, [presetStyle, selfAndCascadeInfo, inheritedInfo]);
 
   return styleData;
 };


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1082

Added preset styles to style info and considered while computing inherited styles.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
