### PR TITLE
Pass selected instance selector to tree

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/navigator/navigator.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/navigator/navigator.tsx
@@ -20,7 +20,6 @@ type NavigatorProps = {
 
 export const Navigator = ({ isClosable, onClose }: NavigatorProps) => {
   const selectedInstanceSelector = useStore(selectedInstanceSelectorStore);
-  const selectedInstanceId = selectedInstanceSelector?.[0];
   const [rootInstance] = useRootInstance();
 
   const handleSelect = useCallback((instanceId: Instance["id"]) => {
@@ -64,8 +63,8 @@ export const Navigator = ({ isClosable, onClose }: NavigatorProps) => {
       <Flex css={{ flexGrow: 1, flexDirection: "column" }}>
         <InstanceTree
           root={rootInstance}
-          // @todo accept and provide in callback instance selector instead of just id
-          selectedItemId={selectedInstanceId}
+          selectedItemSelector={selectedInstanceSelector}
+          // @todo provide in callback instance selector instead of just id
           onSelect={handleSelect}
           onHover={handleHover}
           onDragEnd={handleDragEnd}

--- a/packages/design-system/src/components/tree/item-utils.ts
+++ b/packages/design-system/src/components/tree/item-utils.ts
@@ -1,0 +1,29 @@
+export type ItemId = string;
+
+export type ItemSelector = string[];
+
+export const getElementByItemSelector = (
+  root: undefined | Element,
+  itemSelector: ItemSelector
+) => {
+  // query item from root to target
+  const domSelector = itemSelector
+    .map((id) => `[data-drop-target-id="${id}"]`)
+    .reverse()
+    .join(" ");
+  const [itemId] = itemSelector;
+  return (
+    root?.querySelector(`${domSelector} [data-item-button-id="${itemId}"]`) ??
+    undefined
+  );
+};
+
+export const areItemSelectorsEqual = (
+  left?: ItemSelector,
+  right?: ItemSelector
+) => {
+  if (left === undefined || right === undefined) {
+    return false;
+  }
+  return left.join(",") === right.join(",");
+};

--- a/packages/design-system/src/components/tree/tree.stories.tsx
+++ b/packages/design-system/src/components/tree/tree.stories.tsx
@@ -11,6 +11,7 @@ import {
 } from "./test-tree-data";
 import { Flex } from "../flex";
 import { TreeItemLabel, TreeItemBody } from "./tree-node";
+import type { ItemSelector } from "./item-utils";
 
 export const StressTest = ({ animate }: { animate: boolean }) => {
   const [root, setRoot] = useState<Item>((): Item => {
@@ -72,7 +73,9 @@ export const StressTest = ({ animate }: { animate: boolean }) => {
     };
   });
 
-  const [selectedItemId, setSelectedItemId] = useState<string | undefined>();
+  const [selectedItemSelector, setSelectedItemSelector] = useState<
+    undefined | ItemSelector
+  >();
 
   return (
     <Flex css={{ width: 300, height: 500, flexDirection: "column" }}>
@@ -84,8 +87,14 @@ export const StressTest = ({ animate }: { animate: boolean }) => {
         getItemChildren={getItemChildren}
         animate={animate}
         root={root}
-        selectedItemId={selectedItemId}
-        onSelect={(instanceId) => setSelectedItemId(instanceId)}
+        selectedItemSelector={selectedItemSelector}
+        onSelect={(instanceId) => {
+          setSelectedItemSelector(
+            getItemPath(root, instanceId)
+              .reverse()
+              .map((item) => item.id)
+          );
+        }}
         renderItem={(props) => (
           <TreeItemBody {...props}>
             <TreeItemLabel>{props.itemData.id}</TreeItemLabel>


### PR DESCRIPTION
Selector is a list of ids from root to target to allow identify instances even with duplicated ids.

Here is the first step to support selectors in navigator. Passing selected instance selector already helped to get rid of one getItemPath usage.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @rpominov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
