### PR TITLE
Markdown bugs

### DIFF
--- a/apps/builder/app/shared/copy-paste/init-copy-paste.ts
+++ b/apps/builder/app/shared/copy-paste/init-copy-paste.ts
@@ -115,7 +115,7 @@ export const initCopyPaste = (options: Options) => {
       document.removeEventListener("cut", handleCut);
     }
     if (onPaste) {
-      document.removeEventListener("paste", handlePaste);
+      document.removeEventListener("paste", handlePaste, { capture: true });
     }
   };
 };

--- a/apps/builder/app/shared/copy-paste/init-copy-paste.ts
+++ b/apps/builder/app/shared/copy-paste/init-copy-paste.ts
@@ -1,5 +1,3 @@
-import { textEditingInstanceIdStore } from "../nano-states";
-
 const isValidClipboardEvent = (event: ClipboardEvent) => {
   const selection = document.getSelection();
   if (selection?.type === "Range") {
@@ -79,9 +77,6 @@ export const initCopyPaste = (options: Options) => {
   };
 
   const handlePaste = (event: ClipboardEvent) => {
-    if (textEditingInstanceIdStore.get()) {
-      return;
-    }
     if (
       onPaste === undefined ||
       event.clipboardData === null ||
@@ -107,7 +102,9 @@ export const initCopyPaste = (options: Options) => {
     document.addEventListener("cut", handleCut);
   }
   if (onPaste) {
-    document.addEventListener("paste", handlePaste);
+    // Capture is required so we get the element before content-editable removes it
+    // This way we can detect when we are inside content-editable and ignore the event
+    document.addEventListener("paste", handlePaste, { capture: true });
   }
 
   return () => {

--- a/apps/builder/app/shared/copy-paste/init-copy-paste.ts
+++ b/apps/builder/app/shared/copy-paste/init-copy-paste.ts
@@ -1,3 +1,5 @@
+import { textEditingInstanceIdStore } from "../nano-states";
+
 const isValidClipboardEvent = (event: ClipboardEvent) => {
   const selection = document.getSelection();
   if (selection?.type === "Range") {
@@ -77,6 +79,9 @@ export const initCopyPaste = (options: Options) => {
   };
 
   const handlePaste = (event: ClipboardEvent) => {
+    if (textEditingInstanceIdStore.get()) {
+      return;
+    }
     if (
       onPaste === undefined ||
       event.clipboardData === null ||

--- a/apps/builder/app/shared/copy-paste/plugin-markdown.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-markdown.test.ts
@@ -236,7 +236,7 @@ describe("Plugin Markdown", () => {
                     "value": "link",
                   },
                 ],
-                "component": "Link",
+                "component": "RichTextLink",
                 "id": "123",
                 "type": "instance",
               },

--- a/apps/builder/app/shared/copy-paste/plugin-markdown.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-markdown.ts
@@ -29,10 +29,13 @@ const astTypeComponentMap: Record<string, Instance["component"]> = {
   heading: "Heading",
   strong: "Bold",
   emphasis: "Italic",
-  link: "Link",
+  link: "RichTextLink",
+  // @todo image should not be rendered inside paragraph
+  // we need to either have RichTextImage or support Image inside RichText
   image: "Image",
   blockquote: "Blockquote",
   code: "Code",
+  // @todo same problem as with image
   inlineCode: "Code",
   list: "List",
   listItem: "ListItem",

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -423,9 +423,9 @@ const isScrollingContainer = atom<boolean>(false);
 export const useIsScrolling = () => useValue(isScrollingContainer);
 
 // We are editing the text of that instance in text editor.
-const textEditingInstanceIdContainer = atom<Instance["id"] | undefined>();
+export const textEditingInstanceIdStore = atom<Instance["id"] | undefined>();
 export const useTextEditingInstanceId = () =>
-  useValue(textEditingInstanceIdContainer);
+  useValue(textEditingInstanceIdStore);
 
 export type DragAndDropState = {
   isDragging: boolean;

--- a/packages/react-sdk/src/components/rich-text-link.tsx
+++ b/packages/react-sdk/src/components/rich-text-link.tsx
@@ -1,9 +1,7 @@
-import { forwardRef, type ElementRef, type ComponentProps } from "react";
+import { forwardRef } from "react";
 import { Link } from "./link";
 
-type Props = ComponentProps<typeof Link>;
-
-export const RichTextLink = forwardRef<ElementRef<"a">, Props>((props, ref) => (
+export const RichTextLink: typeof Link = forwardRef((props, ref) => (
   <Link {...props} ref={ref} />
 ));
 

--- a/packages/react-sdk/src/components/rich-text-link.ws.tsx
+++ b/packages/react-sdk/src/components/rich-text-link.ws.tsx
@@ -1,13 +1,14 @@
-import { Link2Icon } from "@webstudio-is/icons";
 import type { WsComponentMeta, WsComponentPropsMeta } from "./component-type";
 import { props } from "./__generated__/rich-text-link.props";
+import { meta as linkMeta, propsMeta as propsLinkMeta } from "./link.ws";
 
 export const meta: WsComponentMeta = {
+  ...linkMeta,
   type: "rich-text-child",
-  label: "Link",
-  Icon: Link2Icon,
+  children: [],
 };
 
 export const propsMeta: WsComponentPropsMeta = {
+  ...propsLinkMeta,
   props,
 };


### PR DESCRIPTION
## Description

1. Don't handle global paste even when inside content-editable (before that when you paste inside texteditable, it would insert an instance additionally outside)
2. Insert links in paragraphs as RichTextLink
3. Make sure rich text link has the same props as link



## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
