### PR TITLE
Allow to delete width/height on Image

### DIFF
--- a/apps/builder/app/builder/features/props-panel/controls/number.tsx
+++ b/apps/builder/app/builder/features/props-panel/controls/number.tsx
@@ -12,12 +12,16 @@ export const NumberControl = ({
   propName,
   onChange,
   onDelete,
+  onSoftDelete,
 }: ControlProps<"number", "number">) => {
   const id = useId();
 
   const localValue = useLocalValue(prop ? prop.value : "", (value) => {
     if (typeof value === "number") {
       onChange({ type: "number", value });
+    }
+    if (value === "") {
+      onSoftDelete();
     }
   });
 

--- a/apps/builder/app/builder/features/props-panel/props-panel.tsx
+++ b/apps/builder/app/builder/features/props-panel/props-panel.tsx
@@ -129,6 +129,7 @@ const Property = ({
   component,
   onChange,
   onDelete,
+  onSoftDelete,
   setCssProperty,
 }: {
   prop: Prop | undefined;
@@ -137,6 +138,7 @@ const Property = ({
   component: Instance["component"];
   onChange: (value: PropValue) => void;
   onDelete?: () => void;
+  onSoftDelete: () => void;
   setCssProperty: SetCssProperty;
 }) =>
   renderControl({
@@ -144,6 +146,7 @@ const Property = ({
     prop,
     propName,
     onDelete,
+    onSoftDelete,
     onChange: (propValue, asset) => {
       onChange(propValue);
 
@@ -215,6 +218,7 @@ export const PropsPanel = ({
             meta={meta}
             component={component}
             onChange={(value) => logic.handleChange({ prop, propName }, value)}
+            onSoftDelete={() => prop && logic.handleSoftDelete(prop)}
             setCssProperty={setCssProperty}
           />
         ))}
@@ -247,6 +251,7 @@ export const PropsPanel = ({
                 logic.handleChange({ prop, propName }, value)
               }
               onDelete={() => logic.handleDelete({ prop, propName })}
+              onSoftDelete={() => prop && logic.handleSoftDelete(prop)}
               setCssProperty={setCssProperty}
             />
           ))}

--- a/apps/builder/app/builder/features/props-panel/shared.tsx
+++ b/apps/builder/app/builder/features/props-panel/shared.tsx
@@ -46,6 +46,10 @@ export type ControlProps<Control, PropType> = {
   propName: string;
   onChange: (value: PropValue, asset?: Asset) => void;
   onDelete?: () => void;
+
+  // Should be called when we want to delete the prop,
+  // but want to keep it in the list until panel is closed
+  onSoftDelete: () => void;
 };
 
 export const getLabel = (meta: { label?: string }, fallback: string) =>

--- a/apps/builder/app/builder/features/props-panel/use-props-logic.ts
+++ b/apps/builder/app/builder/features/props-panel/use-props-logic.ts
@@ -101,6 +101,10 @@ type UsePropsLogicOutput = {
   handleAdd: (propName: string) => void;
   handleChange: (prop: PropOrName, value: PropValue) => void;
   handleDelete: (prop: PropOrName) => void;
+  /**
+   * Delete the prop, but keep it in the list of added props
+   */
+  handleSoftDelete: (prop: Prop) => void;
 };
 
 const getAndDelete = <Value>(map: Map<string, Value>, key: string) => {
@@ -216,6 +220,10 @@ export const usePropsLogic = ({
     setNewNames((prev) => prev.filter((name) => propName !== name));
   };
 
+  const handleSoftDelete = (prop: Prop) => {
+    deleteProp(prop.id);
+  };
+
   return {
     initialProps,
     addedProps: [...oldAdded, ...newAdded],
@@ -225,5 +233,6 @@ export const usePropsLogic = ({
     handleAdd,
     handleChange,
     handleDelete,
+    handleSoftDelete,
   };
 };


### PR DESCRIPTION
## Description

Fix for the bug reported in https://discord.com/channels/955905230107738152/1083358357743742998

Can't delete a value in width field:
- Add image component
- Set width
- try removing width - it won't be saved

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)


## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
