### PR TITLE
Scroll navigator into view when selecting instances on canvas/navigator

### DIFF
--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent, FormEvent } from "react";
+import { MouseEvent, FormEvent, useEffect } from "react";
 import { Suspense, lazy, useCallback, useMemo, useRef } from "react";
 import { useStore } from "@nanostores/react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
@@ -82,6 +82,18 @@ export const WebstudioComponentDev = ({
     return result;
   }, [instanceProps]);
 
+  const isSelected = selectedInstanceId === instanceId;
+
+  // Scroll the selected instance into view when selected from navigator.
+  useEffect(() => {
+    if (isSelected) {
+      instanceElementRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "nearest",
+      });
+    }
+  }, [isSelected]);
+
   const readonlyProps =
     instance.component === "Input" ? { readOnly: true } : undefined;
 
@@ -116,7 +128,7 @@ export const WebstudioComponentDev = ({
 
   const instanceElement = (
     <>
-      {selectedInstanceId === instance.id && (
+      {isSelected && (
         <SelectedInstanceConnector
           instanceElementRef={instanceElementRef}
           instance={instance}

--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -282,6 +282,16 @@ export const TreeItemBody = <Data extends { id: string }>({
   const isDragging = dropTargetItemId !== undefined;
   const isDropTarget = dropTargetItemId === itemData.id;
 
+  // Scroll the selected button into view when selected from canvas.
+  useEffect(() => {
+    if (isSelected && isDragging === false && isDropTarget === false) {
+      itemButtonRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "nearest",
+      });
+    }
+  }, [isSelected, isDragging, isDropTarget]);
+
   return (
     <ItemContainer
       onMouseEnter={onMouseEnter && (() => onMouseEnter(itemData))}


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio-builder/issues/1157


## Description

When selecting in navigator - scroll into view on canvas and vice-versa

## Steps for reproduction

1. insert lots of elements to make navigator and canvas scroll
2. click in navigator last and first - see canvas scrolling
3. same as 2 but for canvas

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview
- [ ] hi @rpominov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
