### PR TITLE
Fix build props migration

### DIFF
--- a/packages/prisma-client/prisma/migrations/20230227180250_build_props_data/migration.ts
+++ b/packages/prisma-client/prisma/migrations/20230227180250_build_props_data/migration.ts
@@ -76,15 +76,7 @@ export default async () => {
         hasNext = builds.length === chunkSize;
 
         for (const build of builds) {
-          // deduplicate badly migrated data
-          const props = Array.from(
-            new Map(
-              (propsByBuildId.get(build.id) ?? []).map((item) => [
-                item.instanceId,
-                item,
-              ])
-            ).values()
-          );
+          const props = propsByBuildId.get(build.id) ?? [];
           build.props = JSON.stringify(props);
         }
         await Promise.all(


### PR DESCRIPTION
Bad copy paste. Results in collapsing props per instance. Didn't found while testing in UI because set only one prop on instances.

At least should not break prod anymore.

## Code Review

- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
