### PR TITLE
Support background-clip text

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -233,7 +233,6 @@ const initialValue: IntermediateStyleValue = {
 };
 
 const itemToString = (item: CssValueInputValue | null) => {
-  console.log(item);
   return item === null
     ? ""
     : item.type === "keyword"

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -232,14 +232,16 @@ const initialValue: IntermediateStyleValue = {
   value: "",
 };
 
-const itemToString = (item: CssValueInputValue | null) =>
-  item === null
+const itemToString = (item: CssValueInputValue | null) => {
+  console.log(item);
+  return item === null
     ? ""
     : item.type === "keyword"
     ? toPascalCase(item.value)
     : item.type === "intermediate" || item.type === "unit"
     ? String(item.value)
     : toValue(item);
+};
 
 const match = <Item,>(
   search: string,

--- a/apps/builder/app/builder/features/style-panel/shared/keyword-utils.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/keyword-utils.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "@jest/globals";
+import { toPascalCase } from "./keyword-utils";
+
+describe("keyword-utils", () => {
+  test("toPascalCase", () => {
+    expect(toPascalCase("box")).toBe("Box");
+    expect(toPascalCase("border-box")).toBe("Border Box");
+    expect(toPascalCase("-border-box")).toBe("Border Box");
+  });
+});

--- a/apps/builder/app/builder/features/style-panel/shared/keyword-utils.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/keyword-utils.ts
@@ -6,6 +6,7 @@ export const toPascalCase = (keyword: string) => {
   const label = keyword
     .replace(/-/g, " ")
     .split(" ")
+    .filter(Boolean)
     .map((word) => {
       return word[0].toUpperCase() + word.slice(1);
     })

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -163,6 +163,13 @@ const toVarStyleWithFallback = (instanceId: string, style: Style): Style => {
         value.type as (typeof validStaticValueTypes)[number]
       )
     ) {
+      // We don't want to wrap backgroundClip into a var, because it's not supported by CSS variables
+      // It's fine because we don't need to update it dynamically via CSS variables during preview changes
+      // we renrender it anyway when CSS update happens
+      if (property === "backgroundClip") {
+        dynamicStyle[property] = value;
+        continue;
+      }
       dynamicStyle[property] = {
         type: "var",
         value: toVarNamespace(instanceId, property),

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "nano-staged": "^0.8.0",
     "prettier": "2.8.4",
     "simple-git-hooks": "^2.8.1",
-    "tsx": "^3.9.0",
+    "tsx": "^3.12.1",
     "turbo": "^1.7.0",
     "typescript": "4.9.5"
   },

--- a/packages/css-data/src/__generated__/keyword-values.ts
+++ b/packages/css-data/src/__generated__/keyword-values.ts
@@ -303,7 +303,7 @@ export const keywordValues = {
     "color",
     "luminosity",
   ],
-  backgroundClip: ["border-box", "padding-box", "content-box"],
+  backgroundClip: ["border-box", "padding-box", "content-box", "text"],
   backgroundColor: [
     "transparent",
     "aliceblue",

--- a/packages/css-engine/src/core/rules.ts
+++ b/packages/css-engine/src/core/rules.ts
@@ -1,6 +1,6 @@
 import type { Style, StyleProperty, StyleValue } from "@webstudio-is/css-data";
-import hyphenate from "hyphenate-style-name";
 import { toValue } from "./to-value";
+import { toProperty } from "./to-property";
 
 class StylePropertyMap {
   #styleMap: Map<StyleProperty, StyleValue | undefined> = new Map();
@@ -37,7 +37,7 @@ class StylePropertyMap {
       if (value === undefined) {
         continue;
       }
-      block.push(`${hyphenate(property)}: ${toValue(value)}`);
+      block.push(`${toProperty(property)}: ${toValue(value)}`);
     }
     this.#string = block.join("; ");
     this.#isDirty = false;

--- a/packages/css-engine/src/core/to-property.test.ts
+++ b/packages/css-engine/src/core/to-property.test.ts
@@ -1,0 +1,11 @@
+import { describe, test } from "@jest/globals";
+import { toProperty } from "./to-property";
+
+describe("toProperty", () => {
+  test("boxSizing", () => {
+    expect(toProperty("boxSizing")).toBe("box-sizing");
+  });
+  test("backgroundClip", () => {
+    expect(toProperty("backgroundClip")).toBe("-webkit-background-clip");
+  });
+});

--- a/packages/css-engine/src/core/to-property.ts
+++ b/packages/css-engine/src/core/to-property.ts
@@ -1,0 +1,12 @@
+import type { StyleProperty } from "@webstudio-is/css-data";
+import hyphenate from "hyphenate-style-name";
+
+export const toProperty = (property: StyleProperty) => {
+  // Currently its a non-standard property and is only officially supported via -webkit- prefix.
+  // Safari illegally supports it without the prefix.
+  // https://caniuse.com/background-clip-text
+  if (property === "backgroundClip") {
+    return "-webkit-background-clip";
+  }
+  return hyphenate(property);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ importers:
         specifier: ^2.8.1
         version: 2.8.1
       tsx:
-        specifier: ^3.9.0
+        specifier: ^3.12.1
         version: 3.12.1
       turbo:
         specifier: ^1.7.0
@@ -2481,12 +2481,12 @@ packages:
       '@babel/code-frame': 7.18.6
       '@babel/generator': 7.21.1
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.21.0)
-      '@babel/helper-module-transforms': 7.21.0
+      '@babel/helper-module-transforms': 7.21.2
       '@babel/helpers': 7.21.0
-      '@babel/parser': 7.21.1
+      '@babel/parser': 7.21.2
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.0
-      '@babel/types': 7.21.0
+      '@babel/traverse': 7.21.2
+      '@babel/types': 7.21.2
       convert-source-map: 1.9.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -2517,7 +2517,7 @@ packages:
     resolution: {integrity: sha512-1lT45bAYlQhFn/BHivJs43AiW2rg3/UbLyShGfF3C0KmHvO5fSghWd5kBJy30kpRRucGzXStvnnCFniCR2kXAA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.0
+      '@babel/types': 7.21.2
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.17
       jsesc: 2.5.2
@@ -2658,7 +2658,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/types': 7.21.0
+      '@babel/types': 7.21.2
     dev: true
 
   /@babel/helper-hoist-variables@7.18.6:
@@ -2710,8 +2710,8 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/helper-module-transforms@7.21.0:
-    resolution: {integrity: sha512-eD/JQ21IG2i1FraJnTMbUarAUkA7G988ofehG5MDCRXaUU91rEBJuCeSoou2Sk1y4RbLYXzqEg1QLwEmRU4qcQ==}
+  /@babel/helper-module-transforms@7.21.2:
+    resolution: {integrity: sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-environment-visitor': 7.18.9
@@ -2720,8 +2720,8 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.0
-      '@babel/types': 7.21.0
+      '@babel/traverse': 7.21.2
+      '@babel/types': 7.21.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2833,8 +2833,8 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.0
-      '@babel/types': 7.21.0
+      '@babel/traverse': 7.21.2
+      '@babel/types': 7.21.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2862,12 +2862,12 @@ packages:
       '@babel/types': 7.20.7
     dev: true
 
-  /@babel/parser@7.21.1:
-    resolution: {integrity: sha512-JzhBFpkuhBNYUY7qs+wTzNmyCWUHEaAFpQQD2YfU1rPL38/L43Wvid0fFkiOCnHvsGncRZgEPyGnltABLcVDTg==}
+  /@babel/parser@7.21.2:
+    resolution: {integrity: sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.21.0
+      '@babel/types': 7.21.2
     dev: true
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6(@babel/core@7.20.12):
@@ -4144,8 +4144,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/traverse@7.21.0:
-    resolution: {integrity: sha512-Xdt2P1H4LKTO8ApPfnO1KmzYMFpp7D/EinoXzLYN/cHcBNrVCAkAtGUcXnHXrl/VGktureU6fkQrHSBE2URfoA==}
+  /@babel/traverse@7.21.2:
+    resolution: {integrity: sha512-ts5FFU/dSUPS13tv8XiEObDu9K+iagEKME9kAbaP7r0Y9KtZJZ+NGndDvWoRAYNpeWafbpFeki3q9QoMD6gxyw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
@@ -4154,8 +4154,8 @@ packages:
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.21.1
-      '@babel/types': 7.21.0
+      '@babel/parser': 7.21.2
+      '@babel/types': 7.21.2
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -4179,8 +4179,8 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
 
-  /@babel/types@7.21.0:
-    resolution: {integrity: sha512-uR7NWq2VNFnDi7EYqiRz2Jv/VQIu38tu64Zy8TX2nQFQ6etJ9V/Rr2msW8BS132mum2rL645qpDrLtAJtVpuow==}
+  /@babel/types@7.21.2:
+    resolution: {integrity: sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.19.4
@@ -7392,7 +7392,7 @@ packages:
       typescript: 4.9.5
       unfetch: 4.2.0
       util-deprecate: 1.0.2
-      webpack: 5.75.0(esbuild@0.14.54)
+      webpack: 5.75.0
 
   /@storybook/core-common@6.5.14(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5):
     resolution: {integrity: sha512-MrxhYXYrtN6z/+tydjPkCIwDQm5q8Jx+w4TPdLKBZu7vzfp6T3sT12Ym96j9MJ42CvE4vSDl/Njbw6C0D+yEVw==}


### PR DESCRIPTION
## Description

There are multiple problems with clipping to text:
1. it is only supported with vendor prefixed -webkit-background-clip
2. it doesn't work with CSS vars (not using them on canvas for this)


## Steps for reproduction

1. add heading
4. set background image src to some image
5. set color to transparent
6. set background-clip to text
7. Background image should be clipped to text

<img width="294" alt="Screenshot 2023-02-24 at 13 49 22" src="https://user-images.githubusercontent.com/52824/221194656-9e4591ed-5727-45f0-8560-eba35e278819.png">


## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
