### PR TITLE
Refactor tree drag item and drop target with selectors

### DIFF
--- a/packages/design-system/src/components/tree/horizontal-shift.test.ts
+++ b/packages/design-system/src/components/tree/horizontal-shift.test.ts
@@ -1,7 +1,8 @@
 import { describe, test, expect } from "@jest/globals";
 import { renderHook, act } from "@testing-library/react-hooks";
-import type { DropTarget, Placement } from "../primitives/dnd";
+import type { Placement } from "../primitives/dnd";
 import { useHorizontalShift } from "./horizontal-shift";
+import type { ItemDropTarget, ItemId } from "./item-utils";
 import {
   canAcceptChild,
   getItemChildren,
@@ -80,16 +81,20 @@ const makeDrop = ({
   into: Item;
   after?: Item;
   placement?: Placement;
-}): DropTarget<Item> => ({
+}): ItemDropTarget<Item> => ({
+  itemSelector: getItemSelector(into.id),
   data: into,
   indexWithinChildren:
     after === undefined ? 0 : into.children.indexOf(after) + 1,
   placement,
-
-  // not used
-  element: null as unknown as HTMLElement,
   rect: null as unknown as DOMRect,
 });
+
+const getItemSelector = (itemId: ItemId) => {
+  return getItemPath(tree, itemId)
+    .reverse()
+    .map((item) => item.id);
+};
 
 const render = (
   {
@@ -97,13 +102,14 @@ const render = (
     dropTarget,
   }: {
     dragItem: Item | undefined;
-    dropTarget: DropTarget<Item> | undefined;
+    dropTarget: ItemDropTarget<Item> | undefined;
   },
   shift = -1
 ) => {
   const { result } = renderHook((props) => useHorizontalShift<Item>(props), {
     initialProps: {
-      dragItem,
+      dragItemSelector:
+        dragItem === undefined ? undefined : getItemSelector(dragItem.id),
       dropTarget,
       root: tree,
       getIsExpanded: (item: Item) => item.children.length > 0,

--- a/packages/design-system/src/components/tree/item-utils.ts
+++ b/packages/design-system/src/components/tree/item-utils.ts
@@ -1,6 +1,16 @@
+import type { Placement } from "../primitives/dnd";
+
 export type ItemId = string;
 
 export type ItemSelector = string[];
+
+export type ItemDropTarget<Item> = {
+  itemSelector: ItemSelector;
+  data: Item;
+  rect: DOMRect;
+  indexWithinChildren: number;
+  placement: Placement;
+};
 
 export const getElementByItemSelector = (
   root: undefined | Element,
@@ -16,6 +26,21 @@ export const getElementByItemSelector = (
     root?.querySelector(`${domSelector} [data-item-button-id="${itemId}"]`) ??
     undefined
   );
+};
+
+export const getItemSelectorFromElement = (element: Element) => {
+  const itemSelector: ItemSelector = [];
+  let matched: undefined | Element =
+    element.closest(`[data-drop-target-id]`) ?? undefined;
+  while (matched) {
+    const itemId = matched.getAttribute("data-drop-target-id") ?? undefined;
+    if (itemId !== undefined) {
+      itemSelector.push(itemId);
+    }
+    matched =
+      matched.parentElement?.closest(`[data-drop-target-id]`) ?? undefined;
+  }
+  return itemSelector;
 };
 
 export const areItemSelectorsEqual = (


### PR DESCRIPTION
Before supporting selector in callbacks need to upport selectors in data. Here internal drag item and drop target supported as selectors.

In the future these states will be exposed so for drop target added custom representation without element to allow sending it via pubsub between realms.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
