### PR TITLE
Code component

### DIFF
--- a/apps/builder/app/shared/copy-paste/plugin-markdown.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-markdown.test.ts
@@ -416,7 +416,7 @@ describe("Plugin Markdown", () => {
                     "value": "foo",
                   },
                 ],
-                "component": "InlineCode",
+                "component": "Code",
                 "id": "123",
                 "type": "instance",
               },
@@ -426,7 +426,15 @@ describe("Plugin Markdown", () => {
             "type": "instance",
           },
         ],
-        "props": [],
+        "props": [
+          {
+            "id": "123",
+            "instanceId": "123",
+            "name": "inline",
+            "type": "boolean",
+            "value": true,
+          },
+        ],
       }
     `);
   });
@@ -449,6 +457,13 @@ describe("Plugin Markdown", () => {
           },
         ],
         "props": [
+          {
+            "id": "123",
+            "instanceId": "123",
+            "name": "inline",
+            "type": "boolean",
+            "value": false,
+          },
           {
             "id": "123",
             "instanceId": "123",

--- a/apps/builder/app/shared/copy-paste/plugin-markdown.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-markdown.ts
@@ -31,7 +31,7 @@ const astTypeComponentMap: Record<string, Instance["component"]> = {
   image: "Image",
   blockquote: "Blockquote",
   code: "Code",
-  inlineCode: "InlineCode",
+  inlineCode: "Code",
   list: "List",
   listItem: "ListItem",
   thematicBreak: "Separator",
@@ -116,11 +116,25 @@ const toInstanceData = (
           type: "text",
           value: child.value,
         });
+        props.push({
+          id: generateId(),
+          type: "boolean",
+          name: "inline",
+          instanceId: instance.id,
+          value: true,
+        });
       }
       if (child.type === "code") {
         instance.children.push({
           type: "text",
           value: child.value,
+        });
+        props.push({
+          id: generateId(),
+          type: "boolean",
+          name: "inline",
+          instanceId: instance.id,
+          value: false,
         });
         if (child.lang) {
           props.push({
@@ -190,7 +204,8 @@ export const parse = (clipboardData: string, options?: Options) => {
   if (ast.children.length === 0) {
     return;
   }
-  return toInstanceData(ast, options);
+  const data = toInstanceData(ast, options);
+  return data;
 };
 
 export const onPaste = (clipboardData: string) => {

--- a/packages/css-vars/src/index.ts
+++ b/packages/css-vars/src/index.ts
@@ -1,6 +1,13 @@
 let counter = -1;
 
-const define = <Name extends string>(name: Name) => {
+const unique = <Name extends string>(name: Name) => {
+  return `${name}-${++counter}` as const;
+};
+
+const define = <Name extends string>(name: Name, unique = false) => {
+  if (unique) {
+    return `--${name}` as const;
+  }
   return `--${name}-${++counter}` as const;
 };
 
@@ -24,4 +31,4 @@ const use = <Args extends string[]>(...args: Args) => {
   return `var(${args.join(", ") as Join<Args, ", ">})` as const;
 };
 
-export const cssVars = { define, use };
+export const cssVars = { define, use, unique };

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -55,6 +55,7 @@
     "@nanostores/react": "^0.4.1",
     "@webstudio-is/asset-uploader": "workspace:^",
     "@webstudio-is/css-data": "workspace:^",
+    "@webstudio-is/css-vars": "workspace:^",
     "@webstudio-is/generate-arg-types": "workspace:^",
     "@webstudio-is/icons": "workspace:^",
     "@webstudio-is/image": "workspace:^",

--- a/packages/react-sdk/src/components/__generated__/code.props.json
+++ b/packages/react-sdk/src/components/__generated__/code.props.json
@@ -1,0 +1,751 @@
+{
+  "slot": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "style": {
+    "type": {
+      "name": "CSSProperties",
+      "required": false
+    },
+    "control": "text"
+  },
+  "title": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "defaultChecked": {
+    "type": {
+      "name": "boolean",
+      "required": false
+    },
+    "control": "boolean"
+  },
+  "defaultValue": {
+    "type": {
+      "name": "string | number | readonly string[]",
+      "required": false
+    },
+    "control": "text"
+  },
+  "suppressContentEditableWarning": {
+    "type": {
+      "name": "boolean",
+      "required": false
+    },
+    "control": "boolean"
+  },
+  "suppressHydrationWarning": {
+    "type": {
+      "name": "boolean",
+      "required": false
+    },
+    "control": "boolean"
+  },
+  "accessKey": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "className": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "contentEditable": {
+    "type": {
+      "name": "Booleanish | \"inherit\"",
+      "required": false
+    },
+    "control": "text"
+  },
+  "contextMenu": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "dir": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "draggable": {
+    "type": {
+      "name": "boolean",
+      "required": false
+    },
+    "control": "boolean"
+  },
+  "hidden": {
+    "type": {
+      "name": "boolean",
+      "required": false
+    },
+    "control": "boolean"
+  },
+  "id": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "lang": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "placeholder": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "spellCheck": {
+    "type": {
+      "name": "boolean",
+      "required": false
+    },
+    "control": "boolean"
+  },
+  "tabIndex": {
+    "type": {
+      "name": "number",
+      "required": false
+    },
+    "control": "number"
+  },
+  "translate": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": {
+      "type": "radio",
+      "options": ["yes", "no"]
+    }
+  },
+  "radioGroup": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "role": {
+    "type": {
+      "name": "AriaRole",
+      "required": false
+    },
+    "control": "text"
+  },
+  "about": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "datatype": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "inlist": {
+    "type": {
+      "name": "any",
+      "required": false
+    },
+    "control": "text"
+  },
+  "prefix": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "property": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "resource": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "typeof": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "vocab": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "autoCapitalize": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "autoCorrect": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "autoSave": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "color": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "color"
+  },
+  "itemProp": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "itemScope": {
+    "type": {
+      "name": "boolean",
+      "required": false
+    },
+    "control": "boolean"
+  },
+  "itemType": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "itemID": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "itemRef": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "results": {
+    "type": {
+      "name": "number",
+      "required": false
+    },
+    "control": "number"
+  },
+  "security": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "unselectable": {
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": {
+      "type": "radio",
+      "options": ["on", "off"]
+    }
+  },
+  "inputMode": {
+    "description": "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": {
+      "type": "select",
+      "options": [
+        "text",
+        "none",
+        "search",
+        "tel",
+        "url",
+        "email",
+        "numeric",
+        "decimal"
+      ]
+    }
+  },
+  "is": {
+    "description": "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "aria-activedescendant": {
+    "description": "Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "aria-atomic": {
+    "description": "Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.",
+    "type": {
+      "name": "boolean",
+      "required": false
+    },
+    "control": "boolean"
+  },
+  "aria-autocomplete": {
+    "description": "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be\npresented if they are made.",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": {
+      "type": "radio",
+      "options": ["inline", "list", "none", "both"]
+    }
+  },
+  "aria-busy": {
+    "description": "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+    "type": {
+      "name": "boolean",
+      "required": false
+    },
+    "control": "boolean"
+  },
+  "aria-checked": {
+    "description": "Indicates the current \"checked\" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.",
+    "type": {
+      "name": "boolean | \"true\" | \"false\" | \"mixed\"",
+      "required": false
+    },
+    "control": "text"
+  },
+  "aria-colcount": {
+    "description": "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+    "type": {
+      "name": "number",
+      "required": false
+    },
+    "control": "number"
+  },
+  "aria-colindex": {
+    "description": "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+    "type": {
+      "name": "number",
+      "required": false
+    },
+    "control": "number"
+  },
+  "aria-colspan": {
+    "description": "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+    "type": {
+      "name": "number",
+      "required": false
+    },
+    "control": "number"
+  },
+  "aria-controls": {
+    "description": "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "aria-current": {
+    "description": "Indicates the element that represents the current item within a container or set of related elements.",
+    "type": {
+      "name": "boolean | \"time\" | \"true\" | \"false\" | \"page\" | \"step\" | \"location\" | \"date\"",
+      "required": false
+    },
+    "control": "text"
+  },
+  "aria-describedby": {
+    "description": "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "aria-details": {
+    "description": "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "aria-disabled": {
+    "description": "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+    "type": {
+      "name": "boolean",
+      "required": false
+    },
+    "control": "boolean"
+  },
+  "aria-dropeffect": {
+    "description": "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": {
+      "type": "select",
+      "options": ["link", "none", "copy", "execute", "move", "popup"]
+    }
+  },
+  "aria-errormessage": {
+    "description": "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "aria-expanded": {
+    "description": "Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.",
+    "type": {
+      "name": "boolean",
+      "required": false
+    },
+    "control": "boolean"
+  },
+  "aria-flowto": {
+    "description": "Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,\nallows assistive technology to override the general default of reading in document source order.",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "aria-grabbed": {
+    "description": "Indicates an element's \"grabbed\" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1",
+    "type": {
+      "name": "boolean",
+      "required": false
+    },
+    "control": "boolean"
+  },
+  "aria-haspopup": {
+    "description": "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.",
+    "type": {
+      "name": "boolean | \"dialog\" | \"menu\" | \"true\" | \"false\" | \"grid\" | \"listbox\" | \"tree\"",
+      "required": false
+    },
+    "control": "text"
+  },
+  "aria-hidden": {
+    "description": "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+    "type": {
+      "name": "boolean",
+      "required": false
+    },
+    "control": "boolean"
+  },
+  "aria-invalid": {
+    "description": "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+    "type": {
+      "name": "boolean | \"true\" | \"false\" | \"grammar\" | \"spelling\"",
+      "required": false
+    },
+    "control": "text"
+  },
+  "aria-keyshortcuts": {
+    "description": "Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "aria-label": {
+    "description": "Defines a string value that labels the current element.\n@see aria-labelledby.",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "aria-labelledby": {
+    "description": "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "aria-level": {
+    "description": "Defines the hierarchical level of an element within a structure.",
+    "type": {
+      "name": "number",
+      "required": false
+    },
+    "control": "number"
+  },
+  "aria-live": {
+    "description": "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": {
+      "type": "radio",
+      "options": ["off", "assertive", "polite"]
+    }
+  },
+  "aria-modal": {
+    "description": "Indicates whether an element is modal when displayed.",
+    "type": {
+      "name": "boolean",
+      "required": false
+    },
+    "control": "boolean"
+  },
+  "aria-multiline": {
+    "description": "Indicates whether a text box accepts multiple lines of input or only a single line.",
+    "type": {
+      "name": "boolean",
+      "required": false
+    },
+    "control": "boolean"
+  },
+  "aria-multiselectable": {
+    "description": "Indicates that the user may select more than one item from the current selectable descendants.",
+    "type": {
+      "name": "boolean",
+      "required": false
+    },
+    "control": "boolean"
+  },
+  "aria-orientation": {
+    "description": "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": {
+      "type": "radio",
+      "options": ["horizontal", "vertical"]
+    }
+  },
+  "aria-owns": {
+    "description": "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "aria-placeholder": {
+    "description": "Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.\nA hint could be a sample value or a brief description of the expected format.",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "aria-posinset": {
+    "description": "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+    "type": {
+      "name": "number",
+      "required": false
+    },
+    "control": "number"
+  },
+  "aria-pressed": {
+    "description": "Indicates the current \"pressed\" state of toggle buttons.\n@see aria-checked\n@see aria-selected.",
+    "type": {
+      "name": "boolean | \"true\" | \"false\" | \"mixed\"",
+      "required": false
+    },
+    "control": "text"
+  },
+  "aria-readonly": {
+    "description": "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+    "type": {
+      "name": "boolean",
+      "required": false
+    },
+    "control": "boolean"
+  },
+  "aria-relevant": {
+    "description": "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": {
+      "type": "select",
+      "options": [
+        "text",
+        "additions",
+        "additions removals",
+        "additions text",
+        "all",
+        "removals",
+        "removals additions",
+        "removals text",
+        "text additions",
+        "text removals"
+      ]
+    }
+  },
+  "aria-required": {
+    "description": "Indicates that user input is required on the element before a form may be submitted.",
+    "type": {
+      "name": "boolean",
+      "required": false
+    },
+    "control": "boolean"
+  },
+  "aria-roledescription": {
+    "description": "Defines a human-readable, author-localized description for the role of an element.",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "aria-rowcount": {
+    "description": "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+    "type": {
+      "name": "number",
+      "required": false
+    },
+    "control": "number"
+  },
+  "aria-rowindex": {
+    "description": "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+    "type": {
+      "name": "number",
+      "required": false
+    },
+    "control": "number"
+  },
+  "aria-rowspan": {
+    "description": "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+    "type": {
+      "name": "number",
+      "required": false
+    },
+    "control": "number"
+  },
+  "aria-selected": {
+    "description": "Indicates the current \"selected\" state of various widgets.\n@see aria-checked\n@see aria-pressed.",
+    "type": {
+      "name": "boolean",
+      "required": false
+    },
+    "control": "boolean"
+  },
+  "aria-setsize": {
+    "description": "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+    "type": {
+      "name": "number",
+      "required": false
+    },
+    "control": "number"
+  },
+  "aria-sort": {
+    "description": "Indicates if items in a table or grid are sorted in ascending or descending order.",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": {
+      "type": "radio",
+      "options": ["none", "ascending", "descending", "other"]
+    }
+  },
+  "aria-valuemax": {
+    "description": "Defines the maximum allowed value for a range widget.",
+    "type": {
+      "name": "number",
+      "required": false
+    },
+    "control": "number"
+  },
+  "aria-valuemin": {
+    "description": "Defines the minimum allowed value for a range widget.",
+    "type": {
+      "name": "number",
+      "required": false
+    },
+    "control": "number"
+  },
+  "aria-valuenow": {
+    "description": "Defines the current value for a range widget.\n@see aria-valuetext.",
+    "type": {
+      "name": "number",
+      "required": false
+    },
+    "control": "number"
+  },
+  "aria-valuetext": {
+    "description": "Defines the human readable text alternative of aria-valuenow for a range widget.",
+    "type": {
+      "name": "string",
+      "required": false
+    },
+    "control": "text"
+  },
+  "inline": {
+    "type": {
+      "name": "boolean",
+      "required": false
+    },
+    "control": "boolean",
+    "defaultValue": false
+  }
+}

--- a/packages/react-sdk/src/components/code.tsx
+++ b/packages/react-sdk/src/components/code.tsx
@@ -4,14 +4,25 @@ import {
   type ElementRef,
   type ComponentProps,
 } from "react";
+import { cssVars } from "@webstudio-is/css-vars";
 
 const defaultTag = "code";
 
-type Props = ComponentProps<typeof defaultTag>;
+export const displayVarNamespace = cssVars.unique("code-display");
+
+const displayVar = cssVars.define(displayVarNamespace, true);
+
+type Props = Omit<ComponentProps<typeof defaultTag>, "inline"> & {
+  inline?: boolean;
+  meta?: string;
+};
 
 export const Code = forwardRef<ElementRef<typeof defaultTag>, Props>(
-  (props, ref) => {
-    return createElement(defaultTag, { ...props, ref });
+  ({ inline = false, ...props }, ref) => {
+    // @todo in the future we should expose the inline prop a an attribute
+    // and define the display style in `presetStyle` in meta.
+    const style = inline ? undefined : { [displayVar]: "block" };
+    return createElement(defaultTag, { ...props, style, ref });
   }
 );
 

--- a/packages/react-sdk/src/components/code.tsx
+++ b/packages/react-sdk/src/components/code.tsx
@@ -10,7 +10,9 @@ const defaultTag = "code";
 
 export const displayVarNamespace = cssVars.unique("code-display");
 
-const displayVar = cssVars.define(displayVarNamespace, true);
+const blockStyle = {
+  [cssVars.define(displayVarNamespace, true)]: "block",
+};
 
 type Props = Omit<ComponentProps<typeof defaultTag>, "inline"> & {
   inline?: boolean;
@@ -21,7 +23,7 @@ export const Code = forwardRef<ElementRef<typeof defaultTag>, Props>(
   ({ inline = false, ...props }, ref) => {
     // @todo in the future we should expose the inline prop a an attribute
     // and define the display style in `presetStyle` in meta.
-    const style = inline ? undefined : { [displayVar]: "block" };
+    const style = inline ? undefined : blockStyle;
     return createElement(defaultTag, { ...props, style, ref });
   }
 );

--- a/packages/react-sdk/src/components/code.ws.tsx
+++ b/packages/react-sdk/src/components/code.ws.tsx
@@ -1,45 +1,36 @@
 import { CodeIcon } from "@webstudio-is/icons";
 import type { WsComponentMeta, WsComponentPropsMeta } from "./component-type";
-import props from "./__generated__/heading.props.json";
+import { displayVarNamespace } from "./code";
+import props from "./__generated__/code.props.json";
 
-const presetStyle = {
-  paddingTop: {
-    type: "keyword",
-    value: "0.2em",
-  },
-  paddingBottom: {
-    type: "keyword",
-    value: "0.2em",
+const presetStyle: WsComponentMeta["presetStyle"] = {
+  display: {
+    type: "var",
+    value: displayVarNamespace,
+    fallbacks: [
+      {
+        type: "keyword",
+        value: "inline-block",
+      },
+    ],
   },
   paddingLeft: {
     type: "keyword",
-    value: "0.4em",
+    value: "0.2em",
   },
   paddingRight: {
     type: "keyword",
-    value: "0.4em",
-  },
-  margin: {
-    type: "keyword",
-    value: "0",
-  },
-  whiteSpace: {
-    type: "keyword",
-    value: "break-spaces",
+    value: "0.2em",
   },
   backgroundColor: {
     type: "keyword",
     value: "#eee",
   },
-  borderRadius: {
-    type: "keyword",
-    value: "3px",
-  },
   fontFamily: {
     type: "keyword",
     value: "monospace",
   },
-} as const;
+};
 
 export const meta: WsComponentMeta = {
   type: "rich-text",
@@ -51,5 +42,5 @@ export const meta: WsComponentMeta = {
 
 export const propsMeta = {
   props,
-  initialProps: [],
+  initialProps: ["inline", "lang", "meta"],
 } as WsComponentPropsMeta;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1240,6 +1240,9 @@ importers:
       '@webstudio-is/css-data':
         specifier: workspace:^
         version: link:../css-data
+      '@webstudio-is/css-vars':
+        specifier: workspace:^
+        version: link:../css-vars
       '@webstudio-is/generate-arg-types':
         specifier: workspace:^
         version: link:../generate-arg-types


### PR DESCRIPTION
## Description

Introduces  Code component, no syntax highlighting just block and inline code

## Steps for reproduction

1. add code component, try toggle inline prop
2. try from markdown

block

```js
alert(123)
alert(123)
alert(123)
```

inline
```
test  test `alert(123)` test 
```

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
