### PR TITLE
Address selected instance with tree path

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/navigator/navigator.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/navigator/navigator.tsx
@@ -3,13 +3,15 @@ import { useStore } from "@nanostores/react";
 import { Flex } from "@webstudio-is/design-system";
 import type { Instance } from "@webstudio-is/project-build";
 import {
-  selectedInstanceIdStore,
+  selectedInstanceAddressStore,
   hoveredInstanceIdStore,
   useRootInstance,
+  instancesStore,
 } from "~/shared/nano-states";
 import { InstanceTree } from "~/builder/shared/tree";
 import { reparentInstance } from "~/shared/instance-utils";
 import { Header, CloseButton } from "../header";
+import { getInstanceAddress } from "~/shared/tree-utils";
 
 type NavigatorProps = {
   isClosable?: boolean;
@@ -17,11 +19,14 @@ type NavigatorProps = {
 };
 
 export const Navigator = ({ isClosable, onClose }: NavigatorProps) => {
-  const selectedInstanceId = useStore(selectedInstanceIdStore);
+  const selectedInstanceAddress = useStore(selectedInstanceAddressStore);
+  const selectedInstanceId = selectedInstanceAddress?.[0];
   const [rootInstance] = useRootInstance();
 
   const handleSelect = useCallback((instanceId: Instance["id"]) => {
-    selectedInstanceIdStore.set(instanceId);
+    const instances = instancesStore.get();
+    const instanceAddress = getInstanceAddress(instances, instanceId);
+    selectedInstanceAddressStore.set(instanceAddress);
   }, []);
 
   const handleDragEnd = useCallback(
@@ -53,6 +58,7 @@ export const Navigator = ({ isClosable, onClose }: NavigatorProps) => {
       <Flex css={{ flexGrow: 1, flexDirection: "column" }}>
         <InstanceTree
           root={rootInstance}
+          // @todo accept and provide in callback instance address instead of just id
           selectedItemId={selectedInstanceId}
           onSelect={handleSelect}
           onHover={handleHover}

--- a/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
@@ -13,7 +13,7 @@ import { utils } from "@webstudio-is/project";
 import { findClosestDroppableTarget } from "~/shared/tree-utils";
 import {
   instancesIndexStore,
-  selectedInstanceIdStore,
+  selectedInstanceAddressStore,
 } from "~/shared/nano-states";
 import { useSubscribe, type Publish } from "~/shared/pubsub";
 import { useCanvasRect } from "~/builder/shared/nano-states";
@@ -175,7 +175,8 @@ export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
               onSetActiveTab("none");
               const dropTarget = findClosestDroppableTarget(
                 instancesIndexStore.get(),
-                selectedInstanceIdStore.get()
+                // @todo accept instance address
+                selectedInstanceAddressStore.get()?.[0]
               );
               insertNewComponentInstance(component, dropTarget);
             }}

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
@@ -398,7 +398,7 @@ export const PageSettings = ({
     }
     const page = pages.pages.find((item) => item.id === pageId);
     if (page) {
-      deleteInstance(page.rootInstanceId);
+      deleteInstance([page.rootInstanceId]);
     }
     pagesStore.set({
       homePage: pages.homePage,

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.ts
@@ -12,7 +12,7 @@ import type {
 import {
   instancesIndexStore,
   selectedInstanceBrowserStyleStore,
-  selectedInstanceIdStore,
+  selectedInstanceAddressStore,
   selectedStyleSourceStore,
   stylesIndexStore,
   useBreakpoints,
@@ -232,7 +232,7 @@ export const useStyleInfo = () => {
   const [breakpoints] = useBreakpoints();
   const selectedBreakpoint = useStore(selectedBreakpointStore);
   const selectedBreakpointId = selectedBreakpoint?.id;
-  const selectedInstanceId = useStore(selectedInstanceIdStore);
+  const selectedInstanceAddress = useStore(selectedInstanceAddressStore);
   const selectedStyleSource = useStore(selectedStyleSourceStore);
   const selectedStyleSourceId = selectedStyleSource?.id;
   const browserStyle = useStore(selectedInstanceBrowserStyleStore);
@@ -262,13 +262,15 @@ export const useStyleInfo = () => {
   const inheritedInfo = useMemo(() => {
     if (
       selectedBreakpointId === undefined ||
-      selectedInstanceId === undefined
+      selectedInstanceAddress === undefined
     ) {
       return {};
     }
+    const [selectedInstanceId] = selectedInstanceAddress;
     return getInheritedInfo(
       instancesIndex,
       stylesByInstanceId,
+      // @todo accept instance address
       selectedInstanceId,
       cascadedBreakpointIds,
       selectedBreakpointId
@@ -278,23 +280,26 @@ export const useStyleInfo = () => {
     stylesByInstanceId,
     cascadedBreakpointIds,
     selectedBreakpointId,
-    selectedInstanceId,
+    selectedInstanceAddress,
   ]);
 
   const cascadedInfo = useMemo(() => {
-    if (selectedInstanceId === undefined) {
+    if (selectedInstanceAddress === undefined) {
       return {};
     }
+    const [selectedInstanceId] = selectedInstanceAddress;
     return getCascadedInfo(
       stylesByInstanceId,
+      // @todo accept instance address
       selectedInstanceId,
       cascadedBreakpointIds
     );
-  }, [stylesByInstanceId, selectedInstanceId, cascadedBreakpointIds]);
+  }, [stylesByInstanceId, selectedInstanceAddress, cascadedBreakpointIds]);
 
   const presetStyle = useMemo(() => {
-    return getPresetStyle(instancesIndex, selectedInstanceId);
-  }, [instancesIndex, selectedInstanceId]);
+    // @todo accept instance address
+    return getPresetStyle(instancesIndex, selectedInstanceAddress?.[0]);
+  }, [instancesIndex, selectedInstanceAddress]);
 
   const styleInfoData = useMemo(() => {
     const styleInfoData: StyleInfo = {};

--- a/apps/builder/app/builder/features/style-panel/style-settings.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-settings.tsx
@@ -15,10 +15,7 @@ import type { SetProperty, CreateBatchUpdate } from "./shared/use-style-data";
 import type { StyleInfo } from "./shared/style-info";
 import type { RenderPropertyProps } from "./style-sections";
 import { useStore } from "@nanostores/react";
-import {
-  instancesIndexStore,
-  selectedInstanceIdStore,
-} from "~/shared/nano-states";
+import { selectedInstanceAddressStore } from "~/shared/nano-states";
 import { useInstanceStyleData } from "./shared/style-info";
 
 // Finds a property/value by using any available form: property, label, value
@@ -99,15 +96,9 @@ export type StyleSettingsProps = {
 };
 
 const useParentStyle = () => {
-  const selectedInstanceId = useStore(selectedInstanceIdStore);
-  const instanceIndex = useStore(instancesIndexStore);
-
-  const parentInstance =
-    selectedInstanceId === undefined
-      ? undefined
-      : instanceIndex.parentInstancesById.get(selectedInstanceId);
-
-  const parentInstanceStyleData = useInstanceStyleData(parentInstance?.id);
+  const selectedInstanceAddress = useStore(selectedInstanceAddressStore);
+  const parentInstanceId = selectedInstanceAddress?.[1];
+  const parentInstanceStyleData = useInstanceStyleData(parentInstanceId);
   return parentInstanceStyleData;
 };
 

--- a/apps/builder/app/builder/features/style-panel/style-source-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.tsx
@@ -16,7 +16,7 @@ import {
 import { useStore } from "@nanostores/react";
 import {
   availableStyleSourcesStore,
-  selectedInstanceIdStore,
+  selectedInstanceAddressStore,
   selectedInstanceStyleSourcesStore,
   selectedStyleSourceIdStore,
   selectedStyleSourceStore,
@@ -43,10 +43,11 @@ const getOrCreateStyleSourceSelectionMutable = (
 };
 
 const createStyleSource = (name: string) => {
-  const selectedInstanceId = selectedInstanceIdStore.get();
-  if (selectedInstanceId === undefined) {
+  const selectedInstanceAddress = selectedInstanceAddressStore.get();
+  if (selectedInstanceAddress === undefined) {
     return;
   }
+  const [selectedInstanceId] = selectedInstanceAddress;
   const newStyleSource: StyleSource = {
     type: "token",
     id: nanoid(),
@@ -67,10 +68,11 @@ const createStyleSource = (name: string) => {
 };
 
 const addStyleSourceToInstace = (newStyleSourceId: StyleSource["id"]) => {
-  const selectedInstanceId = selectedInstanceIdStore.get();
-  if (selectedInstanceId === undefined) {
+  const selectedInstanceAddress = selectedInstanceAddressStore.get();
+  if (selectedInstanceAddress === undefined) {
     return;
   }
+  const [selectedInstanceId] = selectedInstanceAddress;
   store.createTransaction(
     [styleSourceSelectionsStore],
     (styleSourceSelections) => {
@@ -87,10 +89,11 @@ const addStyleSourceToInstace = (newStyleSourceId: StyleSource["id"]) => {
 };
 
 const removeStyleSourceFromInstance = (styleSourceId: StyleSource["id"]) => {
-  const selectedInstanceId = selectedInstanceIdStore.get();
-  if (selectedInstanceId === undefined) {
+  const selectedInstanceAddress = selectedInstanceAddressStore.get();
+  if (selectedInstanceAddress === undefined) {
     return;
   }
+  const [selectedInstanceId] = selectedInstanceAddress;
   store.createTransaction(
     [styleSourceSelectionsStore],
     (styleSourceSelections) => {
@@ -108,10 +111,11 @@ const removeStyleSourceFromInstance = (styleSourceId: StyleSource["id"]) => {
 };
 
 const duplicateStyleSource = (styleSourceId: StyleSource["id"]) => {
-  const selectedInstanceId = selectedInstanceIdStore.get();
-  if (selectedInstanceId === undefined) {
+  const selectedInstanceAddress = selectedInstanceAddressStore.get();
+  if (selectedInstanceAddress === undefined) {
     return;
   }
+  const [selectedInstanceId] = selectedInstanceAddress;
   const styleSources = styleSourcesStore.get();
   // style source may not exist in store which means
   // temporary generated local stye source was not applied yet
@@ -153,10 +157,11 @@ const duplicateStyleSource = (styleSourceId: StyleSource["id"]) => {
 };
 
 const convertLocalStyleSourceToToken = (styleSourceId: StyleSource["id"]) => {
-  const selectedInstanceId = selectedInstanceIdStore.get();
-  if (selectedInstanceId === undefined) {
+  const selectedInstanceAddress = selectedInstanceAddressStore.get();
+  if (selectedInstanceAddress === undefined) {
     return;
   }
+  const [selectedInstanceId] = selectedInstanceAddress;
   const newStyleSource: StyleSource = {
     type: "token",
     id: styleSourceId,
@@ -180,10 +185,11 @@ const convertLocalStyleSourceToToken = (styleSourceId: StyleSource["id"]) => {
 };
 
 const reorderStyleSources = (styleSourceIds: StyleSource["id"][]) => {
-  const selectedInstanceId = selectedInstanceIdStore.get();
-  if (selectedInstanceId === undefined) {
+  const selectedInstanceAddress = selectedInstanceAddressStore.get();
+  if (selectedInstanceAddress === undefined) {
     return;
   }
+  const [selectedInstanceId] = selectedInstanceAddress;
   store.createTransaction(
     [styleSourcesStore, styleSourceSelectionsStore],
     (styleSources, styleSourceSelections) => {

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/hovered-instance-outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/hovered-instance-outline.tsx
@@ -3,21 +3,23 @@ import {
   hoveredInstanceIdStore,
   hoveredInstanceOutlineStore,
   instancesStore,
-  selectedInstanceIdStore,
+  selectedInstanceAddressStore,
   useTextEditingInstanceId,
 } from "~/shared/nano-states";
 import { Outline } from "./outline";
 import { Label } from "./label";
 
 export const HoveredInstanceOutline = () => {
-  const selectedInstanceId = useStore(selectedInstanceIdStore);
+  const selectedInstanceAddress = useStore(selectedInstanceAddressStore);
   const hoveredInstanceId = useStore(hoveredInstanceIdStore);
   const instanceOutline = useStore(hoveredInstanceOutlineStore);
   const [textEditingInstanceId] = useTextEditingInstanceId();
   const instances = useStore(instancesStore);
 
   const isEditingText = textEditingInstanceId !== undefined;
-  const isHoveringSelectedInstance = selectedInstanceId === hoveredInstanceId;
+  // @todo compare instance addresses
+  const isHoveringSelectedInstance =
+    selectedInstanceAddress?.[0] === hoveredInstanceId;
   const instance = hoveredInstanceId
     ? instances.get(hoveredInstanceId)
     : undefined;

--- a/apps/builder/app/builder/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
@@ -18,7 +18,7 @@ import {
 } from "@webstudio-is/icons";
 import { useSubscribe } from "~/shared/pubsub";
 import { theme } from "@webstudio-is/design-system";
-import { selectedInstanceIdStore } from "~/shared/nano-states";
+import { selectedInstanceAddressStore } from "~/shared/nano-states";
 
 type Format =
   | "bold"
@@ -191,9 +191,9 @@ type TextToolbarProps = {
 
 export const TextToolbar = ({ publish }: TextToolbarProps) => {
   const [textToolbar] = useTextToolbarState();
-  const selectedInstanceId = useStore(selectedInstanceIdStore);
+  const selectedInstanceAddress = useStore(selectedInstanceAddressStore);
 
-  if (textToolbar == null || selectedInstanceId === undefined) {
+  if (textToolbar == null || selectedInstanceAddress === undefined) {
     return null;
   }
 

--- a/apps/builder/app/builder/features/workspace/workspace.tsx
+++ b/apps/builder/app/builder/features/workspace/workspace.tsx
@@ -2,7 +2,7 @@ import { useStore } from "@nanostores/react";
 import { theme, Box, Flex, Toaster } from "@webstudio-is/design-system";
 import { useCanvasWidth } from "~/builder/shared/nano-states";
 import type { Publish } from "~/shared/pubsub";
-import { selectedInstanceIdStore } from "~/shared/nano-states";
+import { selectedInstanceAddressStore } from "~/shared/nano-states";
 import {
   workspaceRectStore,
   zoomStore,
@@ -60,7 +60,7 @@ export const Workspace = ({
   const workspaceRef = useSetWorkspaceRect();
 
   const handleWorkspaceClick = () => {
-    selectedInstanceIdStore.set(undefined);
+    selectedInstanceAddressStore.set(undefined);
   };
 
   return (

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -16,13 +16,14 @@ import {
 import type { GetComponent } from "@webstudio-is/react-sdk";
 import {
   instancesStore,
-  selectedInstanceIdStore,
+  selectedInstanceAddressStore,
   useInstanceProps,
   useInstanceStyles,
   useTextEditingInstanceId,
 } from "~/shared/nano-states";
 import { useCssRules } from "~/canvas/shared/styles";
 import { SelectedInstanceConnector } from "./selected-instance-connector";
+import { getInstanceAddress } from "~/shared/tree-utils";
 
 const TextEditor = lazy(() => import("../text-editor"));
 
@@ -68,7 +69,7 @@ export const WebstudioComponentDev = ({
 
   const [editingInstanceId, setTextEditingInstanceId] =
     useTextEditingInstanceId();
-  const selectedInstanceId = useStore(selectedInstanceIdStore);
+  const selectedInstanceAddress = useStore(selectedInstanceAddressStore);
 
   const instanceProps = useInstanceProps(instance.id);
   const userProps = useMemo(() => {
@@ -84,7 +85,8 @@ export const WebstudioComponentDev = ({
     return result;
   }, [instanceProps]);
 
-  const isSelected = selectedInstanceId === instanceId;
+  // @todo compare instance addresses
+  const isSelected = selectedInstanceAddress?.[0] === instanceId;
 
   // Scroll the selected instance into view when selected from navigator.
   useEffect(() => {
@@ -172,9 +174,12 @@ export const WebstudioComponentDev = ({
             }
           });
         }}
+        // @todo provide instance address
         onSelectInstance={(instanceId) => {
           setTextEditingInstanceId(undefined);
-          selectedInstanceIdStore.set(instanceId);
+          selectedInstanceAddressStore.set(
+            getInstanceAddress(instancesStore.get(), instanceId)
+          );
         }}
       />
     </Suspense>

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -5,7 +5,7 @@ import { addGlobalRules } from "@webstudio-is/project";
 import {
   assetsStore,
   isPreviewModeStore,
-  selectedInstanceIdStore,
+  selectedInstanceAddressStore,
   useBreakpoints,
 } from "~/shared/nano-states";
 import type { StyleDecl } from "@webstudio-is/project-build";
@@ -263,7 +263,8 @@ const setCssVar = (id: string, property: string, value?: StyleValue) => {
 
 const useUpdateStyle = () => {
   useSubscribe("updateStyle", ({ id, updates }) => {
-    const selectedInstanceId = selectedInstanceIdStore.get();
+    const selectedInstanceAddress = selectedInstanceAddressStore.get();
+    const selectedInstanceId = selectedInstanceAddress?.[0];
     // Only update styles if they match the selected instance
     // It can potentially happen that we selected a difference instance right after we changed the style in style panel.
     if (id !== selectedInstanceId) {

--- a/apps/builder/app/canvas/shared/use-shortcuts.ts
+++ b/apps/builder/app/canvas/shared/use-shortcuts.ts
@@ -3,7 +3,7 @@ import { getComponentMeta } from "@webstudio-is/react-sdk";
 import { shortcuts, options } from "~/shared/shortcuts";
 import { publish, useSubscribe } from "~/shared/pubsub";
 import {
-  selectedInstanceIdStore,
+  selectedInstanceAddressStore,
   selectedInstanceStore,
   useTextEditingInstanceId,
   isPreviewModeStore,
@@ -40,8 +40,8 @@ export const useShortcuts = () => {
   useHotkeys(
     "esc",
     () => {
-      const selectedInstanceId = selectedInstanceIdStore.get();
-      if (selectedInstanceId === undefined) {
+      const selectedInstanceAddress = selectedInstanceAddressStore.get();
+      if (selectedInstanceAddress === undefined) {
         return;
       }
       // Since we are in text editing mode, we want to first exit that mode without unselecting the instance.
@@ -49,7 +49,7 @@ export const useShortcuts = () => {
         setEditingInstanceId(undefined);
         return;
       }
-      selectedInstanceIdStore.set(undefined);
+      selectedInstanceAddressStore.set(undefined);
     },
     { ...options, enableOnContentEditable: true },
     [editingInstanceId]

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -11,7 +11,7 @@ import {
 import {
   propsStore,
   stylesStore,
-  selectedInstanceIdStore,
+  selectedInstanceAddressStore,
   styleSourceSelectionsStore,
   styleSourcesStore,
   instancesIndexStore,
@@ -126,12 +126,19 @@ export const mimeType = "application/json";
 
 export const onPaste = (clipboardData: string) => {
   const data = parse(clipboardData);
-  if (data === undefined) {
+  const selectedPage = selectedPageStore.get();
+  if (data === undefined || selectedPage === undefined) {
     return;
   }
+  // paste to the root if nothing is selected
+  const instanceAddress = selectedInstanceAddressStore.get() ?? [
+    selectedPage.rootInstanceId,
+  ];
+  const [targetInstanceId] = instanceAddress;
   const dropTarget = findClosestDroppableTarget(
     instancesIndexStore.get(),
-    selectedInstanceIdStore.get()
+    // @todo accept instance address
+    targetInstanceId
   );
   store.createTransaction(
     [
@@ -162,16 +169,20 @@ export const onPaste = (clipboardData: string) => {
 
       // first item is guaranteed root of copied tree
       const copiedRootInstanceId = Array.from(copiedInstanceIds.values())[0];
-      selectedInstanceIdStore.set(copiedRootInstanceId);
+      selectedInstanceAddressStore.set([
+        copiedRootInstanceId,
+        ...instanceAddress,
+      ]);
     }
   );
 };
 
 export const onCopy = () => {
-  const selectedInstanceId = selectedInstanceIdStore.get();
-  if (selectedInstanceId === undefined) {
+  const selectedInstanceAddress = selectedInstanceAddressStore.get();
+  if (selectedInstanceAddress === undefined) {
     return;
   }
+  const [selectedInstanceId] = selectedInstanceAddress;
   const data = getTreeData(selectedInstanceId);
   if (data === undefined) {
     return;
@@ -180,20 +191,21 @@ export const onCopy = () => {
 };
 
 export const onCut = () => {
-  const selectedInstanceId = selectedInstanceIdStore.get();
+  const selectedInstanceAddress = selectedInstanceAddressStore.get();
+  if (selectedInstanceAddress === undefined) {
+    return;
+  }
+  const [selectedInstanceId] = selectedInstanceAddress;
   const rootInstanceId = selectedPageStore.get()?.rootInstanceId;
   // @todo tell user they can't delete root
-  if (
-    selectedInstanceId === undefined ||
-    selectedInstanceId === rootInstanceId
-  ) {
+  if (selectedInstanceId === rootInstanceId) {
     return;
   }
   const data = getTreeData(selectedInstanceId);
   if (data === undefined) {
     return;
   }
-  deleteInstance(selectedInstanceId);
+  deleteInstance(selectedInstanceAddress);
   if (data === undefined) {
     return;
   }

--- a/apps/builder/app/shared/copy-paste/plugin-markdown.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-markdown.ts
@@ -16,7 +16,8 @@ import {
   instancesIndexStore,
   instancesStore,
   propsStore,
-  selectedInstanceIdStore,
+  selectedInstanceAddressStore,
+  selectedPageStore,
 } from "../nano-states";
 
 const micromarkOptions = { extensions: [gfm()] };
@@ -207,13 +208,19 @@ export const parse = (clipboardData: string, options?: Options) => {
 
 export const onPaste = (clipboardData: string) => {
   const data = parse(clipboardData);
-  if (data === undefined) {
+  const selectedPage = selectedPageStore.get();
+  if (data === undefined || selectedPage === undefined) {
     return;
   }
-
+  // paste to the root if nothing is selected
+  const instanceAddress = selectedInstanceAddressStore.get() ?? [
+    selectedPage.rootInstanceId,
+  ];
+  const [targetInstanceId] = instanceAddress;
   const dropTarget = findClosestDroppableTarget(
     instancesIndexStore.get(),
-    selectedInstanceIdStore.get()
+    // @todo accept instance address
+    targetInstanceId
   );
   store.createTransaction([instancesStore, propsStore], (instances, props) => {
     insertInstancesMutable(instances, data.instances, data.rootIds, dropTarget);

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -33,7 +33,7 @@ import type {
 } from "~/builder/shared/assets";
 import { useSyncInitializeOnce } from "../hook-utils";
 import { shallowComputed } from "../store-utils";
-import { createInstancesIndex } from "../tree-utils";
+import { createInstancesIndex, type InstanceAddress } from "../tree-utils";
 
 const useValue = <T>(atom: WritableAtom<T>) => {
   const value = useStore(atom);
@@ -304,15 +304,17 @@ export const useSetAssets = (assets: Asset[]) => {
   });
 };
 
-export const selectedInstanceIdStore = atom<undefined | Instance["id"]>(
+export const selectedInstanceAddressStore = atom<undefined | InstanceAddress>(
   undefined
 );
+
 export const selectedInstanceStore = computed(
-  [instancesIndexStore, selectedInstanceIdStore],
-  (instancesIndex, selectedInstanceId) => {
-    if (selectedInstanceId === undefined) {
+  [instancesIndexStore, selectedInstanceAddressStore],
+  (instancesIndex, selectedInstanceAddress) => {
+    if (selectedInstanceAddress === undefined) {
       return;
     }
+    const [selectedInstanceId] = selectedInstanceAddress;
     return instancesIndex.instancesById.get(selectedInstanceId);
   }
 );
@@ -320,12 +322,13 @@ export const selectedInstanceStore = computed(
 export const selectedInstanceBrowserStyleStore = atom<undefined | Style>();
 
 export const selectedInstanceStyleSourcesStore = computed(
-  [styleSourceSelectionsStore, styleSourcesStore, selectedInstanceIdStore],
-  (styleSourceSelections, styleSources, selectedInstanceId) => {
+  [styleSourceSelectionsStore, styleSourcesStore, selectedInstanceAddressStore],
+  (styleSourceSelections, styleSources, selectedInstanceAddress) => {
     const selectedInstanceStyleSources: StyleSource[] = [];
-    if (selectedInstanceId === undefined) {
+    if (selectedInstanceAddress === undefined) {
       return selectedInstanceStyleSources;
     }
+    const [selectedInstanceId] = selectedInstanceAddress;
     const styleSourceIds =
       styleSourceSelections.get(selectedInstanceId)?.values ?? [];
     let hasLocal = false;

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -13,7 +13,7 @@ import {
   styleSourceSelectionsStore,
   selectedPageIdStore,
   assetContainersStore,
-  selectedInstanceIdStore,
+  selectedInstanceAddressStore,
   selectedInstanceBrowserStyleStore,
   hoveredInstanceIdStore,
   hoveredInstanceOutlineStore,
@@ -60,7 +60,7 @@ export const registerContainers = () => {
   // synchronize whole states
   clientStores.set("selectedPageId", selectedPageIdStore);
   clientStores.set("assetContainers", assetContainersStore);
-  clientStores.set("selectedInstanceId", selectedInstanceIdStore);
+  clientStores.set("selectedInstanceAddress", selectedInstanceAddressStore);
   clientStores.set(
     "selectedInstanceBrowserStyle",
     selectedInstanceBrowserStyleStore


### PR DESCRIPTION
With slots there can be same ids in one tree so we need new way to address instances. Here I propose the list from target instance to the root.

Now instead of computing parents by normalized tree (one instance of slot can have many parents) we just access already computed list from rendered tree.

This address can be computed when user click in dom which can be traversed or it can be passed top-down with props.

The main con of this approach is collaboration. Reparanted instances on by one user makes "selected address" stale. Though we have similar situation with single id when instance is deleted.

Isolated mode for slots/components will make this problem less noticable.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
