### PR TITLE
Pass branchName to publish endpoint

### DIFF
--- a/apps/builder/app/routes/rest/publish.ts
+++ b/apps/builder/app/routes/rest/publish.ts
@@ -28,6 +28,8 @@ export const action = async ({ request }: ActionArgs) => {
           builderApiOrigin: url.origin,
           projectId,
           projectName: domain,
+          // To support preview deployments
+          branchName: env.BRANCH_NAME,
         }),
       });
       const text = await response.text();


### PR DESCRIPTION
## Description

This would allow testing saas preview deployments for specific branch.
Any interaction with 3rd party services like here should contain branchName to allow preview testing of 3rd party services too.


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi anyone please accept

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
