### PR TITLE
Hide background layers

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
@@ -15,7 +15,6 @@ import {
   EyeconClosedIcon,
   SubtractIcon,
 } from "@webstudio-is/icons";
-import { useState } from "react";
 import { PropertyName } from "../../shared/property-name";
 import type { StyleInfo } from "../../shared/style-info";
 import { ColorControl } from "../../controls/color/color-control";
@@ -39,7 +38,28 @@ const Layer = (props: {
   deleteProperty: DeleteBackgroundProperty;
   deleteLayer: () => void;
 }) => {
-  const [hidden, setHidden] = useState(false);
+  const backgrounImageStyle = props.layerStyle.backgroundImage?.value;
+  const hidden =
+    backgrounImageStyle?.type === "image" ||
+    backgrounImageStyle?.type === "unparsed"
+      ? Boolean(backgrounImageStyle.hidden)
+      : false;
+
+  const handleHiddenChange = (hidden: boolean) => {
+    if (
+      backgrounImageStyle?.type === "image" ||
+      backgrounImageStyle?.type === "unparsed"
+    ) {
+      props.setProperty("backgroundImage")({
+        ...backgrounImageStyle,
+        hidden,
+      });
+    }
+  };
+
+  const eyeButtonDisabled =
+    backgrounImageStyle?.type !== "image" &&
+    backgrounImageStyle?.type !== "unparsed";
 
   return (
     <FloatingPanel
@@ -66,8 +86,9 @@ const Layer = (props: {
         buttons={
           <>
             <SmallToggleButton
+              disabled={eyeButtonDisabled}
               pressed={hidden}
-              onPressedChange={setHidden}
+              onPressedChange={handleHiddenChange}
               variant="normal"
               tabIndex={0}
               icon={hidden ? <EyeconClosedIcon /> : <EyeconOpenIcon />}

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
@@ -39,7 +39,7 @@ const Layer = (props: {
   deleteLayer: () => void;
 }) => {
   const backgrounImageStyle = props.layerStyle.backgroundImage?.value;
-  const hidden =
+  const isHidden =
     backgrounImageStyle?.type === "image" ||
     backgrounImageStyle?.type === "unparsed"
       ? Boolean(backgrounImageStyle.hidden)
@@ -57,7 +57,7 @@ const Layer = (props: {
     }
   };
 
-  const eyeButtonDisabled =
+  const canDisable =
     backgrounImageStyle?.type !== "image" &&
     backgrounImageStyle?.type !== "unparsed";
 
@@ -82,16 +82,16 @@ const Layer = (props: {
           />
         }
         thumbnail={<LayerThumbnail layerStyle={props.layerStyle} />}
-        hidden={hidden}
+        hidden={isHidden}
         buttons={
           <>
             <SmallToggleButton
-              disabled={eyeButtonDisabled}
-              pressed={hidden}
+              disabled={canDisable}
+              pressed={isHidden}
               onPressedChange={handleHiddenChange}
               variant="normal"
               tabIndex={0}
-              icon={hidden ? <EyeconClosedIcon /> : <EyeconOpenIcon />}
+              icon={isHidden ? <EyeconClosedIcon /> : <EyeconOpenIcon />}
             />
 
             <SmallIconButton

--- a/packages/css-data/src/schema.ts
+++ b/packages/css-data/src/schema.ts
@@ -51,6 +51,8 @@ export type KeywordValue = z.infer<typeof KeywordValue>;
 export const UnparsedValue = z.object({
   type: z.literal("unparsed"),
   value: z.string(),
+  // For the builder we want to be able to hide background-image
+  hidden: z.boolean().optional(),
 });
 
 const FontFamilyValue = z.object({
@@ -71,6 +73,8 @@ export type RgbValue = z.infer<typeof RgbValue>;
 export const ImageValue = z.object({
   type: z.literal("image"),
   value: z.object({ type: z.literal("asset"), value: ImageAsset }),
+  // For the builder we want to be able to hide images
+  hidden: z.boolean().optional(),
 });
 
 export type ImageValue = z.infer<typeof ImageValue>;

--- a/packages/css-engine/src/core/to-value.ts
+++ b/packages/css-engine/src/core/to-value.ts
@@ -67,6 +67,8 @@ export const toValue = (
   if (value.type === "image") {
     if (isEditMode && value.hidden) {
       // We assume that property is background-image and use this to hide background layers
+      // In the future we might want to have a more generic way to hide values
+      // i.e. have knowledge about property-name, as none is property specific
       return "none";
     }
 
@@ -77,6 +79,8 @@ export const toValue = (
   if (value.type === "unparsed") {
     if (isEditMode && value.hidden) {
       // We assume that property is background-image and use this to hide background layers
+      // In the future we might want to have a more generic way to hide values
+      // i.e. have knowledge about property-name, as none is property specific
       return "none";
     }
 

--- a/packages/css-engine/src/core/to-value.ts
+++ b/packages/css-engine/src/core/to-value.ts
@@ -16,7 +16,8 @@ const assertUnreachable = (_arg: never, errorMessage: string) => {
 
 export const toValue = (
   value?: StyleValue,
-  options: ToCssOptions = defaultOptions
+  options: ToCssOptions = defaultOptions,
+  isEditMode?: boolean
 ): string => {
   if (value === undefined) {
     return "";
@@ -36,9 +37,11 @@ export const toValue = (
     return [...value.value, DEFAULT_FONT_FALLBACK].join(", ");
   }
   if (value.type === "var") {
+    // We use var() in edit mode only
+    const isEditMode = true;
     const fallbacks = [];
     for (const fallback of value.fallbacks) {
-      fallbacks.push(toValue(fallback, options));
+      fallbacks.push(toValue(fallback, options, isEditMode));
     }
     const fallbacksString =
       fallbacks.length > 0 ? `, ${fallbacks.join(", ")}` : "";
@@ -62,20 +65,34 @@ export const toValue = (
   }
 
   if (value.type === "image") {
+    if (isEditMode && value.hidden) {
+      // We assume that property is background-image and use this to hide background layers
+      return "none";
+    }
+
     // @todo image-set
     return `url(${value.value.value.path}) /* id=${value.value.value.id} */`;
   }
 
   if (value.type === "unparsed") {
+    if (isEditMode && value.hidden) {
+      // We assume that property is background-image and use this to hide background layers
+      return "none";
+    }
+
     return value.value;
   }
 
   if (value.type === "layers") {
-    return value.value.map((value) => toValue(value, options)).join(",");
+    return value.value
+      .map((value) => toValue(value, options, isEditMode))
+      .join(",");
   }
 
   if (value.type === "tuple") {
-    return value.value.map((value) => toValue(value, options)).join(" ");
+    return value.value
+      .map((value) => toValue(value, options, isEditMode))
+      .join(" ");
   }
 
   // Will give ts error in case of missing type

--- a/packages/project-build/src/schema/styles.ts
+++ b/packages/project-build/src/schema/styles.ts
@@ -14,6 +14,9 @@ import {
 const StoredImageValue = z.object({
   type: z.literal("image"),
   value: z.object({ type: z.literal("asset"), value: z.string() }),
+
+  // For the builder we want to be able to hide images
+  hidden: z.boolean().optional(),
 });
 
 const StoredLayersValue = z.object({


### PR DESCRIPTION
## Description

ref #877

Allows hiding background layers in edit mode, i.e. eye button now works

<img width="242" alt="image" src="https://user-images.githubusercontent.com/5077042/224558080-6fd5fa13-4e4b-424f-81ec-26456ba7e363.png">

One of the assumptions I made was that `var` is used only in edit mode https://github.com/webstudio-is/webstudio-builder/blob/7ae3ed003e4d7f7fc99038ccdde57b5fa634bbe1/packages/css-engine/src/core/to-value.ts#L41



## Steps for reproduction

Add backgrounds, hide/unhide them

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
