### PR TITLE
Set a meaningful default maxHeight 

### DIFF
--- a/packages/design-system/src/components/floating-panel-popover.tsx
+++ b/packages/design-system/src/components/floating-panel-popover.tsx
@@ -9,6 +9,7 @@ export const FloatingPanelPopover = Primitive.Root;
 const contentStyles = css(floatingPanelStyles, {
   minWidth: theme.spacing[28],
   maxWidth: "max-content",
+  maxHeight: "80vh",
 });
 
 export const FloatingPanelPopoverContent = React.forwardRef(


### PR DESCRIPTION
closes https://github.com/webstudio-is/webstudio-builder/issues/1158

to prevent panel taking more than screen height


## Steps for reproduction

1. upload lots of images
2. see they are scrollable in image manager when choosing source from properties or background image
<img width="546" alt="Screenshot 2023-03-01 at 15 11 04" src="https://user-images.githubusercontent.com/52824/222181464-38e70ced-c2d4-4d8c-b788-4428d5a35c11.png">
<img width="516" alt="Screenshot 2023-03-01 at 15 11 22" src="https://user-images.githubusercontent.com/52824/222181469-7d170a91-8597-4b7f-8c4e-a56114f0f0ef.png">


## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
