### PR TITLE
Run eslint on precommit

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,4 +2,11 @@ module.exports = {
   root: true,
   // This tells ESLint to load the config from the package `eslint-config-custom`
   extends: ["@webstudio-is/eslint-config-custom"],
+  ignorePatterns: [
+    "*.d.ts",
+    "codemod",
+    "packages/*/lib",
+    "packages/prisma-client/prisma/migrations",
+    "apps/builder/api",
+  ],
 };

--- a/apps/builder/env-check.js
+++ b/apps/builder/env-check.js
@@ -25,8 +25,9 @@ const S3_KEYS = [
 const errors = [];
 
 REQUIRED_ENVS.map((env) => {
-  if (!process.env[env])
+  if (!process.env[env]) {
     errors.push(`👉 The ${env} environment variable is required`);
+  }
 });
 
 if (process.env.DEPLOYMENT_ENVIRONMENT === "production") {

--- a/apps/builder/server.js
+++ b/apps/builder/server.js
@@ -1,4 +1,5 @@
 import { createRequestHandler } from "@remix-run/vercel";
+// eslint-disable-next-line
 import * as build from "@remix-run/dev/server-build";
 
 export default createRequestHandler({ build, mode: process.env.NODE_ENV });

--- a/package.json
+++ b/package.json
@@ -41,7 +41,13 @@
     "yarn": "This project is configured to use pnpm"
   },
   "nano-staged": {
-    "*.{ts,tsx,js,json,css,md}": "prettier --write"
+    "*.{ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{js,json,css,md}": [
+      "prettier --write"
+    ]
   },
   "prettier": {},
   "resolutions": {

--- a/packages/asset-uploader/server.js
+++ b/packages/asset-uploader/server.js
@@ -1,1 +1,2 @@
+// eslint-disable-next-line import/no-internal-modules
 export * from "./lib/index.server";

--- a/packages/authorization-token/server.js
+++ b/packages/authorization-token/server.js
@@ -1,1 +1,2 @@
+// eslint-disable-next-line import/no-internal-modules
 export * from "./lib/index.server";

--- a/packages/css-data/bin/mdn-data.ts
+++ b/packages/css-data/bin/mdn-data.ts
@@ -273,7 +273,7 @@ const writeToFile = (fileName: string, constant: string, data: unknown) => {
 const keywordValues = (() => {
   const result: { [prop: string]: Array<string> } = {};
 
-  for (let property in filteredProperties) {
+  for (const property in filteredProperties) {
     const keywords = new Set<string>();
     walkSyntax(filteredProperties[property].syntax, (node) => {
       if (node.type === "Keyword") {

--- a/packages/dashboard/server.js
+++ b/packages/dashboard/server.js
@@ -1,1 +1,2 @@
+// eslint-disable-next-line import/no-internal-modules
 export * from "./lib/index.server";

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -50,6 +50,8 @@ module.exports = {
         allow: [
           "**/server",
           "@lexical/react/*",
+          "css-tree/**",
+          "mdn-data/**",
           "__generated__/*",
           "react-hot-toast/headless",
         ],

--- a/packages/fonts/server.js
+++ b/packages/fonts/server.js
@@ -1,1 +1,2 @@
+// eslint-disable-next-line import/no-internal-modules
 export * from "./lib/index.server";

--- a/packages/project-build/server.js
+++ b/packages/project-build/server.js
@@ -1,1 +1,2 @@
+// eslint-disable-next-line import/no-internal-modules
 export * from "./lib/index.server";

--- a/packages/project/server.js
+++ b/packages/project/server.js
@@ -1,1 +1,2 @@
+// eslint-disable-next-line import/no-internal-modules
 export * from "./lib/index.server";

--- a/packages/scripts/build-package.ts
+++ b/packages/scripts/build-package.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+/* eslint-disable no-console */
 
 import { rm, cp } from "node:fs/promises";
 import { join } from "node:path";

--- a/packages/trpc-interface/server.js
+++ b/packages/trpc-interface/server.js
@@ -1,1 +1,2 @@
+// eslint-disable-next-line import/no-internal-modules
 export * from "./lib/index.server";


### PR DESCRIPTION
We often get failed CI after commit because of lint checks. We commit fixes and wait again for CI to complete.

Here I put eslint to nano-staged to run on staged modules. This will let us see errors prematurely and commit less "Fix lint".

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
