### PR TITLE
Instance name bugs

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
@@ -17,7 +17,7 @@ export const SettingsPanel = () => {
         <Label>Instance Name</Label>
         <TextField
           /* Key is required, otherwise when label is undefined, previous value stayed */
-          key={selectedInstance.label}
+          key={selectedInstance.id}
           onBlur={handleBlur}
           onKeyDown={handleKeyDown}
           placeholder={label}

--- a/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
@@ -16,6 +16,8 @@ export const SettingsPanel = () => {
       <Flex gap="1" direction="column" grow>
         <Label>Instance Name</Label>
         <TextField
+          /* Key is required, otherwise when label is undefined, previous value stayed */
+          key={selectedInstance.label}
           onBlur={handleBlur}
           onKeyDown={handleKeyDown}
           placeholder={label}

--- a/apps/builder/app/builder/features/settings-panel/use-settings-logic.ts
+++ b/apps/builder/app/builder/features/settings-panel/use-settings-logic.ts
@@ -7,28 +7,47 @@ import {
 } from "react";
 import { instancesStore, selectedInstanceStore } from "~/shared/nano-states";
 
-type SettingUpdate = { label?: string };
+type Setting = "label";
+type Value = string;
+
+type Operation =
+  | {
+      operation: "delete";
+      property: Setting;
+    }
+  | {
+      operation: "set";
+      property: Setting;
+      value: Value;
+    };
 
 export const useSettingsLogic = () => {
-  const changes = useRef<SettingUpdate>({});
+  const updates = useRef<Array<Operation>>([]);
 
-  const setLabel = (value: SettingUpdate[keyof SettingUpdate]) => {
-    // Empty string should be replaced with `undefined` so that we can render default label
-    changes.current.label = value || undefined;
+  const setLabel = (value?: Value) => {
+    if (value === undefined) {
+      updates.current.push({ operation: "delete", property: "label" });
+      return;
+    }
+    updates.current.push({ operation: "set", property: "label", value });
   };
 
   const updateLabel = useCallback(() => {
     const selectedInstance = selectedInstanceStore.get();
-    if (
-      selectedInstance === undefined ||
-      changes.current.label === selectedInstance.label
-    ) {
+    if (selectedInstance === undefined) {
       return;
     }
     store.createTransaction([instancesStore], (instances) => {
       const instance = instances.get(selectedInstance.id);
-      if (instance !== undefined) {
-        instance.label = changes.current.label;
+      if (instance === undefined) {
+        return;
+      }
+      for (const update of updates.current) {
+        if (update.operation === "delete") {
+          delete instance.label;
+          continue;
+        }
+        instance.label = update.value;
       }
     });
   }, []);

--- a/apps/builder/app/builder/features/settings-panel/use-settings-logic.ts
+++ b/apps/builder/app/builder/features/settings-panel/use-settings-logic.ts
@@ -19,7 +19,10 @@ export const useSettingsLogic = () => {
 
   const updateLabel = useCallback(() => {
     const selectedInstance = selectedInstanceStore.get();
-    if (selectedInstance === undefined) {
+    if (
+      selectedInstance === undefined ||
+      changes.current.label === selectedInstance.label
+    ) {
       return;
     }
     store.createTransaction([instancesStore], (instances) => {


### PR DESCRIPTION
## Description

1. Don't set the label when id didn't change
2. workaround stale defaultValue in TextField

## Steps for reproduction

1. change instance name
2. select a different instance (see previous instance name is still in the text field)
3. select an different instance or different tab - instance name from previous instance went into a the currently selected instance

4. expect xyz

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
