### PR TITLE
Export instances tree lookup from project-build

### DIFF
--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -3,7 +3,11 @@ import { Suspense, lazy, useCallback, useMemo, useRef } from "react";
 import { useStore } from "@nanostores/react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import store from "immerhin";
-import type { Instance, Prop } from "@webstudio-is/project-build";
+import {
+  type Instance,
+  type Prop,
+  findTreeInstanceIds,
+} from "@webstudio-is/project-build";
 import {
   renderWebstudioComponentChildren,
   idAttribute,
@@ -19,7 +23,6 @@ import {
 } from "~/shared/nano-states";
 import { useCssRules } from "~/canvas/shared/styles";
 import { SelectedInstanceConnector } from "./selected-instance-connector";
-import { findTreeInstances } from "~/shared/tree-utils";
 
 const TextEditor = lazy(() => import("../text-editor"));
 
@@ -158,7 +161,7 @@ export const WebstudioComponentDev = ({
         }
         onChange={(instancesList) => {
           store.createTransaction([instancesStore], (instances) => {
-            const deletedTreeIds = findTreeInstances(instances, instance.id);
+            const deletedTreeIds = findTreeInstanceIds(instances, instance.id);
             for (const updatedInstance of instancesList) {
               instances.set(updatedInstance.id, updatedInstance);
               // exclude reused instances

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -1,6 +1,7 @@
 import store from "immerhin";
 import { z } from "zod";
 import {
+  findTreeInstanceIds,
   InstancesItem,
   Prop,
   StyleDecl,
@@ -20,7 +21,6 @@ import {
 import {
   findClosestDroppableTarget,
   findSubtreeLocalStyleSources,
-  findTreeInstances,
   insertInstancesCopyMutable,
   insertPropsCopyMutable,
   insertStylesCopyMutable,
@@ -49,7 +49,7 @@ const getTreeData = (targetInstanceId: string) => {
   }
 
   const instances = instancesStore.get();
-  const treeInstanceIds = findTreeInstances(instances, targetInstanceId);
+  const treeInstanceIds = findTreeInstanceIds(instances, targetInstanceId);
   const styleSources = styleSourcesStore.get();
   const styleSourceSelections = styleSourceSelectionsStore.get();
   const subtreeLocalStyleSourceIds = findSubtreeLocalStyleSources(

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -1,5 +1,5 @@
 import store from "immerhin";
-import type { Instance } from "@webstudio-is/project-build";
+import { findTreeInstanceIds, Instance } from "@webstudio-is/project-build";
 import {
   rootInstanceContainer,
   propsStore,
@@ -16,7 +16,6 @@ import {
   DroppableTarget,
   findParentInstance,
   findSubtreeLocalStyleSources,
-  findTreeInstances,
   insertInstanceMutable,
   reparentInstanceMutable,
 } from "./tree-utils";
@@ -59,7 +58,7 @@ export const deleteInstance = (targetInstanceId: Instance["id"]) => {
     ],
     (instances, props, styleSourceSelections, styleSources, styles) => {
       const parentInstance = findParentInstance(instances, targetInstanceId);
-      const subtreeIds = findTreeInstances(instances, targetInstanceId);
+      const subtreeIds = findTreeInstanceIds(instances, targetInstanceId);
       const subtreeLocalStyleSourceIds = findSubtreeLocalStyleSources(
         subtreeIds,
         styleSources,

--- a/apps/builder/app/shared/tree-utils.test.ts
+++ b/apps/builder/app/shared/tree-utils.test.ts
@@ -16,7 +16,6 @@ import {
   findClosestRichTextInstance,
   findParentInstance,
   findSubtreeLocalStyleSources,
-  findTreeInstances,
   getInstanceAncestorsAndSelf,
   insertInstanceMutable,
   insertInstancesCopyMutable,
@@ -437,24 +436,6 @@ test("find parent instance", () => {
       { type: "id", value: "5" },
     ],
   });
-});
-
-test("find all tree instances", () => {
-  const instances: Instances = new Map([
-    createInstancePair("1", "Body", [{ type: "id", value: "3" }]),
-    // this is outside of subtree
-    createInstancePair("2", "Box", []),
-    // these should be matched
-    createInstancePair("3", "Box", [
-      { type: "id", value: "4" },
-      { type: "id", value: "5" },
-    ]),
-    createInstancePair("4", "Box", []),
-    createInstancePair("5", "Box", []),
-    // this one is from other tree
-    createInstancePair("6", "Box", []),
-  ]);
-  expect(findTreeInstances(instances, "3")).toEqual(new Set(["3", "4", "5"]));
 });
 
 test("insert tree of instances copy and provide map from ids map", () => {

--- a/apps/builder/app/shared/tree-utils.ts
+++ b/apps/builder/app/shared/tree-utils.ts
@@ -204,34 +204,6 @@ export const findParentInstance = (
   }
 };
 
-const traverseInstancesMap = (
-  instances: Map<Instance["id"], InstancesItem>,
-  instanceId: Instance["id"],
-  callback: (instance: InstancesItem) => void
-) => {
-  const instance = instances.get(instanceId);
-  if (instance === undefined) {
-    return;
-  }
-  callback(instance);
-  for (const child of instance.children) {
-    if (child.type === "id") {
-      traverseInstancesMap(instances, child.value, callback);
-    }
-  }
-};
-
-export const findTreeInstances = (
-  instances: Instances,
-  rootInstanceId: Instance["id"]
-) => {
-  const subtreeIds = new Set<Instance["id"]>();
-  traverseInstancesMap(instances, rootInstanceId, (instance) => {
-    subtreeIds.add(instance.id);
-  });
-  return subtreeIds;
-};
-
 export const cloneStyles = (
   styles: Styles,
   clonedStyleSourceIds: Map<Instance["id"], Instance["id"]>

--- a/packages/project-build/src/index.ts
+++ b/packages/project-build/src/index.ts
@@ -7,3 +7,4 @@ export * from "./schema/style-source-selections";
 export * from "./schema/breakpoints";
 export * from "./types";
 export * from "./shared/pages-utils";
+export * from "./shared/instances-utils";

--- a/packages/project-build/src/shared/instances-utils.test.ts
+++ b/packages/project-build/src/shared/instances-utils.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@jest/globals";
+import type { Instance, Instances, InstancesItem } from "../schema/instances";
+import { findTreeInstanceIds } from "./instances-utils";
+
+const createInstance = (
+  id: Instance["id"],
+  component: string,
+  children: InstancesItem["children"]
+): InstancesItem => {
+  return {
+    type: "instance",
+    id,
+    component,
+    children,
+  };
+};
+
+const createInstancePair = (
+  id: Instance["id"],
+  component: string,
+  children: InstancesItem["children"]
+) => {
+  return [id, createInstance(id, component, children)] as const;
+};
+
+test("find all tree instances", () => {
+  const instances: Instances = new Map([
+    createInstancePair("1", "Body", [{ type: "id", value: "3" }]),
+    // this is outside of subtree
+    createInstancePair("2", "Box", []),
+    // these should be matched
+    createInstancePair("3", "Box", [
+      { type: "id", value: "4" },
+      { type: "id", value: "5" },
+    ]),
+    createInstancePair("4", "Box", []),
+    createInstancePair("5", "Box", []),
+    // this one is from other tree
+    createInstancePair("6", "Box", []),
+  ]);
+  expect(findTreeInstanceIds(instances, "3")).toEqual(new Set(["3", "4", "5"]));
+});

--- a/packages/project-build/src/shared/instances-utils.ts
+++ b/packages/project-build/src/shared/instances-utils.ts
@@ -1,0 +1,29 @@
+import type { Instance, Instances, InstancesItem } from "../schema/instances";
+
+const traverseInstances = (
+  instances: Instances,
+  instanceId: Instance["id"],
+  callback: (instance: InstancesItem) => void
+) => {
+  const instance = instances.get(instanceId);
+  if (instance === undefined) {
+    return;
+  }
+  callback(instance);
+  for (const child of instance.children) {
+    if (child.type === "id") {
+      traverseInstances(instances, child.value, callback);
+    }
+  }
+};
+
+export const findTreeInstanceIds = (
+  instances: Instances,
+  rootInstanceId: Instance["id"]
+) => {
+  const ids = new Set<Instance["id"]>();
+  traverseInstances(instances, rootInstanceId, (instance) => {
+    ids.add(instance.id);
+  });
+  return ids;
+};


### PR DESCRIPTION
This utility is needed to filter loaded data per page on published sites. We aleady have it in builder so easy to move.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
