### PR TITLE
Allow button children and inner text over properties

### DIFF
--- a/packages/react-sdk/src/components/__generated__/button.props.ts
+++ b/packages/react-sdk/src/components/__generated__/button.props.ts
@@ -452,4 +452,10 @@ export const props: Record<string, PropMeta> = {
     control: "text",
     type: "string",
   },
+  innerText: {
+    required: false,
+    control: "text",
+    type: "string",
+    defaultValue: "Edit Inner Text in Properties",
+  },
 };

--- a/packages/react-sdk/src/components/button.stories.tsx
+++ b/packages/react-sdk/src/components/button.stories.tsx
@@ -11,7 +11,3 @@ const Template: ComponentStory<typeof ButtonPrimitive> = (args) => (
 );
 
 export const Button = Template.bind({});
-
-Button.args = {
-  children: "Test",
-};

--- a/packages/react-sdk/src/components/button.tsx
+++ b/packages/react-sdk/src/components/button.tsx
@@ -2,13 +2,22 @@ import { forwardRef, type ElementRef, type ComponentProps } from "react";
 
 const defaultTag = "button";
 
-type ButtonProps = ComponentProps<typeof defaultTag>;
+type ButtonProps = ComponentProps<typeof defaultTag> & { innerText?: string };
 
 export const Button = forwardRef<ElementRef<typeof defaultTag>, ButtonProps>(
-  (props, ref) => <button {...props} ref={ref} />
+  (
+    {
+      type = "submit",
+      innerText = "Edit Inner Text in Properties",
+      children,
+      ...props
+    },
+    ref
+  ) => (
+    <button type={type} {...props} ref={ref}>
+      {children ? children : innerText}
+    </button>
+  )
 );
 
-Button.defaultProps = {
-  type: "submit", // Match the platform default
-};
 Button.displayName = "Button";

--- a/packages/react-sdk/src/components/button.ws.tsx
+++ b/packages/react-sdk/src/components/button.ws.tsx
@@ -3,13 +3,12 @@ import type { WsComponentMeta, WsComponentPropsMeta } from "./component-type";
 import { props } from "./__generated__/button.props";
 
 export const meta: WsComponentMeta = {
-  type: "rich-text",
+  type: "container",
   label: "Button",
   Icon: ButtonIcon,
-  children: ["Button text you can edit"],
 };
 
 export const propsMeta: WsComponentPropsMeta = {
   props,
-  initialProps: ["type"],
+  initialProps: ["type", "innerText", "aria-label"],
 };


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio-builder/issues/1198

## Description

- Button has a standard behavior with space key pressed that can't be turned off, so we can't type a space
- Even if we work around the space behavior somehow, we still  don't have an ability for rich-text to accept any instance and that makes a use case for icon button and button with icon on left/right impossible

The solution I went for is to make it container for accepting child instances and edit text using InnerText property. This may be not as intuitive as direct rich-text but its more capable.

Webflow does the same thing for a form button, though it uses an input element.

<img width="1082" alt="Screenshot 2023-03-09 at 03 10 05" src="https://user-images.githubusercontent.com/52824/223898596-a4aae718-32d6-4090-a6f9-3d883b587ef7.png">



## Steps for reproduction

1. add button
1. change inner text
1. add image or text components

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview
- [ ] @taylornowotny - please test 

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
