### PR TITLE
Create page on client

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
@@ -274,11 +274,10 @@ export const TabContent = (props: TabContentProps) => {
       <SettingsPanel isOpen={editingPageId !== undefined}>
         {editingPageId === newPageId && (
           <NewPageSettings
-            projectId={project.id}
             onClose={() => setEditingPageId(undefined)}
-            onSuccess={(page) => {
+            onSuccess={(pageId) => {
               setEditingPageId(undefined);
-              handleSelect(page.id);
+              handleSelect(pageId);
             }}
           />
         )}

--- a/apps/builder/app/routes/rest/patch.ts
+++ b/apps/builder/app/routes/rest/patch.ts
@@ -8,6 +8,7 @@ import {
   patchStyleSources,
   patchStyleSourceSelections,
   patchInstances,
+  patchPages,
 } from "@webstudio-is/project-build/server";
 import type { Project } from "@webstudio-is/project";
 import { createContext } from "~/shared/context.server";
@@ -36,7 +37,9 @@ export const action = async ({ request }: ActionArgs) => {
     for await (const change of transaction.changes) {
       const { namespace, patches } = change;
 
-      if (namespace === "instances") {
+      if (namespace === "pages") {
+        await patchPages({ buildId, projectId }, patches, context);
+      } else if (namespace === "instances") {
         await patchInstances({ buildId, projectId }, patches, context);
       } else if (namespace === "styleSourceSelections") {
         await patchStyleSourceSelections(

--- a/apps/builder/app/shared/pages/types.ts
+++ b/apps/builder/app/shared/pages/types.ts
@@ -1,8 +1,6 @@
 import type { Page } from "@webstudio-is/project-build";
 import type { FetcherData } from "~/shared/form-utils";
 
-export type CreatePageData = FetcherData<{ page: Page }>;
-
 export type EditPageData = FetcherData<{ page: Page }>;
 
 // eslint-disable-next-line @typescript-eslint/ban-types

--- a/packages/project-build/src/db/build.ts
+++ b/packages/project-build/src/db/build.ts
@@ -131,52 +131,6 @@ const createNewPageInstances = (): Build["instances"] => {
   ];
 };
 
-export const addPage = async ({
-  projectId,
-  buildId,
-  data,
-}: {
-  projectId: Project["id"];
-  buildId: Build["id"];
-  data: Pick<Page, "name" | "path"> &
-    Partial<Omit<Page, "id" | "name" | "path">>;
-}) => {
-  const build = await loadBuildById({ projectId, buildId });
-  const currentPages = build.pages;
-  const currentInstances = build.instances;
-
-  const instances = createNewPageInstances();
-  const [rootInstanceId] = instances[0];
-
-  const updatedPages = Pages.parse({
-    homePage: currentPages.homePage,
-    pages: [
-      ...currentPages.pages,
-      {
-        id: nanoid(),
-        rootInstanceId,
-        name: data.name,
-        path: data.path,
-        title: data.title ?? data.name,
-        meta: data.meta ?? {},
-      },
-    ],
-  } satisfies Pages);
-
-  const updatedBuild = await prisma.build.update({
-    where: {
-      id_projectId: { projectId, id: buildId },
-    },
-    data: {
-      pages: JSON.stringify(updatedPages),
-      instances: serializeInstances(
-        new Map([...currentInstances, ...instances])
-      ),
-    },
-  });
-  return parseBuild(updatedBuild);
-};
-
 export const editPage = async ({
   projectId,
   buildId,

--- a/packages/project-build/src/db/pages.ts
+++ b/packages/project-build/src/db/pages.ts
@@ -1,0 +1,42 @@
+import { applyPatches, type Patch } from "immer";
+import { type Project, type Build, prisma } from "@webstudio-is/prisma-client";
+import {
+  authorizeProject,
+  type AppContext,
+} from "@webstudio-is/trpc-interface/server";
+import { Pages } from "../schema/pages";
+
+export const patchPages = async (
+  { buildId, projectId }: { buildId: Build["id"]; projectId: Project["id"] },
+  patches: Array<Patch>,
+  context: AppContext
+) => {
+  const canEdit = await authorizeProject.hasProjectPermit(
+    { projectId, permit: "edit" },
+    context
+  );
+
+  if (canEdit === false) {
+    throw new Error("You don't have edit access to this project");
+  }
+
+  const build = await prisma.build.findUnique({
+    where: {
+      id_projectId: { projectId, id: buildId },
+    },
+  });
+  if (build === null) {
+    return;
+  }
+  const pages = Pages.parse(JSON.parse(build.pages));
+  const patchedPages = Pages.parse(applyPatches(pages, patches));
+
+  await prisma.build.update({
+    data: {
+      pages: JSON.stringify(patchedPages),
+    },
+    where: {
+      id_projectId: { projectId, id: buildId },
+    },
+  });
+};

--- a/packages/project-build/src/index.server.ts
+++ b/packages/project-build/src/index.server.ts
@@ -1,4 +1,5 @@
 export * from "./db/build";
+export * from "./db/pages";
 export * from "./db/breakpoints";
 export * from "./db/styles";
 export * from "./db/style-sources";


### PR DESCRIPTION
Newly created instance does not propagate to client because we no longer reload on navigating to new page.

Here moved page and root instance creation to client with patches.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @rpominov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
