### PR TITLE
Sync initial client store from builder to canvas

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -30,8 +30,10 @@ import {
 } from "./features/workspace";
 import { usePublishShortcuts } from "./shared/shortcuts";
 import {
+  selectedPageStore,
   useDragAndDropState,
   useIsPreviewMode,
+  useSetAssets,
   useSetAuthPermit,
   useSetAuthToken,
   useSetBreakpoints,
@@ -47,6 +49,7 @@ import { Navigator } from "./features/sidebar-left";
 import { getBuildUrl } from "~/shared/router-utils";
 import { useCopyPaste } from "~/shared/copy-paste";
 import { AssetsProvider } from "./shared/assets";
+import type { Asset } from "@webstudio-is/asset-uploader";
 
 registerContainers();
 
@@ -248,6 +251,7 @@ export type BuilderProps = {
   pages: Pages;
   pageId: string;
   build: Build;
+  assets: Asset[];
   buildOrigin: string;
   authReadToken: string;
   authToken?: string;
@@ -259,6 +263,7 @@ export const Builder = ({
   pages,
   pageId,
   build,
+  assets,
   buildOrigin,
   authReadToken,
   authToken,
@@ -270,6 +275,8 @@ export const Builder = ({
   useSetStyleSources(build.styleSources);
   useSetStyleSourceSelections(build.styleSourceSelections);
   useSetInstances(build.instances);
+
+  useSetAssets(assets);
 
   useSetAuthToken(authToken);
   useSetAuthPermit(authPermit);
@@ -312,6 +319,8 @@ export const Builder = ({
     }
     return page;
   }, [pages, pageId]);
+
+  selectedPageStore.set(page);
 
   const canvasUrl = getBuildUrl({
     buildOrigin,

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -26,8 +26,6 @@ import {
   useRootInstance,
   useSubscribeScrollState,
   useIsPreviewMode,
-  useSetAssets,
-  useSetSelectedPage,
 } from "~/shared/nano-states";
 import { usePublishScrollState } from "./shared/use-publish-scroll-state";
 import { useDragAndDrop } from "./shared/use-drag-drop";
@@ -96,8 +94,6 @@ export const Canvas = ({
   getComponent,
 }: CanvasProps): JSX.Element | null => {
   const isBuilderReady = useSubscribeBuilderReady();
-  useSetAssets(data.assets);
-  useSetSelectedPage(data.page);
   setParams(data.params ?? null);
   useCanvasStore(publish);
   const [isPreviewMode] = useIsPreviewMode();

--- a/apps/builder/app/routes/builder/$projectId.tsx
+++ b/apps/builder/app/routes/builder/$projectId.tsx
@@ -9,6 +9,7 @@ import { ErrorMessage } from "~/shared/error";
 import { sentryException } from "~/shared/sentry";
 import { getBuildOrigin } from "~/shared/router-utils";
 import { type BuilderProps, Builder, links } from "~/builder";
+import { loadByProject } from "@webstudio-is/asset-uploader/server";
 
 export { links };
 
@@ -43,6 +44,7 @@ export const loader = async ({
   }
 
   const devBuild = await loadBuildByProjectId(project.id, "dev");
+  const assets = await loadByProject(project.id, context);
 
   const pages = devBuild.pages;
 
@@ -54,6 +56,7 @@ export const loader = async ({
     pages,
     pageId: pageIdParam || devBuild.pages.homePage.id,
     build: devBuild,
+    assets,
     buildOrigin: getBuildOrigin(request),
     authReadToken,
     authToken,

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -41,11 +41,6 @@ const useValue = <T>(atom: WritableAtom<T>) => {
 };
 
 export const selectedPageStore = atom<undefined | Page>(undefined);
-export const useSetSelectedPage = (page: Page) => {
-  useSyncInitializeOnce(() => {
-    selectedPageStore.set(page);
-  });
-};
 
 export const instancesStore = atom<Map<InstancesItem["id"], InstancesItem>>(
   new Map()

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -171,21 +171,6 @@ const syncStoresState = (name: SyncEventSource, publish: Publish) => {
 
 export const useCanvasStore = (publish: Publish) => {
   useEffect(() => {
-    const data = [];
-    for (const [namespace, store] of clientStores) {
-      data.push({
-        namespace,
-        value: store.get(),
-      });
-    }
-    publish({
-      type: "sendStoreData",
-      payload: {
-        source: "canvas",
-        data,
-      },
-    });
-
     const unsubscribeStoresState = syncStoresState("canvas", publish);
     const unsubscribeStoresChanges = syncStoresChanges("canvas", publish);
 
@@ -210,6 +195,12 @@ export const useBuilderStore = (publish: Publish) => {
         data.push({
           namespace,
           value: container.get(),
+        });
+      }
+      for (const [namespace, store] of clientStores) {
+        data.push({
+          namespace,
+          value: store.get(),
         });
       }
       publish({


### PR DESCRIPTION
Before we send initial data from canvas which broke preview mode. Now builder is leader and fully maintain synchronization.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
