### PR TITLE
Refactor tree node with selectors

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/navigator/navigator.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/navigator/navigator.tsx
@@ -1,20 +1,15 @@
 import { useCallback } from "react";
 import { useStore } from "@nanostores/react";
 import { Flex } from "@webstudio-is/design-system";
-import type { Instance } from "@webstudio-is/project-build";
 import {
   selectedInstanceSelectorStore,
   hoveredInstanceSelectorStore,
   useRootInstance,
-  instancesStore,
 } from "~/shared/nano-states";
 import { InstanceTree } from "~/builder/shared/tree";
 import { reparentInstance } from "~/shared/instance-utils";
+import type { InstanceSelector } from "~/shared/tree-utils";
 import { Header, CloseButton } from "../header";
-import {
-  getInstanceSelector,
-  type InstanceSelector,
-} from "~/shared/tree-utils";
 
 type NavigatorProps = {
   isClosable?: boolean;
@@ -24,12 +19,6 @@ type NavigatorProps = {
 export const Navigator = ({ isClosable, onClose }: NavigatorProps) => {
   const selectedInstanceSelector = useStore(selectedInstanceSelectorStore);
   const [rootInstance] = useRootInstance();
-
-  const handleSelect = useCallback((instanceId: Instance["id"]) => {
-    const instances = instancesStore.get();
-    const instanceSelector = getInstanceSelector(instances, instanceId);
-    selectedInstanceSelectorStore.set(instanceSelector);
-  }, []);
 
   const handleDragEnd = useCallback(
     (payload: {
@@ -44,16 +33,6 @@ export const Navigator = ({ isClosable, onClose }: NavigatorProps) => {
     []
   );
 
-  const handleHover = useCallback((instance: Instance | undefined) => {
-    if (instance) {
-      const instances = instancesStore.get();
-      const instanceSelector = getInstanceSelector(instances, instance.id);
-      hoveredInstanceSelectorStore.set(instanceSelector);
-    } else {
-      hoveredInstanceSelectorStore.set(undefined);
-    }
-  }, []);
-
   if (rootInstance === undefined) {
     return null;
   }
@@ -67,9 +46,8 @@ export const Navigator = ({ isClosable, onClose }: NavigatorProps) => {
         <InstanceTree
           root={rootInstance}
           selectedItemSelector={selectedInstanceSelector}
-          // @todo provide in callback instance selector instead of just id
-          onSelect={handleSelect}
-          onHover={handleHover}
+          onSelect={selectedInstanceSelectorStore.set}
+          onHover={hoveredInstanceSelectorStore.set}
           onDragEnd={handleDragEnd}
         />
       </Flex>

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
@@ -6,6 +6,7 @@ import {
   TreeItemBody,
   TreeNode,
   type TreeItemRenderProps,
+  type ItemSelector,
   styled,
   Flex,
   Tooltip,
@@ -28,7 +29,6 @@ import { SettingsPanel } from "./settings-panel";
 import { NewPageSettings, PageSettings } from "./settings";
 import { pagesStore, selectedPageIdStore } from "~/shared/nano-states";
 import { useSwitchPage } from "~/shared/pages";
-import type { ItemSelector } from "@webstudio-is/design-system/src/components/tree/item-utils";
 
 type TabContentProps = {
   onSetActiveTab: (tabName: TabName) => void;

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
@@ -28,6 +28,7 @@ import { SettingsPanel } from "./settings-panel";
 import { NewPageSettings, PageSettings } from "./settings";
 import { pagesStore, selectedPageIdStore } from "~/shared/nano-states";
 import { useSwitchPage } from "~/shared/pages";
+import type { ItemSelector } from "@webstudio-is/design-system/src/components/tree/item-utils";
 
 type TabContentProps = {
   onSetActiveTab: (tabName: TabName) => void;
@@ -150,7 +151,7 @@ const PagesPanel = ({
           suffix={
             onEdit && (
               <ItemSuffix
-                isParentSelected={props.selectedItemId === props.itemData.id}
+                isParentSelected={props.parentIsSelected ?? false}
                 itemId={props.itemData.id}
                 editingItemId={editingPageId}
                 onEdit={onEdit}
@@ -167,6 +168,11 @@ const PagesPanel = ({
       );
     },
     [editingPageId, onEdit]
+  );
+
+  const selectTreeNode = useCallback(
+    ([pageId]: ItemSelector) => onSelect(pageId),
+    [onSelect]
   );
 
   if (pagesTree === undefined) {
@@ -204,8 +210,8 @@ const PagesPanel = ({
       />
       <TreeNode
         hideRoot
-        selectedItemId={selectedPageId}
-        onSelect={onSelect}
+        selectedItemSelector={[selectedPageId, pagesTree.id]}
+        onSelect={selectTreeNode}
         itemData={pagesTree}
         renderItem={renderItem}
         getItemChildren={(nodeId) => {

--- a/apps/builder/app/builder/features/tree-preview/tree-preview.tsx
+++ b/apps/builder/app/builder/features/tree-preview/tree-preview.tsx
@@ -11,6 +11,7 @@ import {
 } from "~/shared/nano-states";
 import { InstanceTreeNode } from "~/builder/shared/tree";
 import {
+  type InstanceSelector,
   createInstancesIndex,
   getInstanceAncestorsAndSelf,
   insertInstanceMutableDeprecated,
@@ -58,6 +59,13 @@ export const TreePrevew = () => {
       }
     })(rootInstance);
 
+    const dragItemSelector = getInstanceAncestorsAndSelf(
+      createInstancesIndex(instance),
+      dropTargetInstanceId
+    )
+      .map((item) => item.id)
+      .reverse();
+
     const dropTargetPath = getInstanceAncestorsAndSelf(
       instancesIndex,
       dropTargetInstanceId
@@ -65,9 +73,9 @@ export const TreePrevew = () => {
 
     return {
       itemData: instance,
-      selectedItemId: dragItemInstance.id,
-      getIsExpanded: (instance: Instance) =>
-        dropTargetPath.includes(instance.id),
+      selectedItemSelector: dragItemSelector,
+      getIsExpanded: ([instanceId]: InstanceSelector) =>
+        dropTargetPath.includes(instanceId),
       animate: false,
     };
   }, [

--- a/packages/design-system/src/components/tree/index.ts
+++ b/packages/design-system/src/components/tree/index.ts
@@ -1,2 +1,3 @@
+export type { ItemSelector } from "./item-utils";
 export * from "./tree";
 export * from "./tree-node";

--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -482,22 +482,22 @@ export const TreeNode = <Data extends { id: string }>({
       onOpenChange={(isOpen) => setIsExpanded?.(itemSelector, isOpen)}
       data-drop-target-id={itemData.id}
     >
-      {parentSelector !== undefined ||
-        (hideRoot !== true &&
-          renderItem({
-            dropTargetItemId,
-            onMouseEnter,
-            onMouseLeave,
-            itemData,
-            itemSelector,
-            parentIsSelected,
-            isSelected,
-            onSelect,
-            level,
-            isAlwaysExpanded,
-            shouldRenderExpandButton,
-            isExpanded,
-          }))}
+      {/* optionally prevent rendering root item */}
+      {(parentSelector !== undefined || hideRoot !== true) &&
+        renderItem({
+          dropTargetItemId,
+          onMouseEnter,
+          onMouseLeave,
+          itemData,
+          itemSelector,
+          parentIsSelected,
+          isSelected,
+          onSelect,
+          level,
+          isAlwaysExpanded,
+          shouldRenderExpandButton,
+          isExpanded,
+        })}
       {isExpandable && (
         <CollapsibleContent
           onAnimationEnd={handleAnimationEnd}

--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -245,11 +245,11 @@ const useScrollIntoView = (
 };
 
 export type TreeItemRenderProps<Data extends { id: string }> = {
-  dropTargetItemId?: string;
   onMouseEnter?: (itemSelector: ItemSelector) => void;
   onMouseLeave?: (itemSelector: ItemSelector) => void;
   itemData: Data;
   itemSelector: ItemSelector;
+  dropTargetItemSelector?: ItemSelector;
   parentIsSelected?: boolean;
   isSelected?: boolean;
   onSelect?: (itemSelector: ItemSelector) => void;
@@ -264,7 +264,7 @@ export const TreeItemBody = <Data extends { id: string }>({
   onSelect,
   parentIsSelected = false,
   isSelected = false,
-  dropTargetItemId,
+  dropTargetItemSelector,
   onMouseEnter,
   onMouseLeave,
   itemData,
@@ -315,8 +315,11 @@ export const TreeItemBody = <Data extends { id: string }>({
       : { handleFocus: () => onSelect(itemSelector) };
   }, [selectionEvent, onSelect, itemSelector]);
 
-  const isDragging = dropTargetItemId !== undefined;
-  const isDropTarget = dropTargetItemId === itemData.id;
+  const isDragging = dropTargetItemSelector !== undefined;
+  const isDropTarget = areItemSelectorsEqual(
+    dropTargetItemSelector,
+    itemSelector
+  );
 
   useScrollIntoView(itemButtonRef.current, {
     isSelected,
@@ -399,15 +402,15 @@ export type TreeNodeProps<Data extends { id: ItemId }> = {
   onExpandTransitionEnd?: () => void;
 
   selectedItemSelector?: ItemSelector;
+  dropTargetItemSelector?: ItemSelector;
+  parentSelector?: ItemSelector;
+
   parentIsSelected?: boolean;
   onSelect?: (itemSelector: ItemSelector) => void;
   onMouseEnter?: (itemSelector: ItemSelector) => void;
   onMouseLeave?: (itemSelector: ItemSelector) => void;
 
-  parentSelector?: ItemSelector;
   animate?: boolean;
-  dropTargetItemId?: string;
-
   hideRoot?: boolean;
 };
 
@@ -427,7 +430,7 @@ export const TreeNode = <Data extends { id: string }>({
     onMouseEnter,
     onMouseLeave,
     onExpandTransitionEnd,
-    dropTargetItemId,
+    dropTargetItemSelector,
     renderItem,
     getItemChildren,
   } = commonProps;
@@ -485,7 +488,7 @@ export const TreeNode = <Data extends { id: string }>({
       {/* optionally prevent rendering root item */}
       {(parentSelector !== undefined || hideRoot !== true) &&
         renderItem({
-          dropTargetItemId,
+          dropTargetItemSelector,
           onMouseEnter,
           onMouseLeave,
           itemData,

--- a/packages/design-system/src/components/tree/tree.stories.tsx
+++ b/packages/design-system/src/components/tree/tree.stories.tsx
@@ -83,13 +83,7 @@ export const StressTest = ({ animate }: { animate: boolean }) => {
         animate={animate}
         root={root}
         selectedItemSelector={selectedItemSelector}
-        onSelect={(instanceId) => {
-          setSelectedItemSelector(
-            getItemPath(root, instanceId)
-              .reverse()
-              .map((item) => item.id)
-          );
-        }}
+        onSelect={setSelectedItemSelector}
         renderItem={(props) => (
           <TreeItemBody {...props}>
             <TreeItemLabel>{props.itemData.id}</TreeItemLabel>

--- a/packages/design-system/src/components/tree/tree.tsx
+++ b/packages/design-system/src/components/tree/tree.tsx
@@ -32,8 +32,8 @@ export type TreeProps<Data extends { id: string }> = {
   getItemChildren: (itemId: ItemId) => Data[];
   renderItem: (props: TreeItemRenderProps<Data>) => React.ReactNode;
 
-  onSelect?: (itemId: string) => void;
-  onHover?: (item: Data | undefined) => void;
+  onSelect?: (itemSelector: ItemSelector) => void;
+  onHover?: (itemSelector: undefined | ItemSelector) => void;
   animate?: boolean;
   onDragEnd: (event: {
     itemSelector: ItemSelector;
@@ -206,12 +206,11 @@ export const Tree = <Data extends { id: string }>({
       return instance;
     },
     onStart: ({ data }) => {
-      onSelect?.(data.id);
-      setDragItemSelector(
-        getItemPath(root, data.id)
-          .reverse()
-          .map((item) => item.id)
-      );
+      const itemSelector = getItemPath(root, data.id)
+        .reverse()
+        .map((item) => item.id);
+      onSelect?.(itemSelector);
+      setDragItemSelector(itemSelector);
       dropHandlers.handleStart();
       autoScrollHandlers.setEnabled(true);
     },
@@ -255,13 +254,6 @@ export const Tree = <Data extends { id: string }>({
     onEsc: dragHandlers.cancelCurrentDrag,
   });
 
-  const [onMouseEnter, onMouseLeave] = useMemo(() => {
-    if (onHover === undefined) {
-      return [undefined, undefined];
-    }
-    return [(item: Data) => onHover(item), () => onHover(undefined)] as const;
-  }, [onHover]);
-
   return (
     <Box
       css={{
@@ -290,23 +282,12 @@ export const Tree = <Data extends { id: string }>({
           getItemChildren={getItemChildren}
           animate={animate}
           onSelect={onSelect}
-          onMouseEnter={onMouseEnter}
-          onMouseLeave={onMouseLeave}
-          selectedItemId={selectedItemSelector?.[0]}
+          onMouseEnter={onHover}
+          onMouseLeave={onHover}
+          selectedItemSelector={selectedItemSelector}
           itemData={root}
-          level={0}
-          getIsExpanded={(item) => {
-            const itemSelector = getItemPath(root, item.id)
-              .map((item) => item.id)
-              .reverse();
-            return getIsExpanded(itemSelector);
-          }}
-          setIsExpanded={(item, isExpanded) => {
-            const itemSelector = getItemPath(root, item.id)
-              .map((item) => item.id)
-              .reverse();
-            setIsExpanded(itemSelector, isExpanded);
-          }}
+          getIsExpanded={getIsExpanded}
+          setIsExpanded={setIsExpanded}
           onExpandTransitionEnd={dropHandlers.handleDomMutation}
           dropTargetItemId={shiftedDropTarget?.itemSelector[0]}
         />

--- a/packages/design-system/src/components/tree/tree.tsx
+++ b/packages/design-system/src/components/tree/tree.tsx
@@ -289,7 +289,7 @@ export const Tree = <Data extends { id: string }>({
           getIsExpanded={getIsExpanded}
           setIsExpanded={setIsExpanded}
           onExpandTransitionEnd={dropHandlers.handleDomMutation}
-          dropTargetItemId={shiftedDropTarget?.itemSelector[0]}
+          dropTargetItemSelector={shiftedDropTarget?.itemSelector}
         />
       </Box>
 


### PR DESCRIPTION
Tree node is a renderer for pages and navigator instances. Selector of nodes is build by passing parent selectors.

Select and hover callbacks are now provide selectors.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
