### PR TITLE
Paste markdown as normalized instances

### DIFF
--- a/apps/builder/app/shared/copy-paste/plugin-markdown.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-markdown.test.ts
@@ -1,25 +1,19 @@
 import { describe, expect } from "@jest/globals";
-import { Instance, Prop } from "@webstudio-is/project-build";
+import { InstancesItem, Prop } from "@webstudio-is/project-build";
 import { parse } from "./plugin-markdown";
 
-const parseInstanceData = (data?: {
-  children: Instance["children"];
-  props: Array<Prop>;
-}) => {
+const parseInstanceData = (data?: ReturnType<typeof parse>) => {
   if (data === undefined) {
     return;
   }
-  const { children, props } = data;
-  for (const child of children) {
-    if (child.type === "instance") {
-      Instance.parse(child);
-      parseInstanceData({ children: child.children, props });
-    }
+  const { rootIds, instances, props } = data;
+  for (const instance of instances) {
+    InstancesItem.parse(instance);
   }
   for (const prop of props) {
     Prop.parse(prop);
   }
-  return { children, props };
+  return { rootIds, instances, props };
 };
 
 const options = { generateId: () => "123" };
@@ -28,7 +22,7 @@ describe("Plugin Markdown", () => {
   test("paragraph", () => {
     expect(parseInstanceData(parse("xyz", options))).toMatchInlineSnapshot(`
       {
-        "children": [
+        "instances": [
           {
             "children": [
               {
@@ -42,6 +36,9 @@ describe("Plugin Markdown", () => {
           },
         ],
         "props": [],
+        "rootIds": [
+          "123",
+        ],
       }
     `);
   });
@@ -50,7 +47,7 @@ describe("Plugin Markdown", () => {
     expect(parseInstanceData(parse("# heading", options)))
       .toMatchInlineSnapshot(`
       {
-        "children": [
+        "instances": [
           {
             "children": [
               {
@@ -72,6 +69,9 @@ describe("Plugin Markdown", () => {
             "value": "h1",
           },
         ],
+        "rootIds": [
+          "123",
+        ],
       }
     `);
   });
@@ -80,7 +80,7 @@ describe("Plugin Markdown", () => {
     expect(parseInstanceData(parse("###### heading", options)))
       .toMatchInlineSnapshot(`
       {
-        "children": [
+        "instances": [
           {
             "children": [
               {
@@ -102,6 +102,9 @@ describe("Plugin Markdown", () => {
             "value": "h6",
           },
         ],
+        "rootIds": [
+          "123",
+        ],
       }
     `);
   });
@@ -110,19 +113,23 @@ describe("Plugin Markdown", () => {
     expect(parseInstanceData(parse("__bold__", options)))
       .toMatchInlineSnapshot(`
       {
-        "children": [
+        "instances": [
           {
             "children": [
               {
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "bold",
-                  },
-                ],
-                "component": "Bold",
-                "id": "123",
-                "type": "instance",
+                "type": "text",
+                "value": "bold",
+              },
+            ],
+            "component": "Bold",
+            "id": "123",
+            "type": "instance",
+          },
+          {
+            "children": [
+              {
+                "type": "id",
+                "value": "123",
               },
             ],
             "component": "Paragraph",
@@ -131,6 +138,9 @@ describe("Plugin Markdown", () => {
           },
         ],
         "props": [],
+        "rootIds": [
+          "123",
+        ],
       }
     `);
   });
@@ -139,19 +149,23 @@ describe("Plugin Markdown", () => {
     expect(parseInstanceData(parse("**bold**", options)))
       .toMatchInlineSnapshot(`
       {
-        "children": [
+        "instances": [
           {
             "children": [
               {
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "bold",
-                  },
-                ],
-                "component": "Bold",
-                "id": "123",
-                "type": "instance",
+                "type": "text",
+                "value": "bold",
+              },
+            ],
+            "component": "Bold",
+            "id": "123",
+            "type": "instance",
+          },
+          {
+            "children": [
+              {
+                "type": "id",
+                "value": "123",
               },
             ],
             "component": "Paragraph",
@@ -160,6 +174,9 @@ describe("Plugin Markdown", () => {
           },
         ],
         "props": [],
+        "rootIds": [
+          "123",
+        ],
       }
     `);
   });
@@ -168,19 +185,23 @@ describe("Plugin Markdown", () => {
     expect(parseInstanceData(parse("_italic_", options)))
       .toMatchInlineSnapshot(`
       {
-        "children": [
+        "instances": [
           {
             "children": [
               {
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "italic",
-                  },
-                ],
-                "component": "Italic",
-                "id": "123",
-                "type": "instance",
+                "type": "text",
+                "value": "italic",
+              },
+            ],
+            "component": "Italic",
+            "id": "123",
+            "type": "instance",
+          },
+          {
+            "children": [
+              {
+                "type": "id",
+                "value": "123",
               },
             ],
             "component": "Paragraph",
@@ -189,6 +210,9 @@ describe("Plugin Markdown", () => {
           },
         ],
         "props": [],
+        "rootIds": [
+          "123",
+        ],
       }
     `);
   });
@@ -197,19 +221,23 @@ describe("Plugin Markdown", () => {
     expect(parseInstanceData(parse("*italic*", options)))
       .toMatchInlineSnapshot(`
       {
-        "children": [
+        "instances": [
           {
             "children": [
               {
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "italic",
-                  },
-                ],
-                "component": "Italic",
-                "id": "123",
-                "type": "instance",
+                "type": "text",
+                "value": "italic",
+              },
+            ],
+            "component": "Italic",
+            "id": "123",
+            "type": "instance",
+          },
+          {
+            "children": [
+              {
+                "type": "id",
+                "value": "123",
               },
             ],
             "component": "Paragraph",
@@ -218,6 +246,9 @@ describe("Plugin Markdown", () => {
           },
         ],
         "props": [],
+        "rootIds": [
+          "123",
+        ],
       }
     `);
   });
@@ -226,19 +257,23 @@ describe("Plugin Markdown", () => {
     expect(parseInstanceData(parse('[link](/uri "Title")', options)))
       .toMatchInlineSnapshot(`
       {
-        "children": [
+        "instances": [
           {
             "children": [
               {
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "link",
-                  },
-                ],
-                "component": "RichTextLink",
-                "id": "123",
-                "type": "instance",
+                "type": "text",
+                "value": "link",
+              },
+            ],
+            "component": "RichTextLink",
+            "id": "123",
+            "type": "instance",
+          },
+          {
+            "children": [
+              {
+                "type": "id",
+                "value": "123",
               },
             ],
             "component": "Paragraph",
@@ -262,6 +297,9 @@ describe("Plugin Markdown", () => {
             "value": "Title",
           },
         ],
+        "rootIds": [
+          "123",
+        ],
       }
     `);
   });
@@ -270,14 +308,18 @@ describe("Plugin Markdown", () => {
     expect(parseInstanceData(parse('![foo](/url "title")', options)))
       .toMatchInlineSnapshot(`
       {
-        "children": [
+        "instances": [
+          {
+            "children": [],
+            "component": "Image",
+            "id": "123",
+            "type": "instance",
+          },
           {
             "children": [
               {
-                "children": [],
-                "component": "Image",
-                "id": "123",
-                "type": "instance",
+                "type": "id",
+                "value": "123",
               },
             ],
             "component": "Paragraph",
@@ -308,6 +350,9 @@ describe("Plugin Markdown", () => {
             "value": "foo",
           },
         ],
+        "rootIds": [
+          "123",
+        ],
       }
     `);
   });
@@ -323,7 +368,7 @@ describe("Plugin Markdown", () => {
       )
     ).toMatchInlineSnapshot(`
       {
-        "children": [
+        "instances": [
           {
             "children": [
               {
@@ -341,6 +386,9 @@ describe("Plugin Markdown", () => {
           },
         ],
         "props": [],
+        "rootIds": [
+          "123",
+        ],
       }
     `);
   });
@@ -356,7 +404,7 @@ describe("Plugin Markdown", () => {
       )
     ).toMatchInlineSnapshot(`
       {
-        "children": [
+        "instances": [
           {
             "children": [
               {
@@ -371,6 +419,9 @@ describe("Plugin Markdown", () => {
           },
         ],
         "props": [],
+        "rootIds": [
+          "123",
+        ],
       }
     `);
   });
@@ -378,19 +429,23 @@ describe("Plugin Markdown", () => {
   test("blockquote", () => {
     expect(parseInstanceData(parse("> bar", options))).toMatchInlineSnapshot(`
       {
-        "children": [
+        "instances": [
           {
             "children": [
               {
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "bar",
-                  },
-                ],
-                "component": "Paragraph",
-                "id": "123",
-                "type": "instance",
+                "type": "text",
+                "value": "bar",
+              },
+            ],
+            "component": "Paragraph",
+            "id": "123",
+            "type": "instance",
+          },
+          {
+            "children": [
+              {
+                "type": "id",
+                "value": "123",
               },
             ],
             "component": "Blockquote",
@@ -399,6 +454,9 @@ describe("Plugin Markdown", () => {
           },
         ],
         "props": [],
+        "rootIds": [
+          "123",
+        ],
       }
     `);
   });
@@ -406,19 +464,23 @@ describe("Plugin Markdown", () => {
   test("inline code", () => {
     expect(parseInstanceData(parse("`foo`", options))).toMatchInlineSnapshot(`
       {
-        "children": [
+        "instances": [
           {
             "children": [
               {
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "foo",
-                  },
-                ],
-                "component": "Code",
-                "id": "123",
-                "type": "instance",
+                "type": "text",
+                "value": "foo",
+              },
+            ],
+            "component": "Code",
+            "id": "123",
+            "type": "instance",
+          },
+          {
+            "children": [
+              {
+                "type": "id",
+                "value": "123",
               },
             ],
             "component": "Paragraph",
@@ -435,6 +497,9 @@ describe("Plugin Markdown", () => {
             "value": true,
           },
         ],
+        "rootIds": [
+          "123",
+        ],
       }
     `);
   });
@@ -443,7 +508,7 @@ describe("Plugin Markdown", () => {
     expect(parseInstanceData(parse("```js meta\nfoo\n```", options)))
       .toMatchInlineSnapshot(`
       {
-        "children": [
+        "instances": [
           {
             "children": [
               {
@@ -479,6 +544,9 @@ describe("Plugin Markdown", () => {
             "value": "meta",
           },
         ],
+        "rootIds": [
+          "123",
+        ],
       }
     `);
   });
@@ -486,26 +554,34 @@ describe("Plugin Markdown", () => {
   test("list unordered", () => {
     expect(parseInstanceData(parse("- one", options))).toMatchInlineSnapshot(`
       {
-        "children": [
+        "instances": [
           {
             "children": [
               {
-                "children": [
-                  {
-                    "children": [
-                      {
-                        "type": "text",
-                        "value": "one",
-                      },
-                    ],
-                    "component": "Paragraph",
-                    "id": "123",
-                    "type": "instance",
-                  },
-                ],
-                "component": "ListItem",
-                "id": "123",
-                "type": "instance",
+                "type": "text",
+                "value": "one",
+              },
+            ],
+            "component": "Paragraph",
+            "id": "123",
+            "type": "instance",
+          },
+          {
+            "children": [
+              {
+                "type": "id",
+                "value": "123",
+              },
+            ],
+            "component": "ListItem",
+            "id": "123",
+            "type": "instance",
+          },
+          {
+            "children": [
+              {
+                "type": "id",
+                "value": "123",
               },
             ],
             "component": "List",
@@ -522,6 +598,9 @@ describe("Plugin Markdown", () => {
             "value": false,
           },
         ],
+        "rootIds": [
+          "123",
+        ],
       }
     `);
   });
@@ -529,26 +608,34 @@ describe("Plugin Markdown", () => {
   test("list ordered", () => {
     expect(parseInstanceData(parse("3. one", options))).toMatchInlineSnapshot(`
       {
-        "children": [
+        "instances": [
           {
             "children": [
               {
-                "children": [
-                  {
-                    "children": [
-                      {
-                        "type": "text",
-                        "value": "one",
-                      },
-                    ],
-                    "component": "Paragraph",
-                    "id": "123",
-                    "type": "instance",
-                  },
-                ],
-                "component": "ListItem",
-                "id": "123",
-                "type": "instance",
+                "type": "text",
+                "value": "one",
+              },
+            ],
+            "component": "Paragraph",
+            "id": "123",
+            "type": "instance",
+          },
+          {
+            "children": [
+              {
+                "type": "id",
+                "value": "123",
+              },
+            ],
+            "component": "ListItem",
+            "id": "123",
+            "type": "instance",
+          },
+          {
+            "children": [
+              {
+                "type": "id",
+                "value": "123",
               },
             ],
             "component": "List",
@@ -572,6 +659,9 @@ describe("Plugin Markdown", () => {
             "value": 3,
           },
         ],
+        "rootIds": [
+          "123",
+        ],
       }
     `);
   });
@@ -579,7 +669,7 @@ describe("Plugin Markdown", () => {
   test("thematic break | separator", () => {
     expect(parseInstanceData(parse("---", options))).toMatchInlineSnapshot(`
       {
-        "children": [
+        "instances": [
           {
             "children": [],
             "component": "Separator",
@@ -588,6 +678,9 @@ describe("Plugin Markdown", () => {
           },
         ],
         "props": [],
+        "rootIds": [
+          "123",
+        ],
       }
     `);
   });

--- a/apps/builder/app/shared/tree-utils.test.ts
+++ b/apps/builder/app/shared/tree-utils.test.ts
@@ -236,6 +236,7 @@ test("insert instances tree into target", () => {
       ]),
       createInstancesItem("inserted2", "Box", []),
     ],
+    ["inserted1"],
     {
       parentId: "box1",
       position: 1,
@@ -266,6 +267,7 @@ test("insert instances tree into target", () => {
       ]),
       createInstancesItem("inserted4", "Box", []),
     ],
+    ["inserted3"],
     {
       parentId: "box1",
       position: "end",

--- a/apps/builder/app/shared/tree-utils.ts
+++ b/apps/builder/app/shared/tree-utils.ts
@@ -282,6 +282,7 @@ export const findSubtreeLocalStyleSources = (
 export const insertInstancesMutable = (
   instances: Instances,
   insertedInstances: InstancesItem[],
+  rootIds: Instance["id"][],
   dropTarget: undefined | DroppableTarget
 ) => {
   if (dropTarget === undefined) {
@@ -304,14 +305,16 @@ export const insertInstancesMutable = (
   }
 
   const { position } = dropTarget;
-  const dropTargetChild: InstancesItem["children"][number] = {
-    type: "id",
-    value: treeRootInstanceId,
-  };
+  const dropTargetChildren: InstancesItem["children"] = rootIds.map(
+    (instanceId) => ({
+      type: "id",
+      value: instanceId,
+    })
+  );
   if (position === "end") {
-    parentInstance.children.push(dropTargetChild);
+    parentInstance.children.push(...dropTargetChildren);
   } else {
-    parentInstance.children.splice(position, 0, dropTargetChild);
+    parentInstance.children.splice(position, 0, ...dropTargetChildren);
   }
 };
 
@@ -343,7 +346,13 @@ export const insertInstancesCopyMutable = (
     });
   }
 
-  insertInstancesMutable(instances, copiedInstancesWithNewIds, dropTarget);
+  insertInstancesMutable(
+    instances,
+    copiedInstancesWithNewIds,
+    // consider the first instance as the root
+    [copiedInstancesWithNewIds[0].id],
+    dropTarget
+  );
 
   return copiedInstanceIds;
 };


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/696

Refactored markdown parser to produce normalized instances and added multiple roots support for insert utility.

Note: can be reviewed with hidden spaces

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
