### PR TITLE
Add simple background parser

### DIFF
--- a/@types/css-tree.d.ts
+++ b/@types/css-tree.d.ts
@@ -4,6 +4,19 @@ declare module "css-tree" {
     options?: import("@types/css-tree").ParseOptions
   ): import("@types/css-tree").CssNode;
 
+  export function walk(
+    ast: import("@types/css-tree").CssNode,
+    options:
+      | import("@types/css-tree").WalkOptionsNoVisit
+      | import("@types/css-tree").EnterOrLeaveFn
+    // | import("@types/css-tree").WalkOptions
+  ): void;
+
+  export function generate(
+    ast: import("@types/css-tree").CssNode,
+    options?: import("@types/css-tree").GenerateOptions
+  ): string;
+
   type Match =
     | {
         syntax: { type: "Property"; name: string };

--- a/@types/css-tree.d.ts
+++ b/@types/css-tree.d.ts
@@ -9,7 +9,6 @@ declare module "css-tree" {
     options:
       | import("@types/css-tree").WalkOptionsNoVisit
       | import("@types/css-tree").EnterOrLeaveFn
-    // | import("@types/css-tree").WalkOptions
   ): void;
 
   export function generate(

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.stories.tsx
@@ -52,6 +52,9 @@ export const BackgroundContentStory = () => {
               currentStyle={currentStyle}
               deleteProperty={deleteProperty}
               setProperty={setProperty}
+              setBackgroundColor={(color) => {
+                setProperty("backgroundColor")(color);
+              }}
             />
           }
         >

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.stories.tsx
@@ -5,7 +5,7 @@ import {
   FloatingPanelProvider,
 } from "~/builder/shared/floating-panel";
 import { useRef, useState } from "react";
-import type { StyleValue } from "@webstudio-is/css-data";
+import type { SetProperty } from "../../shared/use-style-data";
 
 const defaultCurrentStyle = getLayerBackgroundStyleInfo(0, {
   backgroundImage: {
@@ -24,15 +24,20 @@ export const BackgroundContentStory = () => {
 
   const [currentStyle, setCurrentStyle] = useState(defaultCurrentStyle);
 
-  const setProperty = (propertyName: string) => (style: StyleValue) => {
-    setCurrentStyle({
-      ...currentStyle,
-      [propertyName]: {
-        value: style,
-        local: style,
-      },
-    });
-  };
+  const setProperty: SetProperty =
+    (propertyName: string) => (style, options) => {
+      if (options?.isEphemeral) {
+        return;
+      }
+
+      setCurrentStyle({
+        ...currentStyle,
+        [propertyName]: {
+          value: style,
+          local: style,
+        },
+      });
+    };
 
   return (
     <>

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.tsx
@@ -3,7 +3,7 @@
  * as of now just implement feature parity with old backgrounds section
  **/
 
-import type { StyleValue } from "@webstudio-is/css-data";
+import type { RgbValue, StyleValue } from "@webstudio-is/css-data";
 import {
   theme,
   Flex,
@@ -48,6 +48,7 @@ type BackgroundContentProps = {
   currentStyle: StyleInfo;
   setProperty: SetBackgroundProperty;
   deleteProperty: DeleteBackgroundProperty;
+  setBackgroundColor: (color: RgbValue) => void;
 };
 
 const safeDeleteProperty = (
@@ -192,6 +193,7 @@ export const BackgroundContent = (props: BackgroundContentProps) => {
                 setProperty={setProperty}
                 deleteProperty={deleteProperty}
                 currentStyle={props.currentStyle}
+                setBackgroundColor={props.setBackgroundColor}
               />
             </Flex>
           )}

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
@@ -1,4 +1,4 @@
-import type { InvalidValue } from "@webstudio-is/css-data";
+import type { InvalidValue, RgbValue } from "@webstudio-is/css-data";
 import { TextArea, theme } from "@webstudio-is/design-system";
 import { useEffect, useRef, useState } from "react";
 import { parseCssValue } from "../../shared/parse-css-value";
@@ -11,7 +11,9 @@ type IntermediateValue = {
 };
 
 export const BackgroundGradient = (
-  props: Omit<ControlProps, "property" | "items">
+  props: Omit<ControlProps, "property" | "items"> & {
+    setBackgroundColor: (color: RgbValue) => void;
+  }
 ) => {
   const property = "backgroundImage";
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
@@ -55,11 +57,13 @@ export const BackgroundGradient = (
       return;
     }
 
-    const { backgroundImage /*, backgroundColor */ } = parseBackground(
+    const { backgroundImage, backgroundColor } = parseBackground(
       intermediateValue.value
     );
 
-    // @todo set backgroundColor
+    if (backgroundColor !== undefined) {
+      props.setBackgroundColor(backgroundColor);
+    }
 
     if (backgroundImage.type !== "invalid") {
       setIntermediateValue(undefined);

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
@@ -36,8 +36,9 @@ export const BackgroundGradient = (
       value,
     });
 
-    // This is not same behaviour as CssValueInput has
-    // But it's so good to see immediate result on gradient changes until we will have a good gradient tool
+    // This doesn't have the same behavior as CssValueInput.
+    // However, it's great to see the immediate results when making gradient changes,
+    // especially until we have a better gradient tool.
     const newValue = parseCssValue(property, value);
 
     if (newValue.type === "unparsed") {
@@ -45,7 +46,7 @@ export const BackgroundGradient = (
       return;
     }
 
-    // Set edited layer as none, to see immediate result
+    // Set backgroundImage at layer to none if it's invalid
     props.setProperty(property)(
       { type: "keyword", value: "none" },
       { isEphemeral: true }

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
@@ -21,7 +21,6 @@ export const BackgroundGradient = (
   const styleInfo = props.currentStyle[property];
   const styleValue = styleInfo?.value;
 
-  // In gradient section we want to show gradient data only
   const [intermediateValue, setIntermediateValue] = useState<
     IntermediateValue | InvalidValue | undefined
   >(undefined);

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-gradient.tsx
@@ -1,42 +1,75 @@
+import type { InvalidValue } from "@webstudio-is/css-data";
 import { TextArea, theme } from "@webstudio-is/design-system";
 import { useEffect, useRef, useState } from "react";
 import { parseCssValue } from "../../shared/parse-css-value";
 import type { ControlProps } from "../../style-sections";
+import { parseBackground } from "./background-parser";
+
+type IntermediateValue = {
+  type: "intermediate";
+  value: string;
+};
 
 export const BackgroundGradient = (
   props: Omit<ControlProps, "property" | "items">
 ) => {
   const property = "backgroundImage";
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
   const styleInfo = props.currentStyle[property];
   const styleValue = styleInfo?.value;
 
   // In gradient section we want to show gradient data only
   const [intermediateValue, setIntermediateValue] = useState<
-    string | undefined
+    IntermediateValue | InvalidValue | undefined
   >(undefined);
 
-  const value =
-    intermediateValue ??
+  const textAreaValue =
+    intermediateValue?.value ??
     (styleValue?.type === "unparsed" ? styleValue.value : undefined);
 
-  const handleChange = (value: string, isEphemeral: boolean) => {
-    setIntermediateValue(isEphemeral ? value : undefined);
+  const handleChange = (value: string) => {
+    setIntermediateValue({
+      type: "intermediate",
+      value,
+    });
 
+    // This is not same behaviour as CssValueInput has
+    // But it's so good to see immediate result on gradient changes until we will have a good gradient tool
     const newValue = parseCssValue(property, value);
 
     if (newValue.type === "unparsed") {
-      props.setProperty(property)(newValue, { isEphemeral });
+      props.setProperty(property)(newValue, { isEphemeral: true });
       return;
     }
 
-    props.deleteProperty(property, { isEphemeral });
+    // Set edited layer as none, to see immediate result
+    props.setProperty(property)(
+      { type: "keyword", value: "none" },
+      { isEphemeral: true }
+    );
   };
 
   const handleOnComplete = () => {
-    if (intermediateValue !== undefined) {
-      handleChange(intermediateValue, false);
+    if (intermediateValue === undefined) {
+      return;
     }
+
+    const { backgroundImage /*, backgroundColor */ } = parseBackground(
+      intermediateValue.value
+    );
+
+    // @todo set backgroundColor
+
+    if (backgroundImage.type !== "invalid") {
+      setIntermediateValue(undefined);
+      props.setProperty(property)(backgroundImage);
+      return;
+    }
+
+    // Set invalid state
+    setIntermediateValue({ type: "invalid", value: intermediateValue.value });
+    props.deleteProperty(property, { isEphemeral: true });
   };
 
   const handleOnCompleteRef = useRef(handleOnComplete);
@@ -51,18 +84,30 @@ export const BackgroundGradient = (
 
   return (
     <TextArea
+      ref={textAreaRef}
       css={{ minHeight: theme.spacing[14] }}
       rows={2}
       name="description"
       disabled={props.disabled}
-      value={value}
+      value={textAreaValue ?? ""}
+      state={intermediateValue?.type === "invalid" ? "invalid" : undefined}
       onChange={(event) => {
-        handleChange(event.target.value, true);
+        handleChange(event.target.value);
       }}
       onBlur={handleOnComplete}
       onKeyDown={(event) => {
         if (event.key === "Enter") {
           handleOnComplete();
+          event.preventDefault();
+        }
+
+        if (event.key === "Escape") {
+          if (intermediateValue === undefined) {
+            return;
+          }
+          props.deleteProperty(property, { isEphemeral: true });
+          setIntermediateValue(undefined);
+          event.preventDefault();
         }
       }}
     />

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.test.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.test.ts
@@ -210,6 +210,119 @@ describe("setLayerProperty", () => {
         styleInfo.backgroundImage?.value.value[0].value
     ).toEqual("none");
   });
+
+  test("should insert mutiple layers", () => {
+    const cascaded: NonNullable<StyleInfo["backgroundImage"]>["cascaded"] = {
+      breakpointId: "mobile",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "unparsed",
+            value: "linear-gradient(red, blue)",
+          },
+          {
+            type: "unparsed",
+            value: "linear-gradient(yellow, red)",
+          },
+        ],
+      },
+    };
+    const styleInfo: StyleInfo = {
+      backgroundImage: {
+        cascaded,
+        value: cascaded.value,
+      },
+    };
+
+    let published = false;
+
+    const createBatchUpdate: CreateBatchUpdate = () => ({
+      setProperty:
+        (propertyName: StyleProperty) => (newValue: string | StyleValue) => {
+          if (typeof newValue === "string") {
+            throw new Error("string is deprecated");
+          }
+
+          if (newValue.type !== "layers") {
+            throw new Error("newValue.type !== layers");
+          }
+
+          styleInfo[propertyName] = { value: newValue, local: newValue };
+        },
+      deleteProperty: (propertyName: string) => {
+        // not used
+      },
+      publish: (options?: unknown) => {
+        published = true;
+      },
+    });
+
+    const setProperty = setLayerProperty(1, styleInfo, createBatchUpdate);
+
+    setProperty("backgroundImage")({
+      type: "layers",
+      value: [
+        {
+          type: "unparsed",
+          value: "linear-gradient(blue, blue)",
+        },
+      ],
+    });
+
+    expect(published).toBe(true);
+
+    expect(styleInfo.backgroundImage?.value.type).toEqual("layers");
+    expect(styleInfo.backgroundImage?.value).toMatchInlineSnapshot(`
+      {
+        "type": "layers",
+        "value": [
+          {
+            "type": "unparsed",
+            "value": "linear-gradient(red, blue)",
+          },
+          {
+            "type": "unparsed",
+            "value": "linear-gradient(blue, blue)",
+          },
+        ],
+      }
+    `);
+
+    setProperty("backgroundImage")({
+      type: "layers",
+      value: [
+        {
+          type: "unparsed",
+          value: "linear-gradient(green, blue)",
+        },
+        {
+          type: "unparsed",
+          value: "linear-gradient(yellow, blue)",
+        },
+      ],
+    });
+
+    expect(styleInfo.backgroundImage?.value).toMatchInlineSnapshot(`
+      {
+        "type": "layers",
+        "value": [
+          {
+            "type": "unparsed",
+            "value": "linear-gradient(red, blue)",
+          },
+          {
+            "type": "unparsed",
+            "value": "linear-gradient(green, blue)",
+          },
+          {
+            "type": "unparsed",
+            "value": "linear-gradient(yellow, blue)",
+          },
+        ],
+      }
+    `);
+  });
 });
 
 describe("deleteLayer", () => {

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.test.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.test.ts
@@ -3,6 +3,7 @@ import {
   setLayerProperty,
   addLayer,
   swapLayers,
+  deleteLayer,
 } from "./background-layers";
 
 import { describe, test, expect } from "@jest/globals";
@@ -36,9 +37,18 @@ describe("setLayerProperty", () => {
             throw new Error("newValue.type !== layers");
           }
 
-          changedProps.push([propertyName, newValue]);
+          const index = changedProps.findIndex(
+            ([property]) => property === propertyName
+          );
 
           styleInfo[propertyName] = { value: newValue, local: newValue };
+
+          if (index !== -1) {
+            changedProps[index] = [propertyName, newValue];
+            return;
+          }
+
+          changedProps.push([propertyName, newValue]);
         },
       deleteProperty: (propertyName: string) => {
         // not used
@@ -150,9 +160,18 @@ describe("setLayerProperty", () => {
             throw new Error("newValue.type !== layers");
           }
 
-          changedProps.push([propertyName, newValue]);
+          const index = changedProps.findIndex(
+            ([property]) => property === propertyName
+          );
 
           styleInfo[propertyName] = { value: newValue, local: newValue };
+
+          if (index !== -1) {
+            changedProps[index] = [propertyName, newValue];
+            return;
+          }
+
+          changedProps.push([propertyName, newValue]);
         },
       deleteProperty: (propertyName: string) => {
         // not used
@@ -184,7 +203,78 @@ describe("setLayerProperty", () => {
     expect(
       changedProps.map((changedProp) => changedProp[1].value.length)
     ).toEqual(layeredBackgroundProps.map(() => 3));
+
+    expect(
+      styleInfo.backgroundImage?.value.type === "layers" &&
+        styleInfo.backgroundImage?.value.value[0].type === "keyword" &&
+        styleInfo.backgroundImage?.value.value[0].value
+    ).toEqual("none");
   });
+});
+
+describe("deleteLayer", () => {
+  const cascaded: NonNullable<StyleInfo["backgroundImage"]>["cascaded"] = {
+    breakpointId: "mobile",
+    value: {
+      type: "layers",
+      value: [
+        {
+          type: "unparsed",
+          value: "linear-gradient(red, blue)",
+        },
+        {
+          type: "unparsed",
+          value: "linear-gradient(yellow, red)",
+        },
+      ],
+    },
+  };
+  const styleInfo: StyleInfo = {
+    backgroundImage: {
+      cascaded,
+      value: cascaded.value,
+    },
+  };
+
+  let published = false;
+  const deletedProperties = new Set<string>();
+
+  const createBatchUpdate: CreateBatchUpdate = () => ({
+    setProperty:
+      (propertyName: StyleProperty) => (newValue: string | StyleValue) => {
+        if (typeof newValue === "string") {
+          throw new Error("string is deprecated");
+        }
+
+        if (newValue.type !== "layers") {
+          throw new Error("newValue.type !== layers");
+        }
+
+        styleInfo[propertyName] = { value: newValue, local: newValue };
+      },
+    deleteProperty: (propertyName: string) => {
+      // not used
+      deletedProperties.add(propertyName);
+    },
+    publish: (options?: unknown) => {
+      published = true;
+    },
+  });
+
+  deleteLayer(0, styleInfo, createBatchUpdate)();
+
+  expect(published).toBe(true);
+
+  expect(styleInfo.backgroundImage?.value).toEqual({
+    type: "layers",
+    value: [{ type: "unparsed", value: "linear-gradient(yellow, red)" }],
+  });
+
+  expect(deletedProperties.size).toBe(0);
+
+  deleteLayer(0, styleInfo, createBatchUpdate)();
+
+  expect(deletedProperties.size).toBe(layeredBackgroundProps.length);
 });
 
 describe("swapLayers", () => {

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.ts
@@ -153,7 +153,7 @@ const getLayersValue = (styleValue?: StyleValueInfo) => {
 };
 
 const isLayerStylesRecord = (value: {
-  [p in LayeredBackgroundProperty]?: LayersValue;
+  [property in LayeredBackgroundProperty]?: LayersValue;
 }): value is Record<LayeredBackgroundProperty, LayersValue> => {
   for (const property of layeredBackgroundProps) {
     if (value[property] === undefined) {
@@ -168,7 +168,8 @@ const normalizeLayers = (
   layerCount: number,
   batch: ReturnType<CreateBatchUpdate>
 ) => {
-  const layerStyles: { [p in LayeredBackgroundProperty]?: LayersValue } = {};
+  const layerStyle: { [property in LayeredBackgroundProperty]?: LayersValue } =
+    {};
 
   for (const property of layeredBackgroundProps) {
     const styleValue = style[property];
@@ -196,17 +197,17 @@ const normalizeLayers = (
       isStyleChanged = true;
     }
 
-    layerStyles[property] = newPropertyStyle;
+    layerStyle[property] = newPropertyStyle;
     if (isStyleChanged) {
       batch.setProperty(property)(newPropertyStyle);
     }
   }
 
-  if (!isLayerStylesRecord(layerStyles)) {
-    throw new Error("Invalid layer styles");
+  if (isLayerStylesRecord(layerStyle)) {
+    return layerStyle;
   }
 
-  return layerStyles;
+  throw new Error("Invalid layer styles");
 };
 
 export const setLayerProperty =

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.ts
@@ -221,7 +221,6 @@ export const setLayerProperty =
     if (newValue.type === "layers") {
       // Insert new layers if needed
       for (const property of layeredBackgroundProps) {
-        // If property is not defined, try copy from cascade or set empty
         const newPropertyStyle = layerStyles[property];
 
         const insertItems =
@@ -254,7 +253,6 @@ export const addLayer = (
   const layerStyles = normalizeLayers(style, layerCount, batch);
 
   for (const property of layeredBackgroundProps) {
-    // If property is not defined, try copy from cascade or set empty
     const newPropertyStyle = layerStyles[property];
 
     const newValue = [...newPropertyStyle.value];
@@ -304,7 +302,6 @@ export const swapLayers = (
   const layerStyles = normalizeLayers(style, layerCount, batch);
 
   for (const property of layeredBackgroundProps) {
-    // If property is not defined, try copy from cascade or set empty
     const newPropertyStyle = layerStyles[property];
 
     const newValue = [...newPropertyStyle.value];

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.ts
@@ -173,13 +173,13 @@ const normalizeLayers = (
   for (const property of layeredBackgroundProps) {
     const styleValue = style[property];
 
-    // If property is not defined, try copy from cascade or set empty
+    // If a property is not defined, try copying it from the cascade, or set it as empty.
     const newPropertyStyle: LayersValue = getLayersValue(styleValue);
 
     const missingLayerCount = layerCount - newPropertyStyle.value.length;
 
     if (missingLayerCount < 0) {
-      // In theory this should never happen.
+      // This should never happen.
       throw new Error(
         `Layer count for property ${property} exceeds expected ${layerCount}`
       );
@@ -219,7 +219,6 @@ export const setLayerProperty =
     const layerStyles = normalizeLayers(style, layerCount, batch);
 
     if (newValue.type === "layers") {
-      // Insert new layers if needed
       for (const property of layeredBackgroundProps) {
         const newPropertyStyle = layerStyles[property];
 

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-parser.test.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-parser.test.ts
@@ -17,32 +17,35 @@ describe("parseBackground", () => {
           "r": 235,
           "type": "rgb",
         },
-        "backgroundImages": [
-          {
-            "type": "unparsed",
-            "value": "linear-gradient(180deg,#11181C 0%,rgba(17,24,28,0) 36.09%)",
-          },
-          {
-            "type": "unparsed",
-            "value": "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
-          },
-          {
-            "type": "unparsed",
-            "value": "radial-gradient(54.1% 95.83%at 100% 100%,#FFFFFF 0%,rgba(255,255,255,0) 100%)",
-          },
-          {
-            "type": "unparsed",
-            "value": "linear-gradient(122.33deg,rgba(74,78,250,0.2) 0%,rgba(0,0,0,0) 69.38%)",
-          },
-          {
-            "type": "unparsed",
-            "value": "radial-gradient(92.26% 201.29%at 98.6% 10.65%,rgba(255,174,60,0.3) 0%,rgba(227,53,255,0) 100%)",
-          },
-          {
-            "type": "unparsed",
-            "value": "radial-gradient(84.64% 267.51%at 10.07% 81.45%,rgba(53,255,182,0.2) 0%,rgba(74,78,250,0.2) 100%)",
-          },
-        ],
+        "backgroundImage": {
+          "type": "layers",
+          "value": [
+            {
+              "type": "unparsed",
+              "value": "linear-gradient(180deg,#11181C 0%,rgba(17,24,28,0) 36.09%)",
+            },
+            {
+              "type": "unparsed",
+              "value": "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
+            },
+            {
+              "type": "unparsed",
+              "value": "radial-gradient(54.1% 95.83%at 100% 100%,#FFFFFF 0%,rgba(255,255,255,0) 100%)",
+            },
+            {
+              "type": "unparsed",
+              "value": "linear-gradient(122.33deg,rgba(74,78,250,0.2) 0%,rgba(0,0,0,0) 69.38%)",
+            },
+            {
+              "type": "unparsed",
+              "value": "radial-gradient(92.26% 201.29%at 98.6% 10.65%,rgba(255,174,60,0.3) 0%,rgba(227,53,255,0) 100%)",
+            },
+            {
+              "type": "unparsed",
+              "value": "radial-gradient(84.64% 267.51%at 10.07% 81.45%,rgba(53,255,182,0.2) 0%,rgba(74,78,250,0.2) 100%)",
+            },
+          ],
+        },
       }
     `);
   });
@@ -55,32 +58,35 @@ describe("parseBackground", () => {
     ).toMatchInlineSnapshot(`
       {
         "backgroundColor": undefined,
-        "backgroundImages": [
-          {
-            "type": "unparsed",
-            "value": "linear-gradient(180deg,#11181C 0%,rgba(17,24,28,0) 36.09%)",
-          },
-          {
-            "type": "unparsed",
-            "value": "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
-          },
-          {
-            "type": "unparsed",
-            "value": "radial-gradient(54.1% 95.83%at 100% 100%,#FFFFFF 0%,rgba(255,255,255,0) 100%)",
-          },
-          {
-            "type": "unparsed",
-            "value": "linear-gradient(122.33deg,rgba(74,78,250,0.2) 0%,rgba(0,0,0,0) 69.38%)",
-          },
-          {
-            "type": "unparsed",
-            "value": "radial-gradient(92.26% 201.29%at 98.6% 10.65%,rgba(255,174,60,0.3) 0%,rgba(227,53,255,0) 100%)",
-          },
-          {
-            "type": "unparsed",
-            "value": "radial-gradient(84.64% 267.51%at 10.07% 81.45%,rgba(53,255,182,0.2) 0%,rgba(74,78,250,0.2) 100%)",
-          },
-        ],
+        "backgroundImage": {
+          "type": "layers",
+          "value": [
+            {
+              "type": "unparsed",
+              "value": "linear-gradient(180deg,#11181C 0%,rgba(17,24,28,0) 36.09%)",
+            },
+            {
+              "type": "unparsed",
+              "value": "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
+            },
+            {
+              "type": "unparsed",
+              "value": "radial-gradient(54.1% 95.83%at 100% 100%,#FFFFFF 0%,rgba(255,255,255,0) 100%)",
+            },
+            {
+              "type": "unparsed",
+              "value": "linear-gradient(122.33deg,rgba(74,78,250,0.2) 0%,rgba(0,0,0,0) 69.38%)",
+            },
+            {
+              "type": "unparsed",
+              "value": "radial-gradient(92.26% 201.29%at 98.6% 10.65%,rgba(255,174,60,0.3) 0%,rgba(227,53,255,0) 100%)",
+            },
+            {
+              "type": "unparsed",
+              "value": "radial-gradient(84.64% 267.51%at 10.07% 81.45%,rgba(53,255,182,0.2) 0%,rgba(74,78,250,0.2) 100%)",
+            },
+          ],
+        },
       }
     `);
   });
@@ -93,28 +99,31 @@ describe("parseBackground", () => {
     ).toMatchInlineSnapshot(`
       {
         "backgroundColor": undefined,
-        "backgroundImages": [
-          {
-            "type": "unparsed",
-            "value": "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
-          },
-          {
-            "type": "unparsed",
-            "value": "radial-gradient(54.1% 95.83%at 100% 100%,#FFFFFF 0%,rgba(255,255,255,0) 100%)",
-          },
-          {
-            "type": "unparsed",
-            "value": "linear-gradient(122.33deg,rgba(74,78,250,0.2) 0%,rgba(0,0,0,0) 69.38%)",
-          },
-          {
-            "type": "unparsed",
-            "value": "radial-gradient(92.26% 201.29%at 98.6% 10.65%,rgba(255,174,60,0.3) 0%,rgba(227,53,255,0) 100%)",
-          },
-          {
-            "type": "unparsed",
-            "value": "radial-gradient(84.64% 267.51%at 10.07% 81.45%,rgba(53,255,182,0.2) 0%,rgba(74,78,250,0.2) 100%)",
-          },
-        ],
+        "backgroundImage": {
+          "type": "layers",
+          "value": [
+            {
+              "type": "unparsed",
+              "value": "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
+            },
+            {
+              "type": "unparsed",
+              "value": "radial-gradient(54.1% 95.83%at 100% 100%,#FFFFFF 0%,rgba(255,255,255,0) 100%)",
+            },
+            {
+              "type": "unparsed",
+              "value": "linear-gradient(122.33deg,rgba(74,78,250,0.2) 0%,rgba(0,0,0,0) 69.38%)",
+            },
+            {
+              "type": "unparsed",
+              "value": "radial-gradient(92.26% 201.29%at 98.6% 10.65%,rgba(255,174,60,0.3) 0%,rgba(227,53,255,0) 100%)",
+            },
+            {
+              "type": "unparsed",
+              "value": "radial-gradient(84.64% 267.51%at 10.07% 81.45%,rgba(53,255,182,0.2) 0%,rgba(74,78,250,0.2) 100%)",
+            },
+          ],
+        },
       }
     `);
   });
@@ -127,12 +136,15 @@ describe("parseBackground", () => {
     ).toMatchInlineSnapshot(`
       {
         "backgroundColor": undefined,
-        "backgroundImages": [
-          {
-            "type": "unparsed",
-            "value": "linear-gradient(180deg,#11181C 0%,rgba(17,24,28,0) 36.09%)",
-          },
-        ],
+        "backgroundImage": {
+          "type": "layers",
+          "value": [
+            {
+              "type": "unparsed",
+              "value": "linear-gradient(180deg,#11181C 0%,rgba(17,24,28,0) 36.09%)",
+            },
+          ],
+        },
       }
     `);
   });
@@ -145,12 +157,27 @@ describe("parseBackground", () => {
     ).toMatchInlineSnapshot(`
       {
         "backgroundColor": undefined,
-        "backgroundImages": [
-          {
-            "type": "unparsed",
-            "value": "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
-          },
-        ],
+        "backgroundImage": {
+          "type": "layers",
+          "value": [
+            {
+              "type": "unparsed",
+              "value": "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
+            },
+          ],
+        },
+      }
+    `);
+  });
+
+  test("parse bad background", () => {
+    expect(parseBackground("linear-gradient(180deg,")).toMatchInlineSnapshot(`
+      {
+        "backgroundColor": undefined,
+        "backgroundImage": {
+          "type": "invalid",
+          "value": "linear-gradient(180deg,",
+        },
       }
     `);
   });

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-parser.test.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-parser.test.ts
@@ -1,0 +1,121 @@
+import { describe, test, expect } from "@jest/globals";
+
+import { parseBackground } from "./background-parser";
+
+describe("parseBackground", () => {
+  test("parse background from figma", () => {
+    expect(
+      parseBackground(
+        "linear-gradient(180deg, #11181C 0%, rgba(17, 24, 28, 0) 36.09%), none, linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%), radial-gradient(54.1% 95.83% at 100% 100%, #FFFFFF 0%, rgba(255, 255, 255, 0) 100%), linear-gradient(122.33deg, rgba(74, 78, 250, 0.2) 0%, rgba(0, 0, 0, 0) 69.38%), radial-gradient(92.26% 201.29% at 98.6% 10.65%, rgba(255, 174, 60, 0.3) 0%, rgba(227, 53, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(84.64% 267.51% at 10.07% 81.45%, rgba(53, 255, 182, 0.2) 0%, rgba(74, 78, 250, 0.2) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, #EBFFFC;"
+      )
+    ).toMatchInlineSnapshot(`
+      {
+        "backgroundColor": {
+          "alpha": 1,
+          "b": 252,
+          "g": 255,
+          "r": 235,
+          "type": "rgb",
+        },
+        "backgroundImages": [
+          {
+            "type": "unparsed",
+            "value": "linear-gradient(180deg, #11181C 0%, rgba(17, 24, 28, 0) 36.09%)",
+          },
+          {
+            "type": "unparsed",
+            "value": "linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%)",
+          },
+          {
+            "type": "unparsed",
+            "value": "radial-gradient(54.1% 95.83% at 100% 100%, #FFFFFF 0%, rgba(255, 255, 255, 0) 100%)",
+          },
+          {
+            "type": "unparsed",
+            "value": "linear-gradient(122.33deg, rgba(74, 78, 250, 0.2) 0%, rgba(0, 0, 0, 0) 69.38%)",
+          },
+          {
+            "type": "unparsed",
+            "value": "radial-gradient(92.26% 201.29% at 98.6% 10.65%, rgba(255, 174, 60, 0.3) 0%, rgba(227, 53, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */",
+          },
+          {
+            "type": "unparsed",
+            "value": "radial-gradient(84.64% 267.51% at 10.07% 81.45%, rgba(53, 255, 182, 0.2) 0%, rgba(74, 78, 250, 0.2) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */",
+          },
+        ],
+      }
+    `);
+  });
+
+  test("parse background from figma without backgroundColor", () => {
+    expect(
+      parseBackground(
+        "linear-gradient(180deg, #11181C 0%, rgba(17, 24, 28, 0) 36.09%), linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%), radial-gradient(54.1% 95.83% at 100% 100%, #FFFFFF 0%, rgba(255, 255, 255, 0) 100%), linear-gradient(122.33deg, rgba(74, 78, 250, 0.2) 0%, rgba(0, 0, 0, 0) 69.38%), radial-gradient(92.26% 201.29% at 98.6% 10.65%, rgba(255, 174, 60, 0.3) 0%, rgba(227, 53, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(84.64% 267.51% at 10.07% 81.45%, rgba(53, 255, 182, 0.2) 0%, rgba(74, 78, 250, 0.2) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */"
+      )
+    ).toMatchInlineSnapshot(`
+      {
+        "backgroundColor": undefined,
+        "backgroundImages": [
+          {
+            "type": "unparsed",
+            "value": "linear-gradient(180deg, #11181C 0%, rgba(17, 24, 28, 0) 36.09%)",
+          },
+          {
+            "type": "unparsed",
+            "value": "linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%)",
+          },
+          {
+            "type": "unparsed",
+            "value": "radial-gradient(54.1% 95.83% at 100% 100%, #FFFFFF 0%, rgba(255, 255, 255, 0) 100%)",
+          },
+          {
+            "type": "unparsed",
+            "value": "linear-gradient(122.33deg, rgba(74, 78, 250, 0.2) 0%, rgba(0, 0, 0, 0) 69.38%)",
+          },
+          {
+            "type": "unparsed",
+            "value": "radial-gradient(92.26% 201.29% at 98.6% 10.65%, rgba(255, 174, 60, 0.3) 0%, rgba(227, 53, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */",
+          },
+          {
+            "type": "unparsed",
+            "value": "radial-gradient(84.64% 267.51% at 10.07% 81.45%, rgba(53, 255, 182, 0.2) 0%, rgba(74, 78, 250, 0.2) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */",
+          },
+        ],
+      }
+    `);
+  });
+
+  test("parse background and skips url background", () => {
+    expect(
+      parseBackground(
+        "url(https://hello.world/some-image), linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%), radial-gradient(54.1% 95.83% at 100% 100%, #FFFFFF 0%, rgba(255, 255, 255, 0) 100%), linear-gradient(122.33deg, rgba(74, 78, 250, 0.2) 0%, rgba(0, 0, 0, 0) 69.38%), radial-gradient(92.26% 201.29% at 98.6% 10.65%, rgba(255, 174, 60, 0.3) 0%, rgba(227, 53, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(84.64% 267.51% at 10.07% 81.45%, rgba(53, 255, 182, 0.2) 0%, rgba(74, 78, 250, 0.2) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */"
+      )
+    ).toMatchInlineSnapshot(`
+      {
+        "backgroundColor": undefined,
+        "backgroundImages": [
+          {
+            "type": "unparsed",
+            "value": "linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%)",
+          },
+          {
+            "type": "unparsed",
+            "value": "radial-gradient(54.1% 95.83% at 100% 100%, #FFFFFF 0%, rgba(255, 255, 255, 0) 100%)",
+          },
+          {
+            "type": "unparsed",
+            "value": "linear-gradient(122.33deg, rgba(74, 78, 250, 0.2) 0%, rgba(0, 0, 0, 0) 69.38%)",
+          },
+          {
+            "type": "unparsed",
+            "value": "radial-gradient(92.26% 201.29% at 98.6% 10.65%, rgba(255, 174, 60, 0.3) 0%, rgba(227, 53, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */",
+          },
+          {
+            "type": "unparsed",
+            "value": "radial-gradient(84.64% 267.51% at 10.07% 81.45%, rgba(53, 255, 182, 0.2) 0%, rgba(74, 78, 250, 0.2) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */",
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-parser.test.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-parser.test.ts
@@ -20,27 +20,27 @@ describe("parseBackground", () => {
         "backgroundImages": [
           {
             "type": "unparsed",
-            "value": "linear-gradient(180deg, #11181C 0%, rgba(17, 24, 28, 0) 36.09%)",
+            "value": "linear-gradient(180deg,#11181C 0%,rgba(17,24,28,0) 36.09%)",
           },
           {
             "type": "unparsed",
-            "value": "linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%)",
+            "value": "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
           },
           {
             "type": "unparsed",
-            "value": "radial-gradient(54.1% 95.83% at 100% 100%, #FFFFFF 0%, rgba(255, 255, 255, 0) 100%)",
+            "value": "radial-gradient(54.1% 95.83%at 100% 100%,#FFFFFF 0%,rgba(255,255,255,0) 100%)",
           },
           {
             "type": "unparsed",
-            "value": "linear-gradient(122.33deg, rgba(74, 78, 250, 0.2) 0%, rgba(0, 0, 0, 0) 69.38%)",
+            "value": "linear-gradient(122.33deg,rgba(74,78,250,0.2) 0%,rgba(0,0,0,0) 69.38%)",
           },
           {
             "type": "unparsed",
-            "value": "radial-gradient(92.26% 201.29% at 98.6% 10.65%, rgba(255, 174, 60, 0.3) 0%, rgba(227, 53, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */",
+            "value": "radial-gradient(92.26% 201.29%at 98.6% 10.65%,rgba(255,174,60,0.3) 0%,rgba(227,53,255,0) 100%)",
           },
           {
             "type": "unparsed",
-            "value": "radial-gradient(84.64% 267.51% at 10.07% 81.45%, rgba(53, 255, 182, 0.2) 0%, rgba(74, 78, 250, 0.2) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */",
+            "value": "radial-gradient(84.64% 267.51%at 10.07% 81.45%,rgba(53,255,182,0.2) 0%,rgba(74,78,250,0.2) 100%)",
           },
         ],
       }
@@ -58,27 +58,27 @@ describe("parseBackground", () => {
         "backgroundImages": [
           {
             "type": "unparsed",
-            "value": "linear-gradient(180deg, #11181C 0%, rgba(17, 24, 28, 0) 36.09%)",
+            "value": "linear-gradient(180deg,#11181C 0%,rgba(17,24,28,0) 36.09%)",
           },
           {
             "type": "unparsed",
-            "value": "linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%)",
+            "value": "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
           },
           {
             "type": "unparsed",
-            "value": "radial-gradient(54.1% 95.83% at 100% 100%, #FFFFFF 0%, rgba(255, 255, 255, 0) 100%)",
+            "value": "radial-gradient(54.1% 95.83%at 100% 100%,#FFFFFF 0%,rgba(255,255,255,0) 100%)",
           },
           {
             "type": "unparsed",
-            "value": "linear-gradient(122.33deg, rgba(74, 78, 250, 0.2) 0%, rgba(0, 0, 0, 0) 69.38%)",
+            "value": "linear-gradient(122.33deg,rgba(74,78,250,0.2) 0%,rgba(0,0,0,0) 69.38%)",
           },
           {
             "type": "unparsed",
-            "value": "radial-gradient(92.26% 201.29% at 98.6% 10.65%, rgba(255, 174, 60, 0.3) 0%, rgba(227, 53, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */",
+            "value": "radial-gradient(92.26% 201.29%at 98.6% 10.65%,rgba(255,174,60,0.3) 0%,rgba(227,53,255,0) 100%)",
           },
           {
             "type": "unparsed",
-            "value": "radial-gradient(84.64% 267.51% at 10.07% 81.45%, rgba(53, 255, 182, 0.2) 0%, rgba(74, 78, 250, 0.2) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */",
+            "value": "radial-gradient(84.64% 267.51%at 10.07% 81.45%,rgba(53,255,182,0.2) 0%,rgba(74,78,250,0.2) 100%)",
           },
         ],
       }
@@ -96,23 +96,23 @@ describe("parseBackground", () => {
         "backgroundImages": [
           {
             "type": "unparsed",
-            "value": "linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%)",
+            "value": "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
           },
           {
             "type": "unparsed",
-            "value": "radial-gradient(54.1% 95.83% at 100% 100%, #FFFFFF 0%, rgba(255, 255, 255, 0) 100%)",
+            "value": "radial-gradient(54.1% 95.83%at 100% 100%,#FFFFFF 0%,rgba(255,255,255,0) 100%)",
           },
           {
             "type": "unparsed",
-            "value": "linear-gradient(122.33deg, rgba(74, 78, 250, 0.2) 0%, rgba(0, 0, 0, 0) 69.38%)",
+            "value": "linear-gradient(122.33deg,rgba(74,78,250,0.2) 0%,rgba(0,0,0,0) 69.38%)",
           },
           {
             "type": "unparsed",
-            "value": "radial-gradient(92.26% 201.29% at 98.6% 10.65%, rgba(255, 174, 60, 0.3) 0%, rgba(227, 53, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */",
+            "value": "radial-gradient(92.26% 201.29%at 98.6% 10.65%,rgba(255,174,60,0.3) 0%,rgba(227,53,255,0) 100%)",
           },
           {
             "type": "unparsed",
-            "value": "radial-gradient(84.64% 267.51% at 10.07% 81.45%, rgba(53, 255, 182, 0.2) 0%, rgba(74, 78, 250, 0.2) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */",
+            "value": "radial-gradient(84.64% 267.51%at 10.07% 81.45%,rgba(53,255,182,0.2) 0%,rgba(74,78,250,0.2) 100%)",
           },
         ],
       }
@@ -130,7 +130,7 @@ describe("parseBackground", () => {
         "backgroundImages": [
           {
             "type": "unparsed",
-            "value": "linear-gradient(180deg, #11181C 0%, rgba(17, 24, 28, 0) 36.09%)",
+            "value": "linear-gradient(180deg,#11181C 0%,rgba(17,24,28,0) 36.09%)",
           },
         ],
       }
@@ -148,7 +148,7 @@ describe("parseBackground", () => {
         "backgroundImages": [
           {
             "type": "unparsed",
-            "value": "linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%)",
+            "value": "linear-gradient(180deg,rgba(230,60,254,0.33) 0%,rgba(255,174,60,0) 100%)",
           },
         ],
       }

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-parser.test.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-parser.test.ts
@@ -118,4 +118,40 @@ describe("parseBackground", () => {
       }
     `);
   });
+
+  test("parse background partially copied background", () => {
+    expect(
+      parseBackground(
+        "linear-gradient(180deg, #11181C 0%, rgba(17, 24, 28, 0) 36.09%), linear-gradient(180deg, "
+      )
+    ).toMatchInlineSnapshot(`
+      {
+        "backgroundColor": undefined,
+        "backgroundImages": [
+          {
+            "type": "unparsed",
+            "value": "linear-gradient(180deg, #11181C 0%, rgba(17, 24, 28, 0) 36.09%)",
+          },
+        ],
+      }
+    `);
+  });
+
+  test("parse background partially commented", () => {
+    expect(
+      parseBackground(
+        "linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%), /* radial-gradient(54.1% 95.83% at 100% 100%, #FFFFFF 0%, rgba(255, 255, 255, 0) 100%) */"
+      )
+    ).toMatchInlineSnapshot(`
+      {
+        "backgroundColor": undefined,
+        "backgroundImages": [
+          {
+            "type": "unparsed",
+            "value": "linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%)",
+          },
+        ],
+      }
+    `);
+  });
 });

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-parser.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-parser.ts
@@ -1,0 +1,108 @@
+import type { StyleValue } from "@webstudio-is/css-data";
+import { colord } from "colord";
+import { parseCssValue } from "../../shared/parse-css-value";
+
+export const gradientNames = [
+  "conic-gradient",
+  "linear-gradient",
+  "radial-gradient",
+  "repeating-conic-gradient",
+  "repeating-linear-gradient",
+  "repeating-radial-gradient",
+];
+
+/**
+ * We are not trying to parse the CSS here, just split it into layers.
+ * i.e. transform something like:
+ * linear-gradient(180deg, #11181C 0%, rgba(17, 24, 28, 0) 36.09%), none, linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%)
+ * into this:
+ * [linear-gradient(180deg, #11181C 0%, rgba(17, 24, 28, 0) 36.09%), linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%)]
+ */
+export const parseBackground = (background: string) => {
+  const tokensRe = /([,()]|\/\*|\*\/)/;
+
+  let tokenStream = background.trim();
+
+  tokenStream = tokenStream.endsWith(";")
+    ? tokenStream.slice(0, -1)
+    : tokenStream;
+
+  let parens = 0;
+  let comment = 0;
+
+  let layer = "";
+  const layers = [];
+
+  while (tokenStream.length > 0) {
+    const match = tokensRe.exec(tokenStream);
+
+    if (match === null) {
+      layer += tokenStream;
+      break;
+    }
+
+    const matched = tokenStream.slice(0, match.index);
+    const token = match[0];
+
+    if (parens === 0 && comment === 0 && token === ",") {
+      layers.push((layer + matched).trim());
+      layer = "";
+    } else {
+      layer += matched + token;
+    }
+
+    switch (token) {
+      case "(":
+        parens++;
+        break;
+      case ")":
+        parens--;
+        break;
+      case "/*":
+        comment++;
+        break;
+      case "*/":
+        comment--;
+        break;
+    }
+
+    tokenStream = tokenStream.slice(match.index + token.length);
+  }
+
+  if (parens === 0 && comment === 0) {
+    layers.push(layer.trim());
+  }
+
+  if (layers.length === 0) {
+    return;
+  }
+
+  const validGradientLayers = layers
+    .filter((layer) =>
+      gradientNames.some((gradientName) => layer.startsWith(gradientName))
+    )
+    .map((layer) => parseCssValue("backgroundImage", layer))
+    .filter((layer) => layer.type === "unparsed");
+
+  // Last layer can be a backgroundColor
+  const lastLayer = layers[layers.length - 1];
+  const colordValue = colord(lastLayer);
+
+  let backgroundColor: StyleValue | undefined;
+
+  if (colordValue.isValid()) {
+    const rgb = colordValue.toRgb();
+    backgroundColor = {
+      type: "rgb",
+      r: rgb.r,
+      g: rgb.g,
+      b: rgb.b,
+      alpha: rgb.a ?? 1,
+    };
+  }
+
+  return {
+    backgroundImages: validGradientLayers,
+    backgroundColor,
+  };
+};

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-parser.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-parser.ts
@@ -52,9 +52,9 @@ export const parseBackground = (
           layers.push(csstree.generate(node));
         }
 
-        // If at level 0 depth and the next item is null, it's probably a backgroundColor written as rgba(x,y,z,a) or like
+        // If the depth is at level 0 and the next item is null, it's likely that the backgroundColor
+        // is written as rgba(x,y,z,a) or similar format.
         if (item.next === null && callDepth === 0) {
-          // Probably a color
           backgroundColorRaw = csstree.generate(node);
         }
 
@@ -62,7 +62,8 @@ export const parseBackground = (
       }
 
       if (node.type === "Hash" && item.next === null && callDepth === 0) {
-        // If at level 0 depth and the next item is null, it's probably a backgroundColor written as hex #XYZFGH
+        // If the depth is at level 0 and the next item is null, it's likely that the backgroundColor
+        // is written as hex #XYZFGH
         backgroundColorRaw = csstree.generate(node);
       }
     },

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.stories.tsx
@@ -81,7 +81,6 @@ export const Backgrounds = () => {
       });
     },
     publish: (options) => {
-      // do nothing
       if (options?.isEphemeral) {
         return;
       }

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.stories.tsx
@@ -1,6 +1,6 @@
 import type { LayersValue } from "@webstudio-is/css-data";
 import { styled, theme } from "@webstudio-is/design-system";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { StyleInfo } from "../../shared/style-info";
 import type {
   CreateBatchUpdate,
@@ -40,7 +40,12 @@ const Panel = styled("div", {
 
 export const Backgrounds = () => {
   const [styleInfo, setStyleInfo] = useState(() => styleInfoInitial);
+
   const setProperty: SetProperty = (name) => (value, options) => {
+    if (options?.isEphemeral) {
+      return;
+    }
+
     setStyleInfo((styleInfo) => ({
       ...styleInfo,
       [name]: {
@@ -51,18 +56,41 @@ export const Backgrounds = () => {
     }));
   };
 
-  const deleteProperty: DeleteProperty = (name) => {
+  const deleteProperty: DeleteProperty = (name, options) => {
+    if (options?.isEphemeral) {
+      return;
+    }
+
     setStyleInfo((styleInfo) => {
       const { [name]: _, ...rest } = styleInfo;
       return rest;
     });
   };
 
+  const execCommands = useRef<(() => void)[]>([]);
+
   const createBatchUpdate: CreateBatchUpdate = () => ({
-    deleteProperty,
-    setProperty,
-    publish: () => {
+    deleteProperty: (property) => {
+      execCommands.current.push(() => {
+        deleteProperty(property);
+      });
+    },
+    setProperty: (property) => (style) => {
+      execCommands.current.push(() => {
+        setProperty(property)(style);
+      });
+    },
+    publish: (options) => {
       // do nothing
+      if (options?.isEphemeral) {
+        return;
+      }
+
+      for (const command of execCommands.current) {
+        command();
+      }
+
+      execCommands.current = [];
     },
   });
 

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
@@ -34,6 +34,7 @@ import { BackgroundContent } from "./background-content";
 import { getLayerName, LayerThumbnail } from "./background-thumbnail";
 import { useSortable } from "./use-sortable";
 import { useMemo } from "react";
+import type { RgbValue } from "@webstudio-is/css-data";
 
 const Layer = (props: {
   id: string;
@@ -42,6 +43,7 @@ const Layer = (props: {
   setProperty: SetBackgroundProperty;
   deleteProperty: DeleteBackgroundProperty;
   deleteLayer: () => void;
+  setBackgroundColor: (color: RgbValue) => void;
 }) => {
   const backgrounImageStyle = props.layerStyle.backgroundImage?.value;
   const isHidden =
@@ -74,6 +76,7 @@ const Layer = (props: {
           currentStyle={props.layerStyle}
           setProperty={props.setProperty}
           deleteProperty={props.deleteProperty}
+          setBackgroundColor={props.setBackgroundColor}
         />
       }
     >
@@ -174,6 +177,9 @@ export const BackgroundsSection = ({
               deleteProperty,
               createBatchUpdate
             )}
+            setBackgroundColor={(color) =>
+              setProperty("backgroundColor")(color)
+            }
           />
         ))}
 

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
@@ -177,9 +177,7 @@ export const BackgroundsSection = ({
               deleteProperty,
               createBatchUpdate
             )}
-            setBackgroundColor={(color) =>
-              setProperty("backgroundColor")(color)
-            }
+            setBackgroundColor={setProperty("backgroundColor")}
           />
         ))}
 

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -318,8 +318,15 @@ export const CssValueInput = ({
       return;
     }
 
+    const parsedValue = parseIntermediateOrInvalidValue(property, value);
+
+    if (parsedValue.type === "invalid") {
+      props.onChange(parsedValue);
+      return;
+    }
+
     props.onChangeComplete({
-      value: parseIntermediateOrInvalidValue(property, value),
+      value: parsedValue,
       reason,
     });
   };

--- a/apps/builder/app/canvas/features/text-editor/text-editor.tsx
+++ b/apps/builder/app/canvas/features/text-editor/text-editor.tsx
@@ -131,11 +131,13 @@ export const TextEditor = ({
   onChange,
   onSelectInstance,
 }: TextEditorProps) => {
-  const [paragraphClassName] = useState(() => nanoid());
-  const [italicClassName] = useState(() => nanoid());
+  // class names must be started with letter so we add a prefix
+  const [paragraphClassName] = useState(() => `a${nanoid()}`);
+  const [italicClassName] = useState(() => `a${nanoid()}`);
 
   useLayoutEffect(() => {
     const engine = createCssEngine({ name: "text-editor" });
+
     // reset paragraph styles and make it work inside <a>
     engine.addPlaintextRule(`
       .${paragraphClassName} { display: inline; margin: 0; }

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -258,10 +258,7 @@ const setCssVar = (id: string, property: string, value?: StyleValue) => {
     document.body.style.removeProperty(customProperty);
     return;
   }
-  document.body.style.setProperty(
-    customProperty,
-    toValue(value, undefined, true)
-  );
+  document.body.style.setProperty(customProperty, toValue(value, undefined));
 };
 
 const useUpdateStyle = () => {

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -258,7 +258,10 @@ const setCssVar = (id: string, property: string, value?: StyleValue) => {
     document.body.style.removeProperty(customProperty);
     return;
   }
-  document.body.style.setProperty(customProperty, toValue(value));
+  document.body.style.setProperty(
+    customProperty,
+    toValue(value, undefined, true)
+  );
 };
 
 const useUpdateStyle = () => {

--- a/packages/css-data/src/schema.ts
+++ b/packages/css-data/src/schema.ts
@@ -55,6 +55,8 @@ export const UnparsedValue = z.object({
   hidden: z.boolean().optional(),
 });
 
+export type UnparsedValue = z.infer<typeof UnparsedValue>;
+
 const FontFamilyValue = z.object({
   type: z.literal("fontFamily"),
   value: z.array(z.string()),

--- a/packages/css-engine/src/core/to-value.ts
+++ b/packages/css-engine/src/core/to-value.ts
@@ -16,8 +16,7 @@ const assertUnreachable = (_arg: never, errorMessage: string) => {
 
 export const toValue = (
   value?: StyleValue,
-  options: ToCssOptions = defaultOptions,
-  isEditMode?: boolean
+  options: ToCssOptions = defaultOptions
 ): string => {
   if (value === undefined) {
     return "";
@@ -37,11 +36,9 @@ export const toValue = (
     return [...value.value, DEFAULT_FONT_FALLBACK].join(", ");
   }
   if (value.type === "var") {
-    // We use var() in edit mode only
-    const isEditMode = true;
     const fallbacks = [];
     for (const fallback of value.fallbacks) {
-      fallbacks.push(toValue(fallback, options, isEditMode));
+      fallbacks.push(toValue(fallback, options));
     }
     const fallbacksString =
       fallbacks.length > 0 ? `, ${fallbacks.join(", ")}` : "";
@@ -65,7 +62,7 @@ export const toValue = (
   }
 
   if (value.type === "image") {
-    if (isEditMode && value.hidden) {
+    if (value.hidden) {
       // We assume that property is background-image and use this to hide background layers
       // In the future we might want to have a more generic way to hide values
       // i.e. have knowledge about property-name, as none is property specific
@@ -77,7 +74,7 @@ export const toValue = (
   }
 
   if (value.type === "unparsed") {
-    if (isEditMode && value.hidden) {
+    if (value.hidden) {
       // We assume that property is background-image and use this to hide background layers
       // In the future we might want to have a more generic way to hide values
       // i.e. have knowledge about property-name, as none is property specific
@@ -88,15 +85,11 @@ export const toValue = (
   }
 
   if (value.type === "layers") {
-    return value.value
-      .map((value) => toValue(value, options, isEditMode))
-      .join(",");
+    return value.value.map((value) => toValue(value, options)).join(",");
   }
 
   if (value.type === "tuple") {
-    return value.value
-      .map((value) => toValue(value, options, isEditMode))
-      .join(" ");
+    return value.value.map((value) => toValue(value, options)).join(" ");
   }
 
   // Will give ts error in case of missing type


### PR DESCRIPTION
## Description

ref #877 - the ability to parse multiple gradient layers from Figma 
![Screen Recording 2023-03-18 at 00 25 12](https://user-images.githubusercontent.com/5077042/226031486-0dc0978b-5572-4dd6-9441-b86b2e469a7a.gif)


closes #1255 - now background added at the top

fixes css value input invalid input now shows as invalid

## Steps for reproduction

Copy some background from figma like
```
background: linear-gradient(180deg, #11181C 0%, rgba(17, 24, 28, 0) 36.09%), none, linear-gradient(180deg, rgba(230, 60, 254, 0.33) 0%, rgba(255, 174, 60, 0) 100%), radial-gradient(54.1% 95.83% at 100% 100%, #FFFFFF 0%, rgba(255, 255, 255, 0) 100%), linear-gradient(122.33deg, rgba(74, 78, 250, 0.2) 0%, rgba(0, 0, 0, 0) 69.38%), radial-gradient(92.26% 201.29% at 98.6% 10.65%, rgba(255, 174, 60, 0.3) 0%, rgba(227, 53, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(84.64% 267.51% at 10.07% 81.45%, rgba(53, 255, 182, 0.2) 0%, rgba(74, 78, 250, 0.2) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, #EBFFFC;
```

Open any layer paste it into the code, and click enter or blur.
See layers added. BGColor has changed if set.


## Code Review

- [x] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [x] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
