### PR TITLE
Remove handled updates from the updates list

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/use-settings-logic.ts
+++ b/apps/builder/app/builder/features/settings-panel/use-settings-logic.ts
@@ -32,6 +32,19 @@ export const useSettingsLogic = () => {
     updates.current.push({ operation: "set", property: "label", value });
   };
 
+  // Gets updates by property and removes them from the list
+  const popUpdates = (property: Setting) => {
+    const remainingUpdates: Array<Operation> = [];
+    const searchedUpdates: Array<Operation> = [];
+    for (const update of updates.current) {
+      const array =
+        update.property === property ? searchedUpdates : remainingUpdates;
+      array.push(update);
+    }
+    updates.current = remainingUpdates;
+    return searchedUpdates;
+  };
+
   const updateLabel = useCallback(() => {
     const selectedInstance = selectedInstanceStore.get();
     if (selectedInstance === undefined) {
@@ -42,7 +55,8 @@ export const useSettingsLogic = () => {
       if (instance === undefined) {
         return;
       }
-      for (const update of updates.current) {
+      const labelUpdates = popUpdates("label");
+      for (const update of labelUpdates) {
         if (update.operation === "delete") {
           delete instance.label;
           continue;


### PR DESCRIPTION
## Description

Fixes https://github.com/webstudio-is/webstudio-builder/issues/1223

After handling settings update, I forgot to delete the update from the list, but if the user doesn't unmount component, switches instance, then unmounts, the same scheduled update is still there and applies to the new instance

## Steps for reproduction

1. name an instance
2. select a diff instsance
3. switch from settings tab to styles tab

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
