### PR TITLE
Switch pages on client side

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useStore } from "@nanostores/react";
 import { useNavigate } from "@remix-run/react";
 import {
   DeprecatedIconButton,
@@ -21,17 +22,17 @@ import {
 } from "@webstudio-is/icons";
 import type { Page, Pages } from "@webstudio-is/project-build";
 import type { Publish } from "~/shared/pubsub";
-import {
-  useCurrentPageId,
-  usePages,
-  useProject,
-} from "~/builder/shared/nano-states";
+import { useProject } from "~/builder/shared/nano-states";
 import { builderPath } from "~/shared/router-utils";
 import type { TabName } from "../../types";
 import { CloseButton, Header } from "../../header";
 import { SettingsPanel } from "./settings-panel";
 import { NewPageSettings, PageSettings } from "./settings";
-import { useAuthToken } from "~/shared/nano-states";
+import {
+  pagesStore,
+  selectedPageIdStore,
+  useAuthToken,
+} from "~/shared/nano-states";
 
 type TabContentProps = {
   onSetActiveTab: (tabName: TabName) => void;
@@ -149,7 +150,7 @@ const PagesPanel = ({
   onEdit?: (pageId: string | undefined) => void;
   editingPageId?: string;
 }) => {
-  const [pages] = usePages();
+  const pages = useStore(pagesStore);
   const pagesTree = useMemo(() => pages && toTreeData(pages), [pages]);
 
   const renderItem = useCallback(
@@ -231,7 +232,7 @@ const PagesPanel = ({
 };
 
 export const TabContent = (props: TabContentProps) => {
-  const [currentPageId] = useCurrentPageId();
+  const currentPageId = useStore(selectedPageIdStore);
   const [project] = useProject();
   const [authToken] = useAuthToken();
 

--- a/apps/builder/app/builder/features/topbar/topbar.tsx
+++ b/apps/builder/app/builder/features/topbar/topbar.tsx
@@ -1,5 +1,6 @@
-import type { Publish } from "~/shared/pubsub";
+import { useStore } from "@nanostores/react";
 import {
+  theme,
   css,
   Flex,
   Text,
@@ -7,9 +8,9 @@ import {
   ToolbarSeparator,
   ToolbarToggleGroup,
 } from "@webstudio-is/design-system";
-import type { Page } from "@webstudio-is/project-build";
 import type { Project } from "@webstudio-is/project";
-import { theme } from "@webstudio-is/design-system";
+import type { Publish } from "~/shared/pubsub";
+import { selectedPageStore } from "~/shared/nano-states";
 import { PreviewButton } from "./preview";
 import { ShareButton } from "./share";
 import { PublishButton } from "./publish";
@@ -28,11 +29,15 @@ const topbarContainerStyle = css({
 type TopbarProps = {
   gridArea: string;
   project: Project;
-  page: Page;
   publish: Publish;
 };
 
-export const Topbar = ({ gridArea, project, page, publish }: TopbarProps) => {
+export const Topbar = ({ gridArea, project, publish }: TopbarProps) => {
+  const page = useStore(selectedPageStore);
+  if (page === undefined) {
+    return null;
+  }
+
   return (
     <Toolbar className={topbarContainerStyle({ css: { gridArea } })}>
       <Flex grow={false} shrink={false}>

--- a/apps/builder/app/builder/shared/nano-states/index.ts
+++ b/apps/builder/app/builder/shared/nano-states/index.ts
@@ -1,8 +1,6 @@
 import { atom, type WritableAtom } from "nanostores";
 import { useStore } from "@nanostores/react";
-import type { Pages } from "@webstudio-is/project-build";
 import type { Project } from "@webstudio-is/project";
-import type { AssetContainer, DeletingAssetContainer } from "../assets";
 
 const useValue = <T>(atom: WritableAtom<T>) => {
   const value = useStore(atom);
@@ -21,17 +19,6 @@ export const useCanvasWidth = () => useValue(canvasWidthContainer);
 
 const canvasRectContainer = atom<DOMRect | undefined>();
 export const useCanvasRect = () => useValue(canvasRectContainer);
-
-const assetsContainer = atom<Array<AssetContainer | DeletingAssetContainer>>(
-  []
-);
-export const useAssetsContainer = () => useValue(assetsContainer);
-
-const pagesContainer = atom<Pages | undefined>();
-export const usePages = () => useValue(pagesContainer);
-
-const currentPageIdContainer = atom<string | undefined>();
-export const useCurrentPageId = () => useValue(currentPageIdContainer);
 
 const projectContainer = atom<Project | undefined>();
 export const useProject = () => useValue(projectContainer);

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -1,4 +1,5 @@
 import { useMemo, Fragment, useEffect } from "react";
+import { useStore } from "@nanostores/react";
 import { computed } from "nanostores";
 import type { CanvasData } from "@webstudio-is/project";
 import type { Instance } from "@webstudio-is/project-build";
@@ -26,6 +27,7 @@ import {
   useRootInstance,
   useSubscribeScrollState,
   useIsPreviewMode,
+  selectedPageStore,
 } from "~/shared/nano-states";
 import { usePublishScrollState } from "./shared/use-publish-scroll-state";
 import { useDragAndDrop } from "./shared/use-drag-drop";
@@ -105,16 +107,17 @@ export const Canvas = ({
   // e.g. toggling preview is still needed in both modes
   useShortcuts();
   useSharedShortcuts();
+  const selectedPage = useStore(selectedPageStore);
 
   useEffect(() => {
-    const rootInstanceId = data.page.rootInstanceId;
+    const rootInstanceId = selectedPage?.rootInstanceId;
     if (rootInstanceId !== undefined) {
       setDataCollapsed(rootInstanceId);
     }
   });
 
   useWindowResizeDebounced(() => {
-    const rootInstanceId = data.page.rootInstanceId;
+    const rootInstanceId = selectedPage?.rootInstanceId;
     if (rootInstanceId !== undefined) {
       setDataCollapsed(rootInstanceId);
     }

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -12,6 +12,7 @@ import type {
   Instances,
   InstancesItem,
   Page,
+  Pages,
   Prop,
   Props,
   StyleDecl,
@@ -40,7 +41,32 @@ const useValue = <T>(atom: WritableAtom<T>) => {
   return [value, atom.set] as const;
 };
 
-export const selectedPageStore = atom<undefined | Page>(undefined);
+export const pagesStore = atom<undefined | Pages>(undefined);
+export const useSetPages = (pages: Pages) => {
+  useSyncInitializeOnce(() => {
+    pagesStore.set(pages);
+  });
+};
+
+export const selectedPageIdStore = atom<undefined | Page["id"]>(undefined);
+export const useSetSelectedPageId = (pageId: Page["id"]) => {
+  useSyncInitializeOnce(() => {
+    selectedPageIdStore.set(pageId);
+  });
+};
+
+export const selectedPageStore = computed(
+  [pagesStore, selectedPageIdStore],
+  (pages, selectedPageId) => {
+    if (pages === undefined) {
+      return undefined;
+    }
+    if (pages.homePage.id === selectedPageId) {
+      return pages.homePage;
+    }
+    return pages.pages.find((page) => page.id === selectedPageId);
+  }
+);
 
 export const instancesStore = atom<Map<InstancesItem["id"], InstancesItem>>(
   new Map()

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -4,14 +4,15 @@ import type { WritableAtom } from "nanostores";
 import { useEffect } from "react";
 import { type Publish, subscribe } from "~/shared/pubsub";
 import {
+  pagesStore,
   instancesStore,
   propsStore,
   breakpointsContainer,
   stylesStore,
   styleSourcesStore,
   styleSourceSelectionsStore,
+  selectedPageIdStore,
   assetContainersStore,
-  selectedPageStore,
   selectedInstanceIdStore,
   selectedInstanceBrowserStyleStore,
   hoveredInstanceIdStore,
@@ -49,6 +50,7 @@ const clientStores = new Map<string, WritableAtom<unknown>>();
 
 export const registerContainers = () => {
   // synchronize patches
+  store.register("pages", pagesStore);
   store.register("breakpoints", breakpointsContainer);
   store.register("instances", instancesStore);
   store.register("styles", stylesStore);
@@ -56,8 +58,8 @@ export const registerContainers = () => {
   store.register("styleSourceSelections", styleSourceSelectionsStore);
   store.register("props", propsStore);
   // synchronize whole states
+  clientStores.set("selectedPageId", selectedPageIdStore);
   clientStores.set("assetContainers", assetContainersStore);
-  clientStores.set("selectedPage", selectedPageStore);
   clientStores.set("selectedInstanceId", selectedInstanceIdStore);
   clientStores.set(
     "selectedInstanceBrowserStyle",


### PR DESCRIPTION
Switching between pages takes very long time though all data already loaded. Here I added validation to not reload builder data when page is changed and render canvas with static id which is not really used for anything so iframe no longer reloads.

Switching pages now instant.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
