### PR TITLE
Move initial data to builder

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { type Publish, usePublish, useSubscribe } from "~/shared/pubsub";
-import { type Pages, findPageByIdOrPath } from "@webstudio-is/project-build";
+import {
+  type Build,
+  type Pages,
+  findPageByIdOrPath,
+} from "@webstudio-is/project-build";
 import type { Project } from "@webstudio-is/project";
 import { theme, Box, type CSS, Flex, Grid } from "@webstudio-is/design-system";
 import type { AuthPermit } from "@webstudio-is/trpc-interface";
@@ -30,7 +34,13 @@ import {
   useIsPreviewMode,
   useSetAuthPermit,
   useSetAuthToken,
+  useSetBreakpoints,
+  useSetInstances,
   useSetIsPreviewMode,
+  useSetProps,
+  useSetStyles,
+  useSetStyleSources,
+  useSetStyleSourceSelections,
 } from "~/shared/nano-states";
 import { useClientSettings } from "./shared/client-settings";
 import { Navigator } from "./features/sidebar-left";
@@ -237,7 +247,7 @@ export type BuilderProps = {
   project: Project;
   pages: Pages;
   pageId: string;
-  buildId: string;
+  build: Build;
   buildOrigin: string;
   authReadToken: string;
   authToken?: string;
@@ -248,12 +258,19 @@ export const Builder = ({
   project,
   pages,
   pageId,
-  buildId,
+  build,
   buildOrigin,
   authReadToken,
   authToken,
   authPermit,
 }: BuilderProps) => {
+  useSetBreakpoints(build.breakpoints);
+  useSetProps(build.props);
+  useSetStyles(build.styles);
+  useSetStyleSources(build.styleSources);
+  useSetStyleSourceSelections(build.styleSourceSelections);
+  useSetInstances(build.instances);
+
   useSetAuthToken(authToken);
   useSetAuthPermit(authPermit);
   useSetProject(project);
@@ -262,7 +279,7 @@ export const Builder = ({
   const [publish, publishRef] = usePublish();
   useBuilderStore(publish);
   useSyncServer({
-    buildId,
+    buildId: build.id,
     projectId: project.id,
     authToken,
     authPermit,

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -1,6 +1,7 @@
 import { useMemo, Fragment, useEffect } from "react";
 import { computed } from "nanostores";
 import type { CanvasData } from "@webstudio-is/project";
+import type { Instance } from "@webstudio-is/project-build";
 import {
   createElementsTree,
   registerComponents,
@@ -23,12 +24,6 @@ import {
   propsIndexStore,
   assetsStore,
   useRootInstance,
-  useSetBreakpoints,
-  useSetInstances,
-  useSetProps,
-  useSetStyles,
-  useSetStyleSources,
-  useSetStyleSourceSelections,
   useSubscribeScrollState,
   useIsPreviewMode,
   useSetAssets,
@@ -49,17 +44,22 @@ const propsByInstanceIdStore = computed(
   (propsIndex) => propsIndex.propsByInstanceId
 );
 
+const temporaryRootInstance: Instance = {
+  type: "instance",
+  id: "temporaryRootInstance",
+  component: "Body",
+  children: [],
+};
+
 const useElementsTree = (getComponent: GetComponent) => {
   const [rootInstance] = useRootInstance();
 
   return useMemo(() => {
-    if (rootInstance === undefined) {
-      return;
-    }
-
     return createElementsTree({
       sandbox: true,
-      instance: rootInstance,
+      // fallback to temporary root instance to render scripts
+      // and receive real data from builder
+      instance: rootInstance ?? temporaryRootInstance,
       propsByInstanceIdStore,
       assetsStore,
       Component: WebstudioComponentDev,
@@ -96,12 +96,6 @@ export const Canvas = ({
 }: CanvasProps): JSX.Element | null => {
   const isBuilderReady = useSubscribeBuilderReady();
   useSetAssets(data.assets);
-  useSetBreakpoints(data.build.breakpoints);
-  useSetProps(data.build.props);
-  useSetStyles(data.build.styles);
-  useSetStyleSources(data.build.styleSources);
-  useSetStyleSourceSelections(data.build.styleSourceSelections);
-  useSetInstances(data.build.instances);
   useSetSelectedPage(data.page);
   setParams(data.params ?? null);
   useCanvasStore(publish);

--- a/apps/builder/app/routes/builder/$projectId.tsx
+++ b/apps/builder/app/routes/builder/$projectId.tsx
@@ -53,7 +53,7 @@ export const loader = async ({
     project,
     pages,
     pageId: pageIdParam || devBuild.pages.homePage.id,
-    buildId: devBuild.id,
+    build: devBuild,
     buildOrigin: getBuildOrigin(request),
     authReadToken,
     authToken,


### PR DESCRIPTION
Canvas no longer populate stores data. Builder load project build, populate stores and synchronize them into canvas.

This way we can simplify data flow, make builder responsible for both initial data and patches, do less work on canvas side.

This is also necessary to move pages management to client side.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
