### PR TITLE
Support selectors in tree expanded logic

### DIFF
--- a/packages/design-system/src/components/tree/horizontal-shift.test.ts
+++ b/packages/design-system/src/components/tree/horizontal-shift.test.ts
@@ -2,9 +2,10 @@ import { describe, test, expect } from "@jest/globals";
 import { renderHook, act } from "@testing-library/react-hooks";
 import type { Placement } from "../primitives/dnd";
 import { useHorizontalShift } from "./horizontal-shift";
-import type { ItemDropTarget, ItemId } from "./item-utils";
+import type { ItemDropTarget, ItemId, ItemSelector } from "./item-utils";
 import {
   canAcceptChild,
+  findItemById,
   getItemChildren,
   getItemPath,
   Item,
@@ -112,7 +113,8 @@ const render = (
         dragItem === undefined ? undefined : getItemSelector(dragItem.id),
       dropTarget,
       root: tree,
-      getIsExpanded: (item: Item) => item.children.length > 0,
+      getIsExpanded: (itemSelector: ItemSelector) =>
+        (findItemById(tree, itemSelector[0])?.children.length ?? 0) > 0,
       canAcceptChild,
       getItemChildren,
       getItemPath,

--- a/packages/design-system/src/components/tree/horizontal-shift.ts
+++ b/packages/design-system/src/components/tree/horizontal-shift.ts
@@ -24,7 +24,7 @@ export const useHorizontalShift = <Data extends { id: string }>({
   dragItemSelector: undefined | ItemSelector;
   dropTarget: ItemDropTarget<Data> | undefined;
   root: Data;
-  getIsExpanded: (item: Data) => boolean;
+  getIsExpanded: (itemSelector: ItemSelector) => boolean;
 }) => {
   const [horizontalShift, setHorizontalShift] = useState(0);
 
@@ -145,7 +145,7 @@ export const useHorizontalShift = <Data extends { id: string }>({
 
       while (
         potentialNewParent &&
-        getIsExpanded(potentialNewParent) &&
+        getIsExpanded([potentialNewParent.id, ...newParentSelector]) &&
         canAcceptChild(potentialNewParent) &&
         shifted < desiredDepth - currentDepth
       ) {

--- a/packages/design-system/src/components/tree/item-utils.ts
+++ b/packages/design-system/src/components/tree/item-utils.ts
@@ -44,8 +44,8 @@ export const getItemSelectorFromElement = (element: Element) => {
 };
 
 export const areItemSelectorsEqual = (
-  left?: ItemSelector,
-  right?: ItemSelector
+  left: undefined | ItemSelector,
+  right: undefined | ItemSelector
 ) => {
   if (left === undefined || right === undefined) {
     return false;


### PR DESCRIPTION
Now getIsExpanded and setIsExpanded accept selectors. Though still have to use findItemById for getChildren utility. Later whole data will be managed with ids.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
