### PR TITLE
Migrate all left updates to normalized instances

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
@@ -17,7 +17,7 @@ import {
 } from "~/shared/nano-states";
 import { useSubscribe, type Publish } from "~/shared/pubsub";
 import { useCanvasRect } from "~/builder/shared/nano-states";
-import { insertInstance } from "~/shared/instance-utils";
+import { insertNewComponentInstance } from "~/shared/instance-utils";
 import { zoomStore } from "~/shared/nano-states/breakpoints";
 import type { TabName } from "../../types";
 import { Header, CloseButton } from "../../header";
@@ -173,14 +173,11 @@ export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
             component={component}
             onClick={() => {
               onSetActiveTab("none");
-              const instance = utils.tree.createInstance({
-                component,
-              });
               const dropTarget = findClosestDroppableTarget(
                 instancesIndexStore.get(),
                 selectedInstanceIdStore.get()
               );
-              insertInstance(instance, dropTarget);
+              insertNewComponentInstance(component, dropTarget);
             }}
           />
         ))}

--- a/apps/builder/app/builder/features/tree-preview/tree-preview.tsx
+++ b/apps/builder/app/builder/features/tree-preview/tree-preview.tsx
@@ -13,8 +13,8 @@ import { InstanceTreeNode } from "~/builder/shared/tree";
 import {
   createInstancesIndex,
   getInstanceAncestorsAndSelf,
-  insertInstanceMutable,
-  reparentInstanceMutable,
+  insertInstanceMutableDeprecated,
+  reparentInstanceMutableDeprecated,
 } from "~/shared/tree-utils";
 
 export const TreePrevew = () => {
@@ -42,7 +42,7 @@ export const TreePrevew = () => {
     const instance: Instance = produce<Instance>((draft) => {
       const instancesIndex = createInstancesIndex(draft);
       if (isNew) {
-        insertInstanceMutable(
+        insertInstanceMutableDeprecated(
           instancesIndex,
           utils.tree.createInstance({ component: dragItemInstance.component }),
           {
@@ -51,7 +51,7 @@ export const TreePrevew = () => {
           }
         );
       } else {
-        reparentInstanceMutable(instancesIndex, dragItemInstance.id, {
+        reparentInstanceMutableDeprecated(instancesIndex, dragItemInstance.id, {
           parentId: dropTargetInstanceId,
           position: dropTargetPosition,
         });

--- a/apps/builder/app/canvas/shared/use-drag-drop.ts
+++ b/apps/builder/app/canvas/shared/use-drag-drop.ts
@@ -1,6 +1,5 @@
 import { useLayoutEffect, useRef } from "react";
 import { useStore } from "@nanostores/react";
-import { utils } from "@webstudio-is/project";
 import {
   type DropTarget,
   type Point,
@@ -20,7 +19,10 @@ import {
   useTextEditingInstanceId,
 } from "~/shared/nano-states";
 import { publish, useSubscribe } from "~/shared/pubsub";
-import { insertInstance, reparentInstance } from "~/shared/instance-utils";
+import {
+  insertNewComponentInstance,
+  reparentInstance,
+} from "~/shared/instance-utils";
 import {
   getInstanceElementById,
   getInstanceIdFromElement,
@@ -282,11 +284,7 @@ export const useDragAndDrop = () => {
       const { dropTarget, dragItem } = state.current;
 
       if (dropTarget && dragItem && isCanceled === false) {
-        const instance = utils.tree.createInstance({
-          component: dragItem.component,
-        });
-
-        insertInstance(instance, {
+        insertNewComponentInstance(dragItem.component, {
           parentId: dropTarget.data.id,
           position: dropTarget.indexWithinChildren,
         });

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -1,35 +1,31 @@
 import store from "immerhin";
 import { findTreeInstanceIds, Instance } from "@webstudio-is/project-build";
 import {
-  rootInstanceContainer,
   propsStore,
   stylesStore,
   selectedInstanceIdStore,
   styleSourceSelectionsStore,
   styleSourcesStore,
   instancesStore,
-  patchInstancesMutable,
   selectedPageStore,
 } from "./nano-states";
 import {
-  createInstancesIndex,
+  createComponentInstance,
   DroppableTarget,
   findParentInstance,
   findSubtreeLocalStyleSources,
-  insertInstanceMutable,
+  insertInstancesMutable,
   reparentInstanceMutable,
 } from "./tree-utils";
 import { removeByMutable } from "./array-utils";
 
-export const insertInstance = (
-  instance: Instance,
+export const insertNewComponentInstance = (
+  component: string,
   dropTarget?: DroppableTarget
 ) => {
-  const rootInstance = rootInstanceContainer.get();
+  const instance = createComponentInstance(component);
   store.createTransaction([instancesStore], (instances) => {
-    const instancesIndex = createInstancesIndex(rootInstance);
-    insertInstanceMutable(instancesIndex, instance, dropTarget);
-    patchInstancesMutable(rootInstance, instances);
+    insertInstancesMutable(instances, [instance], [instance.id], dropTarget);
   });
   selectedInstanceIdStore.set(instance.id);
 };
@@ -38,11 +34,8 @@ export const reparentInstance = (
   targetInstanceId: Instance["id"],
   dropTarget: DroppableTarget
 ) => {
-  const rootInstance = rootInstanceContainer.get();
   store.createTransaction([instancesStore], (instances) => {
-    const instancesIndex = createInstancesIndex(rootInstance);
-    reparentInstanceMutable(instancesIndex, targetInstanceId, dropTarget);
-    patchInstancesMutable(rootInstance, instances);
+    reparentInstanceMutable(instances, targetInstanceId, dropTarget);
   });
   selectedInstanceIdStore.set(targetInstanceId);
 };

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import deepEqual from "fast-deep-equal";
 import { atom, computed, type WritableAtom } from "nanostores";
 import { useStore } from "@nanostores/react";
 import { nanoid } from "nanoid";
@@ -51,41 +50,6 @@ export const useSetInstances = (
   useSyncInitializeOnce(() => {
     instancesStore.set(new Map(instances));
   });
-};
-
-/**
- * this is temporary utility to map rootInstance changes
- * to normalized instances
- *
- * later its usages should be rewritten with direct instances mutations
- */
-export const patchInstancesMutable = (
-  rootInstance: undefined | Instance,
-  instances: Instances
-) => {
-  const oldInstancesIndex = createInstancesIndex(rootInstance);
-  for (const oldInstance of oldInstancesIndex.instancesById.values()) {
-    const instance = instances.get(oldInstance.id);
-    const convertedOldInstance: InstancesItem = {
-      type: "instance",
-      id: oldInstance.id,
-      component: oldInstance.component,
-      label: oldInstance.label,
-      children: oldInstance.children.map((child) => {
-        if (child.type === "text") {
-          return child;
-        }
-        return {
-          type: "id",
-          value: child.id,
-        };
-      }),
-    };
-    if (deepEqual(convertedOldInstance, instance)) {
-      continue;
-    }
-    instances.set(oldInstance.id, convertedOldInstance);
-  }
 };
 
 // @todo will be removed soon

--- a/apps/builder/app/shared/tree-utils.test.ts
+++ b/apps/builder/app/shared/tree-utils.test.ts
@@ -17,7 +17,6 @@ import {
   findParentInstance,
   findSubtreeLocalStyleSources,
   getInstanceAncestorsAndSelf,
-  insertInstanceMutable,
   insertInstancesCopyMutable,
   insertInstancesMutable,
   insertPropsCopyMutable,
@@ -153,67 +152,6 @@ test("find closest droppable target", () => {
   });
 });
 
-test("insert instance into target", () => {
-  const rootInstance = createInstance("root", "Body", [
-    createInstance("box1", "Box", [
-      createInstance("box11", "Box", []),
-      createInstance("box12", "Box", []),
-      createInstance("box13", "Box", []),
-    ]),
-  ]);
-
-  let instancesIndex = createInstancesIndex(rootInstance);
-  insertInstanceMutable(
-    instancesIndex,
-    createInstance("inserted1", "Box", [
-      createInstance("inserted2", "Box", []),
-    ]),
-    {
-      parentId: "box1",
-      position: 1,
-    }
-  );
-  expect(rootInstance).toEqual(
-    createInstance("root", "Body", [
-      createInstance("box1", "Box", [
-        createInstance("box11", "Box", []),
-        createInstance("inserted1", "Box", [
-          createInstance("inserted2", "Box", []),
-        ]),
-        createInstance("box12", "Box", []),
-        createInstance("box13", "Box", []),
-      ]),
-    ])
-  );
-
-  instancesIndex = createInstancesIndex(rootInstance);
-  insertInstanceMutable(
-    instancesIndex,
-    createInstance("inserted3", "Box", [
-      createInstance("inserted4", "Box", []),
-    ]),
-    {
-      parentId: "box1",
-      position: "end",
-    }
-  );
-  expect(rootInstance).toEqual(
-    createInstance("root", "Body", [
-      createInstance("box1", "Box", [
-        createInstance("box11", "Box", []),
-        createInstance("inserted1", "Box", [
-          createInstance("inserted2", "Box", []),
-        ]),
-        createInstance("box12", "Box", []),
-        createInstance("box13", "Box", []),
-        createInstance("inserted3", "Box", [
-          createInstance("inserted4", "Box", []),
-        ]),
-      ]),
-    ])
-  );
-});
-
 test("insert instances tree into target", () => {
   const instances = new Map([
     createInstancePair("root", "Body", [{ type: "id", value: "box1" }]),
@@ -296,64 +234,93 @@ test("insert instances tree into target", () => {
 });
 
 test("reparent instance into target", () => {
-  const rootInstance = createInstance("root", "Body", [
-    createInstance("target", "Box", []),
-    createInstance("box1", "Box", [
-      createInstance("box11", "Box", []),
-      createInstance("box12", "Box", []),
-      createInstance("box13", "Box", []),
+  const instances: Instances = new Map([
+    createInstancePair("root", "Body", [
+      { type: "id", value: "target" },
+      { type: "id", value: "box1" },
+      { type: "id", value: "box2" },
     ]),
-    createInstance("box2", "Box", []),
+    createInstancePair("target", "Box", []),
+    createInstancePair("box1", "Box", [
+      { type: "id", value: "box11" },
+      { type: "id", value: "box12" },
+      { type: "id", value: "box13" },
+    ]),
+    createInstancePair("box2", "Box", []),
+    createInstancePair("box11", "Box", []),
+    createInstancePair("box12", "Box", []),
+    createInstancePair("box13", "Box", []),
   ]);
 
-  let instancesIndex = createInstancesIndex(rootInstance);
-  reparentInstanceMutable(instancesIndex, "target", {
+  reparentInstanceMutable(instances, "target", {
     parentId: "box1",
     position: 1,
   });
-  expect(rootInstance).toEqual(
-    createInstance("root", "Body", [
-      createInstance("box1", "Box", [
-        createInstance("box11", "Box", []),
-        createInstance("target", "Box", []),
-        createInstance("box12", "Box", []),
-        createInstance("box13", "Box", []),
+  expect(instances).toEqual(
+    new Map([
+      createInstancePair("root", "Body", [
+        { type: "id", value: "box1" },
+        { type: "id", value: "box2" },
       ]),
-      createInstance("box2", "Box", []),
+      createInstancePair("target", "Box", []),
+      createInstancePair("box1", "Box", [
+        { type: "id", value: "box11" },
+        { type: "id", value: "target" },
+        { type: "id", value: "box12" },
+        { type: "id", value: "box13" },
+      ]),
+      createInstancePair("box2", "Box", []),
+      createInstancePair("box11", "Box", []),
+      createInstancePair("box12", "Box", []),
+      createInstancePair("box13", "Box", []),
     ])
   );
 
-  instancesIndex = createInstancesIndex(rootInstance);
-  reparentInstanceMutable(instancesIndex, "target", {
+  reparentInstanceMutable(instances, "target", {
     parentId: "box1",
     position: 3,
   });
-  expect(rootInstance).toEqual(
-    createInstance("root", "Body", [
-      createInstance("box1", "Box", [
-        createInstance("box11", "Box", []),
-        createInstance("box12", "Box", []),
-        createInstance("target", "Box", []),
-        createInstance("box13", "Box", []),
+  expect(instances).toEqual(
+    new Map([
+      createInstancePair("root", "Body", [
+        { type: "id", value: "box1" },
+        { type: "id", value: "box2" },
       ]),
-      createInstance("box2", "Box", []),
+      createInstancePair("target", "Box", []),
+      createInstancePair("box1", "Box", [
+        { type: "id", value: "box11" },
+        { type: "id", value: "box12" },
+        { type: "id", value: "target" },
+        { type: "id", value: "box13" },
+      ]),
+      createInstancePair("box2", "Box", []),
+      createInstancePair("box11", "Box", []),
+      createInstancePair("box12", "Box", []),
+      createInstancePair("box13", "Box", []),
     ])
   );
 
-  instancesIndex = createInstancesIndex(rootInstance);
-  reparentInstanceMutable(instancesIndex, "target", {
+  reparentInstanceMutable(instances, "target", {
     parentId: "root",
     position: "end",
   });
-  expect(rootInstance).toEqual(
-    createInstance("root", "Body", [
-      createInstance("box1", "Box", [
-        createInstance("box11", "Box", []),
-        createInstance("box12", "Box", []),
-        createInstance("box13", "Box", []),
+  expect(instances).toEqual(
+    new Map([
+      createInstancePair("root", "Body", [
+        { type: "id", value: "box1" },
+        { type: "id", value: "box2" },
+        { type: "id", value: "target" },
       ]),
-      createInstance("box2", "Box", []),
-      createInstance("target", "Box", []),
+      createInstancePair("target", "Box", []),
+      createInstancePair("box1", "Box", [
+        { type: "id", value: "box11" },
+        { type: "id", value: "box12" },
+        { type: "id", value: "box13" },
+      ]),
+      createInstancePair("box2", "Box", []),
+      createInstancePair("box11", "Box", []),
+      createInstancePair("box12", "Box", []),
+      createInstancePair("box13", "Box", []),
     ])
   );
 });


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/696

Here the last pieces to get rid of hacky patchInstancesMutable utility. Now will be easier to integrate slots.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
