### PR TITLE
Improve instance hovering

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/navigator/navigator.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/navigator/navigator.tsx
@@ -4,7 +4,7 @@ import { Flex } from "@webstudio-is/design-system";
 import type { Instance } from "@webstudio-is/project-build";
 import {
   selectedInstanceSelectorStore,
-  hoveredInstanceIdStore,
+  hoveredInstanceSelectorStore,
   useRootInstance,
   instancesStore,
 } from "~/shared/nano-states";
@@ -43,7 +43,13 @@ export const Navigator = ({ isClosable, onClose }: NavigatorProps) => {
   );
 
   const handleHover = useCallback((instance: Instance | undefined) => {
-    hoveredInstanceIdStore.set(instance?.id);
+    if (instance) {
+      const instances = instancesStore.get();
+      const instanceSelector = getInstanceSelector(instances, instance.id);
+      hoveredInstanceSelectorStore.set(instanceSelector);
+    } else {
+      hoveredInstanceSelectorStore.set(undefined);
+    }
   }, []);
 
   if (rootInstance === undefined) {

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/hovered-instance-outline.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/hovered-instance-outline.tsx
@@ -1,31 +1,27 @@
 import { useStore } from "@nanostores/react";
 import {
-  hoveredInstanceIdStore,
+  hoveredInstanceSelectorStore,
   hoveredInstanceOutlineStore,
-  instancesStore,
   selectedInstanceSelectorStore,
   useTextEditingInstanceId,
 } from "~/shared/nano-states";
+import { areInstanceSelectorsEqual } from "~/shared/tree-utils";
 import { Outline } from "./outline";
 import { Label } from "./label";
 
 export const HoveredInstanceOutline = () => {
   const selectedInstanceSelector = useStore(selectedInstanceSelectorStore);
-  const hoveredInstanceId = useStore(hoveredInstanceIdStore);
+  const hoveredInstanceSelector = useStore(hoveredInstanceSelectorStore);
   const instanceOutline = useStore(hoveredInstanceOutlineStore);
   const [textEditingInstanceId] = useTextEditingInstanceId();
-  const instances = useStore(instancesStore);
 
   const isEditingText = textEditingInstanceId !== undefined;
-  // @todo compare instance selectors
-  const isHoveringSelectedInstance =
-    selectedInstanceSelector?.[0] === hoveredInstanceId;
-  const instance = hoveredInstanceId
-    ? instances.get(hoveredInstanceId)
-    : undefined;
+  const isHoveringSelectedInstance = areInstanceSelectorsEqual(
+    selectedInstanceSelector,
+    hoveredInstanceSelector
+  );
 
   if (
-    instance === undefined ||
     instanceOutline === undefined ||
     isHoveringSelectedInstance ||
     isEditingText
@@ -35,7 +31,7 @@ export const HoveredInstanceOutline = () => {
 
   return (
     <Outline rect={instanceOutline.rect}>
-      <Label instance={instance} instanceRect={instanceOutline.rect} />
+      <Label instance={instanceOutline} instanceRect={instanceOutline.rect} />
     </Outline>
   );
 };

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -34,10 +34,10 @@ import { usePublishScrollState } from "./shared/use-publish-scroll-state";
 import { useDragAndDrop } from "./shared/use-drag-drop";
 import { useSubscribeBuilderReady } from "./shared/use-builder-ready";
 import { useCopyPaste } from "~/shared/copy-paste";
-import { useHoveredInstanceConnector } from "./hovered-instance-connector";
 import { setDataCollapsed, subscribeCollapsedToPubSub } from "./collapsed";
 import { useWindowResizeDebounced } from "~/shared/dom-hooks";
 import { subscribeInstanceSelection } from "./instance-selection";
+import { subscribeInstanceHovering } from "./instance-hovering";
 
 registerContainers();
 
@@ -82,9 +82,9 @@ const DesignMode = () => {
   // @todo we need to forward the events from canvas to builder and avoid importing this
   // in both places
   useCopyPaste();
-  useHoveredInstanceConnector();
 
   useEffect(subscribeInstanceSelection, []);
+  useEffect(subscribeInstanceHovering, []);
 
   return null;
 };

--- a/apps/builder/app/canvas/instance-selection.ts
+++ b/apps/builder/app/canvas/instance-selection.ts
@@ -1,4 +1,5 @@
-import { getComponentMeta, idAttribute } from "@webstudio-is/react-sdk";
+import { getComponentMeta } from "@webstudio-is/react-sdk";
+import { getInstanceSelectorFromElement } from "~/shared/dom-utils";
 import {
   instancesStore,
   selectedInstanceSelectorStore,
@@ -15,24 +16,6 @@ declare module "~/shared/pubsub" {
     clickCanvas: undefined;
   }
 }
-
-// traverse dom to the root and find all instances
-const getInstanceSelectorFromElement = (element: Element) => {
-  const instanceSelector: InstanceSelector = [];
-  let matched: undefined | Element =
-    element.closest(`[${idAttribute}]`) ?? undefined;
-  while (matched) {
-    const instanceId = matched.getAttribute(idAttribute) ?? undefined;
-    if (instanceId !== undefined) {
-      instanceSelector.push(instanceId);
-    }
-    matched = matched.parentElement?.closest(`[${idAttribute}]`) ?? undefined;
-  }
-  if (instanceSelector.length === 0) {
-    return;
-  }
-  return instanceSelector;
-};
 
 const findClosestRichTextInstanceSelector = (
   instanceSelector: InstanceSelector

--- a/apps/builder/app/shared/dom-utils.ts
+++ b/apps/builder/app/shared/dom-utils.ts
@@ -1,5 +1,6 @@
 import type { Instance } from "@webstudio-is/project-build";
 import { idAttribute } from "@webstudio-is/react-sdk";
+import type { InstanceSelector } from "./tree-utils";
 
 export const getInstanceElementById = (id: Instance["id"]) => {
   return document.querySelector(`[${idAttribute}="${id}"]`);
@@ -9,4 +10,33 @@ export const getInstanceIdFromElement = (
   element: Element
 ): Instance["id"] | undefined => {
   return element.getAttribute(idAttribute) ?? undefined;
+};
+
+// traverse dom to the root and find all instances
+export const getInstanceSelectorFromElement = (element: Element) => {
+  const instanceSelector: InstanceSelector = [];
+  let matched: undefined | Element =
+    element.closest(`[${idAttribute}]`) ?? undefined;
+  while (matched) {
+    const instanceId = matched.getAttribute(idAttribute) ?? undefined;
+    if (instanceId !== undefined) {
+      instanceSelector.push(instanceId);
+    }
+    matched = matched.parentElement?.closest(`[${idAttribute}]`) ?? undefined;
+  }
+  if (instanceSelector.length === 0) {
+    return;
+  }
+  return instanceSelector;
+};
+
+export const getElementByInstanceSelector = (
+  instanceSelector: InstanceSelector | Readonly<InstanceSelector>
+) => {
+  // query instance from root to target
+  const domSelector = instanceSelector
+    .map((id) => `[${idAttribute}="${id}"]`)
+    .reverse()
+    .join(" ");
+  return document.querySelector(domSelector) ?? undefined;
 };

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -371,11 +371,11 @@ export const selectedStyleSourceStore = computed(
   }
 );
 
-export const hoveredInstanceIdStore = atom<undefined | Instance["id"]>(
+export const hoveredInstanceSelectorStore = atom<undefined | InstanceSelector>(
   undefined
 );
 export const hoveredInstanceOutlineStore = atom<
-  undefined | { instanceId: Instance["id"]; rect: DOMRect }
+  undefined | { label?: string; component: string; rect: DOMRect }
 >(undefined);
 
 export const isPreviewModeStore = atom<boolean>(false);

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -15,7 +15,7 @@ import {
   assetContainersStore,
   selectedInstanceSelectorStore,
   selectedInstanceBrowserStyleStore,
-  hoveredInstanceIdStore,
+  hoveredInstanceSelectorStore,
   hoveredInstanceOutlineStore,
   isPreviewModeStore,
 } from "~/shared/nano-states";
@@ -65,9 +65,9 @@ export const registerContainers = () => {
     "selectedInstanceBrowserStyle",
     selectedInstanceBrowserStyleStore
   );
-  clientStores.set("hoveredInstanceIdStore", hoveredInstanceIdStore);
-  clientStores.set("hoveredInstanceOutlineStore", hoveredInstanceOutlineStore);
-  clientStores.set("isPreviewModeStore", isPreviewModeStore);
+  clientStores.set("hoveredInstanceSelector", hoveredInstanceSelectorStore);
+  clientStores.set("hoveredInstanceOutline", hoveredInstanceOutlineStore);
+  clientStores.set("isPreviewMode", isPreviewModeStore);
   for (const [name, store] of synchronizedBreakpointsStores) {
     clientStores.set(name, store);
   }

--- a/apps/builder/app/shared/tree-utils.ts
+++ b/apps/builder/app/shared/tree-utils.ts
@@ -34,6 +34,16 @@ export const getAncestorInstanceSelector = (
   return instanceSelector.slice(ancestorIndex);
 };
 
+export const areInstanceSelectorsEqual = (
+  left?: InstanceSelector,
+  right?: InstanceSelector
+) => {
+  if (left === undefined || right === undefined) {
+    return false;
+  }
+  return left.join(",") === right.join(",");
+};
+
 // this utility is temporary solution to compute instance selectors
 // before all logic is migrated to get it from rendered context
 // @todo should be deleted before adding slots


### PR DESCRIPTION
Label again started flickering because hovered instance and hovered outline store changes have delay in between. Solution as before is to provide all info with outline. Here I just passed both label and component to get the shape for getInstanceLabel.

Removed react hook from instance hovering and refactored with instance selectors.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
