### PR TITLE
Make canvas iframe receive no pointer events for the time of dragging

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -14,7 +14,7 @@ import { useSharedShortcuts } from "~/shared/shortcuts";
 import { SidebarLeft } from "./features/sidebar-left";
 import { Inspector } from "./features/inspector";
 import {
-  useEnabledCanvasPointerEvents,
+  isCanvasPointerEventsEnabledStore,
   useProject,
 } from "./shared/nano-states";
 import { Topbar } from "./features/topbar";
@@ -53,6 +53,7 @@ import type { Asset } from "@webstudio-is/asset-uploader";
 import { useSearchParams } from "@remix-run/react";
 import { useSyncInitializeOnce } from "~/shared/hook-utils";
 import { BlockingAlerts } from "./features/blocking-alerts";
+import { useStore } from "@nanostores/react";
 
 registerContainers();
 
@@ -305,7 +306,9 @@ export const Builder = ({
     },
     [publishRef, onRefReadCanvasWidth, onRefReadCanvas]
   );
-  const [isCanvasPointerEventsEnabled] = useEnabledCanvasPointerEvents();
+  const isCanvasPointerEventsEnabled = useStore(
+    isCanvasPointerEventsEnabledStore
+  );
 
   const canvasUrl = getBuildUrl({
     buildOrigin,
@@ -323,7 +326,7 @@ export const Builder = ({
             <CanvasIframe
               ref={iframeRefCallback}
               src={canvasUrl}
-              pointerEvents={isCanvasPointerEventsEnabled ? "all" : "none"}
+              pointerEvents={isCanvasPointerEventsEnabled ? "auto" : "none"}
               title={project.title}
               css={{
                 height: "100%",

--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -13,7 +13,10 @@ import robotoMonoFont from "@fontsource/roboto-mono/index.css";
 import { useSharedShortcuts } from "~/shared/shortcuts";
 import { SidebarLeft } from "./features/sidebar-left";
 import { Inspector } from "./features/inspector";
-import { useProject } from "./shared/nano-states";
+import {
+  useEnabledCanvasPointerEvents,
+  useProject,
+} from "./shared/nano-states";
 import { Topbar } from "./features/topbar";
 import builderStyles from "./builder.css";
 import { Footer } from "./features/footer";
@@ -302,6 +305,7 @@ export const Builder = ({
     },
     [publishRef, onRefReadCanvasWidth, onRefReadCanvas]
   );
+  const [isCanvasPointerEventsEnabled] = useEnabledCanvasPointerEvents();
 
   const canvasUrl = getBuildUrl({
     buildOrigin,
@@ -319,12 +323,7 @@ export const Builder = ({
             <CanvasIframe
               ref={iframeRefCallback}
               src={canvasUrl}
-              pointerEvents={
-                dragAndDropState.isDragging &&
-                dragAndDropState.origin === "panel"
-                  ? "none"
-                  : "all"
-              }
+              pointerEvents={isCanvasPointerEventsEnabled ? "all" : "none"}
               title={project.title}
               css={{
                 height: "100%",

--- a/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
@@ -16,7 +16,10 @@ import {
   selectedInstanceSelectorStore,
 } from "~/shared/nano-states";
 import { useSubscribe, type Publish } from "~/shared/pubsub";
-import { useCanvasRect } from "~/builder/shared/nano-states";
+import {
+  useCanvasRect,
+  useEnabledCanvasPointerEvents,
+} from "~/builder/shared/nano-states";
 import { insertNewComponentInstance } from "~/shared/instance-utils";
 import { zoomStore } from "~/shared/nano-states/breakpoints";
 import type { TabName } from "../../types";
@@ -92,6 +95,7 @@ const elementToComponentName = (
 export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
   const [dragComponent, setDragComponent] = useState<Instance["component"]>();
   const [point, setPoint] = useState<Point>({ x: 0, y: 0 });
+  const [, toggleCanvasPointerEvents] = useEnabledCanvasPointerEvents();
 
   const [canvasRect] = useCanvasRect();
   const zoom = useStore(zoomStore);
@@ -134,6 +138,7 @@ export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
           dragItem: utils.tree.createInstance({ component: componentName }),
         },
       });
+      toggleCanvasPointerEvents(false);
     },
     onMove: (point) => {
       setPoint(point);
@@ -148,6 +153,7 @@ export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
         type: "dragEnd",
         payload: { origin: "panel", isCanceled },
       });
+      toggleCanvasPointerEvents(true);
     },
   });
 

--- a/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
@@ -17,8 +17,8 @@ import {
 } from "~/shared/nano-states";
 import { useSubscribe, type Publish } from "~/shared/pubsub";
 import {
+  isCanvasPointerEventsEnabledStore,
   useCanvasRect,
-  useEnabledCanvasPointerEvents,
 } from "~/builder/shared/nano-states";
 import { insertNewComponentInstance } from "~/shared/instance-utils";
 import { zoomStore } from "~/shared/nano-states/breakpoints";
@@ -95,7 +95,6 @@ const elementToComponentName = (
 export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
   const [dragComponent, setDragComponent] = useState<Instance["component"]>();
   const [point, setPoint] = useState<Point>({ x: 0, y: 0 });
-  const [, toggleCanvasPointerEvents] = useEnabledCanvasPointerEvents();
 
   const [canvasRect] = useCanvasRect();
   const zoom = useStore(zoomStore);
@@ -138,7 +137,7 @@ export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
           dragItem: utils.tree.createInstance({ component: componentName }),
         },
       });
-      toggleCanvasPointerEvents(false);
+      isCanvasPointerEventsEnabledStore.set(false);
     },
     onMove: (point) => {
       setPoint(point);
@@ -153,7 +152,7 @@ export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
         type: "dragEnd",
         payload: { origin: "panel", isCanceled },
       });
-      toggleCanvasPointerEvents(true);
+      isCanvasPointerEventsEnabledStore.set(true);
     },
   });
 

--- a/apps/builder/app/builder/features/workspace/canvas-iframe.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-iframe.tsx
@@ -8,20 +8,20 @@ const iframeStyle = css({
       none: {
         pointerEvents: "none",
       },
-      all: {
-        pointerEvents: "all",
+      auto: {
+        pointerEvents: "auto",
       },
     },
   },
 });
 
 type CanvasIframeProps = {
-  pointerEvents: "all" | "none";
+  pointerEvents: "auto" | "none";
   css: CSS;
 } & JSX.IntrinsicElements["iframe"];
 
 export const CanvasIframe = forwardRef<HTMLIFrameElement, CanvasIframeProps>(
-  ({ pointerEvents = "all", css, ...rest }, ref) => {
+  ({ pointerEvents = "auto", css, ...rest }, ref) => {
     return (
       <iframe
         {...rest}

--- a/apps/builder/app/builder/shared/nano-states/index.ts
+++ b/apps/builder/app/builder/shared/nano-states/index.ts
@@ -34,3 +34,7 @@ export type TextToolbarState = {
 };
 const textToolbarState = atom<undefined | TextToolbarState>();
 export const useTextToolbarState = () => useValue(textToolbarState);
+
+const enabledCanvasPointerEvents = atom<boolean>(true);
+export const useEnabledCanvasPointerEvents = () =>
+  useValue(enabledCanvasPointerEvents);

--- a/apps/builder/app/builder/shared/nano-states/index.ts
+++ b/apps/builder/app/builder/shared/nano-states/index.ts
@@ -35,6 +35,4 @@ export type TextToolbarState = {
 const textToolbarState = atom<undefined | TextToolbarState>();
 export const useTextToolbarState = () => useValue(textToolbarState);
 
-const enabledCanvasPointerEvents = atom<boolean>(true);
-export const useEnabledCanvasPointerEvents = () =>
-  useValue(enabledCanvasPointerEvents);
+export const isCanvasPointerEventsEnabledStore = atom<boolean>(true);


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio-builder/issues/1213

## Description

when user drags color picker thumb, they can move mouse over canvas, with CORS canvas will hide the events and we loose control

## Steps for reproduction

1. see video in the issue
2. also affected dragging components onto canvas

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
