### PR TITLE
Fix stacking context issues for any combobox dropdowns

### DIFF
--- a/apps/builder/app/builder/features/props-panel/props-panel.tsx
+++ b/apps/builder/app/builder/features/props-panel/props-panel.tsx
@@ -4,9 +4,9 @@ import {
   theme,
   Box,
   useCombobox,
-  ComboboxPopper,
-  ComboboxPopperContent,
-  ComboboxPopperAnchor,
+  Combobox,
+  ComboboxContent,
+  ComboboxAnchor,
   ComboboxListbox,
   ComboboxListboxItem,
   TextField,
@@ -63,7 +63,7 @@ const InstanceInfo = ({
   </Flex>
 );
 
-const Combobox = ({
+const PropsCombobox = ({
   items,
   onItemSelect,
 }: {
@@ -85,9 +85,9 @@ const Combobox = ({
   });
 
   return (
-    <ComboboxPopper>
+    <Combobox>
       <div {...combobox.getComboboxProps()}>
-        <ComboboxPopperAnchor>
+        <ComboboxAnchor>
           <TextField
             {...combobox.getInputProps()}
             placeholder="Property"
@@ -98,8 +98,8 @@ const Combobox = ({
               />
             }
           />
-        </ComboboxPopperAnchor>
-        <ComboboxPopperContent align="end" sideOffset={5}>
+        </ComboboxAnchor>
+        <ComboboxContent align="end" sideOffset={5}>
           <ComboboxListbox {...combobox.getMenuProps()}>
             {combobox.isOpen &&
               combobox.items.map((item, index) => (
@@ -112,9 +112,9 @@ const Combobox = ({
                 </ComboboxListboxItem>
               ))}
           </ComboboxListbox>
-        </ComboboxPopperContent>
+        </ComboboxContent>
       </div>
-    </ComboboxPopper>
+    </Combobox>
   );
 };
 
@@ -175,7 +175,7 @@ const AddPropertyForm = ({
   onPropSelected: (propName: string) => void;
 }) => (
   <Flex css={{ height: theme.spacing[13] }} direction="column" justify="center">
-    <Combobox
+    <PropsCombobox
       items={availableProps}
       onItemSelect={(item) => onPropSelected(item.name)}
     />

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -3,9 +3,9 @@ import {
   Box,
   TextField,
   useCombobox,
-  ComboboxPopper,
-  ComboboxPopperContent,
-  ComboboxPopperAnchor,
+  Combobox,
+  ComboboxContent,
+  ComboboxAnchor,
   ComboboxListbox,
   ComboboxListboxItem,
   numericScrubControl,
@@ -488,9 +488,9 @@ export const CssValueInput = ({
   );
 
   return (
-    <ComboboxPopper>
+    <Combobox>
       <Box {...getComboboxProps()}>
-        <ComboboxPopperAnchor>
+        <ComboboxAnchor>
           <TextField
             disabled={disabled}
             {...inputProps}
@@ -510,12 +510,8 @@ export const CssValueInput = ({
             suffix={suffix}
             css={{ cursor: "default" }}
           />
-        </ComboboxPopperAnchor>
-        <ComboboxPopperContent
-          align="start"
-          sideOffset={8}
-          collisionPadding={10}
-        >
+        </ComboboxAnchor>
+        <ComboboxContent align="start" sideOffset={8} collisionPadding={10}>
           <ComboboxListbox {...menuProps}>
             {isOpen &&
               items.map((item, index) => (
@@ -527,9 +523,9 @@ export const CssValueInput = ({
                 </ComboboxListboxItem>
               ))}
           </ComboboxListbox>
-        </ComboboxPopperContent>
+        </ComboboxContent>
       </Box>
-    </ComboboxPopper>
+    </Combobox>
   );
 };
 

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
@@ -16,9 +16,9 @@ import {
   Box,
   ComboboxListbox,
   ComboboxListboxItem,
-  ComboboxPopper,
-  ComboboxPopperAnchor,
-  ComboboxPopperContent,
+  Combobox,
+  ComboboxAnchor,
+  ComboboxContent,
   TextFieldContainer,
   TextFieldInput,
   useTextFieldFocus,
@@ -302,9 +302,9 @@ export const StyleSourceInput = <Item extends IntermediateItem>(
   let hasNewTokenItem = false;
 
   return (
-    <ComboboxPopper>
+    <Combobox>
       <Box {...getComboboxProps()}>
-        <ComboboxPopperAnchor>
+        <ComboboxAnchor>
           <TextField
             {...inputProps}
             onRemoveItem={props.onRemoveItem}
@@ -321,8 +321,8 @@ export const StyleSourceInput = <Item extends IntermediateItem>(
             css={props.css}
             editingItemId={props.editingItemId}
           />
-        </ComboboxPopperAnchor>
-        <ComboboxPopperContent align="start" sideOffset={5}>
+        </ComboboxAnchor>
+        <ComboboxContent align="start" sideOffset={5}>
           <ComboboxListbox {...getMenuProps()}>
             {isOpen &&
               items.map((item, index) => {
@@ -373,8 +373,8 @@ export const StyleSourceInput = <Item extends IntermediateItem>(
                 );
               })}
           </ComboboxListbox>
-        </ComboboxPopperContent>
+        </ComboboxContent>
       </Box>
-    </ComboboxPopper>
+    </Combobox>
   );
 };

--- a/packages/design-system/src/components/combobox.tsx
+++ b/packages/design-system/src/components/combobox.tsx
@@ -8,11 +8,13 @@ import {
   useRef,
   type ChangeEvent,
   type ReactNode,
+  Ref,
 } from "react";
 // @todo:
 //   react-popper "is an internal utility, not intended for public usage"
 //   probably need to switch to @radix-ui/react-popover
 import { Popper, PopperContent, PopperAnchor } from "@radix-ui/react-popper";
+import { Portal } from "@radix-ui/react-portal";
 import {
   type DownshiftState,
   type UseComboboxStateChangeOptions,
@@ -90,11 +92,18 @@ export const ComboboxListbox = Listbox;
 
 export const ComboboxListboxItem = forwardRef(ListboxItemBase);
 
-export const ComboboxPopper = Popper;
+export const Combobox = Popper;
 
-export const ComboboxPopperContent = PopperContent;
+export const ComboboxContent = forwardRef(
+  (props: ComponentProps<typeof PopperContent>, ref: Ref<HTMLDivElement>) => (
+    <Portal>
+      <PopperContent ref={ref} {...props} />
+    </Portal>
+  )
+);
+ComboboxContent.displayName = "ComboboxContent";
 
-export const ComboboxPopperAnchor = PopperAnchor;
+export const ComboboxAnchor = PopperAnchor;
 
 type Match<Item> = (
   search: string,

--- a/packages/design-system/src/components/menu.stories.tsx
+++ b/packages/design-system/src/components/menu.stories.tsx
@@ -18,9 +18,9 @@ import {
 } from "./dropdown-menu";
 import {
   useCombobox,
-  ComboboxPopper,
-  ComboboxPopperContent,
-  ComboboxPopperAnchor,
+  Combobox,
+  ComboboxContent,
+  ComboboxAnchor,
   ComboboxListbox,
   ComboboxListboxItem,
   ComboboxLabel,
@@ -175,9 +175,9 @@ const ComboboxDemo = () => {
   const longItems = items.filter((item) => item === "Banana");
 
   return (
-    <ComboboxPopper>
+    <Combobox>
       <div {...getComboboxProps()}>
-        <ComboboxPopperAnchor>
+        <ComboboxAnchor>
           <TextField
             {...getInputProps()}
             placeholder="Enter: Apple"
@@ -187,8 +187,8 @@ const ComboboxDemo = () => {
               </DeprecatedIconButton>
             }
           />
-        </ComboboxPopperAnchor>
-        <ComboboxPopperContent align="end" sideOffset={5}>
+        </ComboboxAnchor>
+        <ComboboxContent align="end" sideOffset={5}>
           <ComboboxListbox {...getMenuProps()}>
             {roundItems.length > 0 && (
               <>
@@ -206,9 +206,9 @@ const ComboboxDemo = () => {
               </>
             )}
           </ComboboxListbox>
-        </ComboboxPopperContent>
+        </ComboboxContent>
       </div>
-    </ComboboxPopper>
+    </Combobox>
   );
 };
 


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio-builder/issues/1104

## Description

anything that uses position relative has higher stacking context, in this case spacing uses position relative, so we always use portal to prevent the need to use zIndex

## Steps for reproduction

1. open spacing
2. open style sources dropdown
3. it should not overlap

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
