### PR TITLE
Keep the label from old instance

### DIFF
--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -75,6 +75,7 @@ export const patchInstancesMutable = (
       type: "instance",
       id: oldInstance.id,
       component: oldInstance.component,
+      label: oldInstance.label,
       children: oldInstance.children.map((child) => {
         if (child.type === "text") {
           return child;


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio-builder/issues/1214

## Description

We ended up removing instance labels when sorting instances, is there more situations like this?

## Steps for reproduction

1. name instance
2. sort it in navigator or on canvas

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
