### PR TITLE
Fix text highlighing

### DIFF
--- a/apps/builder/app/canvas/shared/use-track-selected-element.ts
+++ b/apps/builder/app/canvas/shared/use-track-selected-element.ts
@@ -20,6 +20,8 @@ const eventOptions = {
   passive: true,
 };
 
+const isHighlighting = () => getSelection()?.type === "Range";
+
 export const useTrackSelectedElement = () => {
   const selectedInstanceId = useStore(selectedInstanceIdStore);
   const [editingInstanceId, setEditingInstanceId] = useTextEditingInstanceId();
@@ -38,6 +40,12 @@ export const useTrackSelectedElement = () => {
 
   useEffect(() => {
     const handleClick = (event: MouseEvent) => {
+      // When user is selecting text inside content editable and mouse goes up
+      // on a different instance - we don't want to select a different instance
+      // because that would cancel the text selection.
+      if (isHighlighting()) {
+        return;
+      }
       // Notify in general that document was clicked
       // e.g. to hide the side panel
       publish({ type: "clickCanvas" });
@@ -75,7 +83,6 @@ export const useTrackSelectedElement = () => {
         }
         return;
       }
-
       selectedInstanceIdStore.set(id);
     };
 


### PR DESCRIPTION
## Description

Closes https://github.com/webstudio-is/webstudio-builder/issues/1193

When user is selecting text inside content editable and mouse goes up on a different instance - we don't want to select a different instance because that would cancel the text selection.

## Steps for reproduction

1. enter text editing
2. select text and let mouse go up on a different instance outside of the current
3. see text now stays highlighted, before it would select a different instance

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
