### PR TITLE
Migrate text editor to normalized instances

### DIFF
--- a/apps/builder/app/canvas/features/text-editor/interop.test.ts
+++ b/apps/builder/app/canvas/features/text-editor/interop.test.ts
@@ -1,0 +1,209 @@
+import { test, expect } from "@jest/globals";
+import { createHeadlessEditor } from "@lexical/headless";
+import { LinkNode } from "@lexical/link";
+import type { Instance, InstancesItem } from "@webstudio-is/project-build";
+import { $convertToLexical, $convertToUpdates, Refs } from "./interop";
+
+const createInstance = (
+  id: Instance["id"],
+  component: string,
+  children: InstancesItem["children"]
+) => {
+  return {
+    type: "instance",
+    id,
+    component,
+    children,
+  };
+};
+
+const createInstancePair = (
+  id: Instance["id"],
+  component: string,
+  children: InstancesItem["children"]
+): [Instance["id"], InstancesItem] => {
+  return [
+    id,
+    {
+      type: "instance",
+      id,
+      component,
+      children,
+    },
+  ];
+};
+
+const instances = new Map([
+  createInstancePair("1", "Body", [
+    { type: "id", value: "2" },
+    { type: "id", value: "3" },
+  ]),
+  createInstancePair("2", "Box", []),
+  createInstancePair("3", "Box", [
+    { type: "text", value: "Hello" },
+    { type: "text", value: "\n" },
+    { type: "id", value: "4" },
+    { type: "text", value: "\n" },
+    { type: "id", value: "6" },
+    { type: "text", value: "\n" },
+    { type: "id", value: "7" },
+  ]),
+  createInstancePair("4", "Bold", [{ type: "id", value: "5" }]),
+  createInstancePair("5", "Italic", [{ type: "text", value: "world" }]),
+  createInstancePair("6", "Span", [{ type: "text", value: "and" }]),
+  createInstancePair("7", "RichTextLink", [
+    { type: "text", value: "other realms" },
+  ]),
+]);
+
+const expectedRefs = new Map([
+  ["4:bold", "4"],
+  ["4:italic", "5"],
+  ["6:span", "6"],
+  ["8", "7"],
+]);
+
+test("convert instances to lexical", async () => {
+  // console.dir(rootInstance, { depth: null });
+  const refs: Refs = new Map();
+  const editor = createHeadlessEditor({
+    nodes: [LinkNode],
+    onError: console.error,
+  });
+  await new Promise<void>((resolve) => {
+    editor.update(
+      () => {
+        $convertToLexical(instances, "3", refs);
+      },
+      { onUpdate: resolve }
+    );
+  });
+
+  expect(editor.getEditorState().toJSON()).toMatchInlineSnapshot(`
+    {
+      "root": {
+        "children": [
+          {
+            "children": [
+              {
+                "detail": 0,
+                "format": 0,
+                "mode": "normal",
+                "style": "",
+                "text": "Hello",
+                "type": "text",
+                "version": 1,
+              },
+              {
+                "type": "linebreak",
+                "version": 1,
+              },
+              {
+                "detail": 0,
+                "format": 3,
+                "mode": "normal",
+                "style": "",
+                "text": "world",
+                "type": "text",
+                "version": 1,
+              },
+              {
+                "type": "linebreak",
+                "version": 1,
+              },
+              {
+                "detail": 0,
+                "format": 0,
+                "mode": "normal",
+                "style": "--style-node-trigger:;",
+                "text": "and",
+                "type": "text",
+                "version": 1,
+              },
+              {
+                "type": "linebreak",
+                "version": 1,
+              },
+              {
+                "children": [
+                  {
+                    "detail": 0,
+                    "format": 0,
+                    "mode": "normal",
+                    "style": "",
+                    "text": "other realms",
+                    "type": "text",
+                    "version": 1,
+                  },
+                ],
+                "direction": null,
+                "format": "",
+                "indent": 0,
+                "rel": null,
+                "target": null,
+                "type": "link",
+                "url": "",
+                "version": 1,
+              },
+            ],
+            "direction": null,
+            "format": "",
+            "indent": 0,
+            "type": "paragraph",
+            "version": 1,
+          },
+        ],
+        "direction": null,
+        "format": "",
+        "indent": 0,
+        "type": "root",
+        "version": 1,
+      },
+    }
+  `);
+
+  expect(refs).toEqual(expectedRefs);
+});
+
+test("convert lexical to instances updates", async () => {
+  // console.dir(rootInstance, { depth: null });
+  const refs: Refs = new Map();
+  const editor = createHeadlessEditor({
+    nodes: [LinkNode],
+    onError: console.error,
+  });
+  await new Promise<void>((resolve) => {
+    editor.update(
+      () => {
+        $convertToLexical(instances, "3", refs);
+      },
+      { onUpdate: resolve }
+    );
+  });
+  const treeRootInstance = instances.get("3");
+  if (treeRootInstance === undefined) {
+    throw Error("Tree root instance should be in test data");
+  }
+
+  const updates = editor.getEditorState().read(() => {
+    return $convertToUpdates(treeRootInstance, refs);
+  });
+
+  expect(updates).toEqual([
+    createInstance("3", "Box", [
+      { type: "text", value: "Hello" },
+      { type: "text", value: "\n" },
+      { type: "id", value: "4" },
+      { type: "text", value: "\n" },
+      { type: "id", value: "6" },
+      { type: "text", value: "\n" },
+      { type: "id", value: "7" },
+    ]),
+    createInstance("4", "Bold", [{ type: "id", value: "5" }]),
+    createInstance("5", "Italic", [{ type: "text", value: "world" }]),
+    createInstance("6", "Span", [{ type: "text", value: "and" }]),
+    createInstance("7", "RichTextLink", [
+      { type: "text", value: "other realms" },
+    ]),
+  ]);
+});

--- a/apps/builder/app/canvas/features/text-editor/interop.test.ts
+++ b/apps/builder/app/canvas/features/text-editor/interop.test.ts
@@ -64,11 +64,9 @@ const expectedRefs = new Map([
 ]);
 
 test("convert instances to lexical", async () => {
-  // console.dir(rootInstance, { depth: null });
   const refs: Refs = new Map();
   const editor = createHeadlessEditor({
     nodes: [LinkNode],
-    onError: console.error,
   });
   await new Promise<void>((resolve) => {
     editor.update(
@@ -166,11 +164,9 @@ test("convert instances to lexical", async () => {
 });
 
 test("convert lexical to instances updates", async () => {
-  // console.dir(rootInstance, { depth: null });
   const refs: Refs = new Map();
   const editor = createHeadlessEditor({
     nodes: [LinkNode],
-    onError: console.error,
   });
   await new Promise<void>((resolve) => {
     editor.update(

--- a/apps/builder/app/canvas/features/text-editor/text-editor.stories.tsx
+++ b/apps/builder/app/canvas/features/text-editor/text-editor.stories.tsx
@@ -4,10 +4,14 @@ import type { ComponentStory, ComponentMeta } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { Box } from "@webstudio-is/design-system";
 import { useSubscribe, publish } from "~/shared/pubsub";
-import { utils } from "@webstudio-is/project";
 import type { TextToolbarState } from "~/builder/shared/nano-states";
 import { TextEditor } from "./text-editor";
 import { theme } from "@webstudio-is/design-system";
+import type {
+  Instance,
+  Instances,
+  InstancesItem,
+} from "@webstudio-is/project-build";
 
 export default {
   component: TextEditor,
@@ -22,6 +26,37 @@ type Format =
   | "link"
   | "span"
   | "clear";
+
+const createInstancePair = (
+  id: Instance["id"],
+  component: string,
+  children: InstancesItem["children"]
+): [Instance["id"], InstancesItem] => {
+  return [
+    id,
+    {
+      type: "instance",
+      id,
+      component,
+      children,
+    },
+  ];
+};
+
+const instances: Instances = new Map([
+  createInstancePair("1", "TextBlock", [
+    { type: "text", value: "Paragraph you can edit " },
+    { type: "id", value: "2" },
+    { type: "id", value: "3" },
+    { type: "id", value: "5" },
+  ]),
+  createInstancePair("2", "Bold", [{ type: "text", value: "very bold text " }]),
+  createInstancePair("3", "Bold", [{ type: "id", value: "4" }]),
+  createInstancePair("4", "Italic", [
+    { type: "text", value: "with small italic" },
+  ]),
+  createInstancePair("5", "Bold", [{ type: "text", value: " subtext" }]),
+]);
 
 export const Basic: ComponentStory<typeof TextEditor> = ({ onChange }) => {
   const [state, setState] = useState<null | TextToolbarState>(null);
@@ -41,7 +76,10 @@ export const Basic: ComponentStory<typeof TextEditor> = ({ onChange }) => {
       <button
         disabled={state == null}
         style={{ fontWeight: state?.isBold ? "bold" : "normal" }}
-        onClick={() => setFormat("bold")}
+        onClick={(event) => {
+          event.preventDefault();
+          setFormat("bold");
+        }}
       >
         Bold
       </button>
@@ -97,29 +135,8 @@ export const Basic: ComponentStory<typeof TextEditor> = ({ onChange }) => {
         }}
       >
         <TextEditor
-          instance={utils.tree.createInstance({
-            component: "TextBlock",
-            children: [
-              { type: "text", value: "Paragraph you can edit " },
-              utils.tree.createInstance({
-                component: "Bold",
-                children: [{ type: "text", value: "very bold text " }],
-              }),
-              utils.tree.createInstance({
-                component: "Bold",
-                children: [
-                  utils.tree.createInstance({
-                    component: "Italic",
-                    children: [{ type: "text", value: "with small italic" }],
-                  }),
-                ],
-              }),
-              utils.tree.createInstance({
-                component: "Bold",
-                children: [{ type: "text", value: " subtext" }],
-              }),
-            ],
-          })}
+          rootInstanceId={"1"}
+          instances={instances}
           contentEditable={<ContentEditable />}
           onChange={onChange}
           onSelectInstance={(instanceId) =>

--- a/apps/builder/app/canvas/features/text-editor/text-editor.tsx
+++ b/apps/builder/app/canvas/features/text-editor/text-editor.tsx
@@ -19,7 +19,11 @@ import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
 import { nanoid } from "nanoid";
 import { createCssEngine } from "@webstudio-is/css-engine";
-import type { Instance } from "@webstudio-is/project-build";
+import type {
+  Instance,
+  Instances,
+  InstancesList,
+} from "@webstudio-is/project-build";
 import { idAttribute } from "@webstudio-is/react-sdk";
 import { ToolbarConnectorPlugin } from "./toolbar-connector";
 import { type Refs, $convertToLexical, $convertToUpdates } from "./interop";
@@ -113,14 +117,16 @@ const onError = (error: Error) => {
 };
 
 type TextEditorProps = {
-  instance: Instance;
+  rootInstanceId: Instance["id"];
+  instances: Instances;
   contentEditable: JSX.Element;
-  onChange: (updates: Instance["children"]) => void;
+  onChange: (instancesList: InstancesList) => void;
   onSelectInstance: (instanceId: string) => void;
 };
 
 export const TextEditor = ({
-  instance,
+  rootInstanceId,
+  instances,
   contentEditable,
   onChange,
   onSelectInstance,
@@ -160,7 +166,7 @@ export const TextEditor = ({
       // text editor is unmounted when change properties in side panel
       // so assume new nodes don't need to preserve instance id
       // and store only initial references
-      $convertToLexical(instance, refs);
+      $convertToLexical(instances, rootInstanceId, refs);
     },
     nodes: [LinkNode],
     onError,
@@ -190,7 +196,10 @@ export const TextEditor = ({
         ignoreSelectionChange={true}
         onChange={(editorState) => {
           editorState.read(() => {
-            onChange($convertToUpdates(refs));
+            const treeRootInstance = instances.get(rootInstanceId);
+            if (treeRootInstance) {
+              onChange($convertToUpdates(treeRootInstance, refs));
+            }
           });
         }}
       />

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -12,16 +12,14 @@ import {
 import type { GetComponent } from "@webstudio-is/react-sdk";
 import {
   instancesStore,
-  patchInstancesMutable,
-  rootInstanceContainer,
   selectedInstanceIdStore,
   useInstanceProps,
   useInstanceStyles,
   useTextEditingInstanceId,
 } from "~/shared/nano-states";
-import { createInstancesIndex } from "~/shared/tree-utils";
 import { useCssRules } from "~/canvas/shared/styles";
 import { SelectedInstanceConnector } from "./selected-instance-connector";
+import { findTreeInstances } from "~/shared/tree-utils";
 
 const TextEditor = lazy(() => import("../text-editor"));
 
@@ -63,6 +61,7 @@ export const WebstudioComponentDev = ({
   const instanceElementRef = useRef<HTMLElement>();
   const instanceStyles = useInstanceStyles(instanceId);
   useCssRules({ instanceId: instance.id, instanceStyles });
+  const instances = useStore(instancesStore);
 
   const [editingInstanceId, setTextEditingInstanceId] =
     useTextEditingInstanceId();
@@ -151,7 +150,8 @@ export const WebstudioComponentDev = ({
   return (
     <Suspense fallback={instanceElement}>
       <TextEditor
-        instance={instance}
+        rootInstanceId={instance.id}
+        instances={instances}
         contentEditable={
           <ContentEditable
             {...props}
@@ -159,15 +159,17 @@ export const WebstudioComponentDev = ({
             Component={Component}
           />
         }
-        onChange={(updates) => {
-          const rootInstance = rootInstanceContainer.get();
+        onChange={(instancesList) => {
           store.createTransaction([instancesStore], (instances) => {
-            const { instancesById } = createInstancesIndex(rootInstance);
-            const instance = instancesById.get(instanceId);
-            if (instance) {
-              instance.children = updates;
+            const deletedTreeIds = findTreeInstances(instances, instance.id);
+            for (const updatedInstance of instancesList) {
+              instances.set(updatedInstance.id, updatedInstance);
+              // exclude reused instances
+              deletedTreeIds.delete(updatedInstance.id);
             }
-            patchInstancesMutable(rootInstance, instances);
+            for (const instanceId of deletedTreeIds) {
+              instances.delete(instanceId);
+            }
           });
         }}
         onSelectInstance={(instanceId) => {

--- a/apps/builder/jest.config.js
+++ b/apps/builder/jest.config.js
@@ -7,5 +7,14 @@ const baseConfig = require("@webstudio-is/jest-config");
 module.exports = {
   ...baseConfig,
   testMatch: ["<rootDir>/app/**/*.test.ts"],
-  moduleNameMapper: { "^~/(.*)$": "<rootDir>/app/$1" },
+  moduleNameMapper: {
+    "^~/(.*)$": "<rootDir>/app/$1",
+    "^lexical$": "lexical/Lexical.dev.js",
+    "^@lexical/headless$": "@lexical/headless/LexicalHeadless.dev.js",
+    "^@lexical/utils$": "@lexical/utils/LexicalUtils.dev.js",
+    "^@lexical/selection$": "@lexical/selection/LexicalSelection.dev.js",
+    "^@lexical/link$": "@lexical/link/LexicalLink.dev.js",
+    "^@lexical/react/LexicalComposerContext$":
+      "@lexical/react/LexicalComposerContext.dev.js",
+  },
 };

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -22,6 +22,7 @@
     "@fontsource/inter": "^4.5.15",
     "@fontsource/manrope": "^4.5.13",
     "@fontsource/roboto-mono": "^4.5.10",
+    "@lexical/headless": "^0.6.0",
     "@lexical/link": "^0.6.0",
     "@lexical/react": "^0.6.0",
     "@lexical/selection": "^0.6.0",

--- a/packages/asset-uploader/package.json
+++ b/packages/asset-uploader/package.json
@@ -37,7 +37,10 @@
     "zod": "^3.19.1"
   },
   "exports": {
-    ".": "./lib/index.js",
+    ".": {
+      "import": "./lib/index.js",
+      "require": "./lib/cjs/index.cjs"
+    },
     "./server": "./server.js"
   },
   "types": "src/index.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@fontsource/roboto-mono':
         specifier: ^4.5.10
         version: 4.5.10
+      '@lexical/headless':
+        specifier: ^0.6.0
+        version: 0.6.0(lexical@0.6.0)
       '@lexical/link':
         specifier: ^0.6.0
         version: 0.6.0(lexical@0.6.0)
@@ -5712,6 +5715,14 @@ packages:
       lexical: 0.6.0
     dependencies:
       '@lexical/utils': 0.6.0(lexical@0.6.0)
+      lexical: 0.6.0
+    dev: false
+
+  /@lexical/headless@0.6.0(lexical@0.6.0):
+    resolution: {integrity: sha512-d8JH0voJ9R771Rk+pRrzyDpHEvyDY0HYnGz6k8AHib1Dqq0u8UVfQzmDi3rwGrFmAZaxBNYnOh9DHdc9AAtYow==}
+    peerDependencies:
+      lexical: 0.6.0
+    dependencies:
       lexical: 0.6.0
     dev: false
 


### PR DESCRIPTION
Text editor relied on legacy denormalized tree which on updates may lead to orphan instances. Here migrated to normalized instances and considered deleting instances. Added tests for lexical conversions.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
