### PR TITLE
Migrate delete normalized instances

### DIFF
--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -69,9 +69,7 @@ export const patchInstancesMutable = (
   instances: Instances
 ) => {
   const oldInstancesIndex = createInstancesIndex(rootInstance);
-  const deletedInstanceIds = new Set<Instance["id"]>(instances.keys());
   for (const oldInstance of oldInstancesIndex.instancesById.values()) {
-    deletedInstanceIds.delete(oldInstance.id);
     const instance = instances.get(oldInstance.id);
     const convertedOldInstance: InstancesItem = {
       type: "instance",
@@ -91,9 +89,6 @@ export const patchInstancesMutable = (
       continue;
     }
     instances.set(oldInstance.id, convertedOldInstance);
-  }
-  for (const deletedId of deletedInstanceIds) {
-    instances.delete(deletedId);
   }
 };
 

--- a/apps/builder/app/shared/tree-utils.ts
+++ b/apps/builder/app/shared/tree-utils.ts
@@ -2,6 +2,8 @@ import { nanoid } from "nanoid";
 import produce from "immer";
 import type {
   Instance,
+  Instances,
+  InstancesItem,
   Prop,
   Props,
   StyleDecl,
@@ -215,6 +217,47 @@ export const findSubtree = (
     targetInstance: instancesById.get(targetInstanceId),
     subtreeIds,
   };
+};
+
+export const findParentInstance = (
+  instances: Instances,
+  instanceId: Instance["id"]
+) => {
+  for (const instance of instances.values()) {
+    for (const child of instance.children) {
+      if (child.type === "id" && child.value === instanceId) {
+        return instance;
+      }
+    }
+  }
+};
+
+const traverseInstancesMap = (
+  instances: Map<Instance["id"], InstancesItem>,
+  instanceId: Instance["id"],
+  callback: (instance: InstancesItem) => void
+) => {
+  const instance = instances.get(instanceId);
+  if (instance === undefined) {
+    return;
+  }
+  callback(instance);
+  for (const child of instance?.children) {
+    if (child.type === "id") {
+      traverseInstancesMap(instances, child.value, callback);
+    }
+  }
+};
+
+export const findTreeInstances = (
+  instances: Instances,
+  rootInstanceId: Instance["id"]
+) => {
+  const subtreeIds = new Set<Instance["id"]>();
+  traverseInstancesMap(instances, rootInstanceId, (instance) => {
+    subtreeIds.add(instance.id);
+  });
+  return subtreeIds;
 };
 
 export const cloneInstance = (targetInstance: Instance) => {

--- a/apps/builder/app/shared/tree-utils.ts
+++ b/apps/builder/app/shared/tree-utils.ts
@@ -242,7 +242,7 @@ const traverseInstancesMap = (
     return;
   }
   callback(instance);
-  for (const child of instance?.children) {
+  for (const child of instance.children) {
     if (child.type === "id") {
       traverseInstancesMap(instances, child.value, callback);
     }


### PR DESCRIPTION
We found a bug a bug after release. Any instances changes on the page erase instances of other pages.

Recently I migrated to normalized instances though didn't have time to migrate utilities and just added patchInstancesMutable utility to synchronize changes from denormalized rootInstance to normalized instances.

Though after merging instances of all pages into single list this synchronization started to clear instances not found in rootInstance.

To solve this I stopped clearing instances in patchInstancesMutable and migrate delete instances utility to mutating normalized instances directly.

## Steps for testing

1. create project
2. create new page
3. add box on this page
4. go to home page
5. see if body disappear (should not)

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
