### PR TITLE
Simplify horizontal shift computation

### DIFF
--- a/packages/design-system/src/components/tree/horizontal-shift.test.ts
+++ b/packages/design-system/src/components/tree/horizontal-shift.test.ts
@@ -76,9 +76,8 @@ const makeDrop = ({
   into: Item;
   after?: Item;
   placement?: Placement;
-}): ItemDropTarget<Item> => ({
+}): ItemDropTarget => ({
   itemSelector: getItemSelector(into.id),
-  data: into,
   indexWithinChildren:
     after === undefined ? 0 : into.children.indexOf(after) + 1,
   placement,
@@ -97,7 +96,7 @@ const render = (
     dropTarget,
   }: {
     dragItem: Item | undefined;
-    dropTarget: ItemDropTarget<Item> | undefined;
+    dropTarget: ItemDropTarget | undefined;
   },
   shift = -1
 ) => {
@@ -106,14 +105,12 @@ const render = (
       dragItemSelector:
         dragItem === undefined ? undefined : getItemSelector(dragItem.id),
       dropTarget,
-      root: tree,
       getIsExpanded: (itemSelector: ItemSelector) =>
         (findItemById(tree, itemSelector[0])?.children.length ?? 0) > 0,
       canAcceptChild: (itemId: ItemId) =>
         findItemById(tree, itemId)?.canAcceptChildren ?? false,
       getItemChildren: (itemId: ItemId) =>
         findItemById(tree, itemId)?.children ?? [],
-      getItemPath,
     },
   });
 

--- a/packages/design-system/src/components/tree/item-utils.ts
+++ b/packages/design-system/src/components/tree/item-utils.ts
@@ -4,9 +4,8 @@ export type ItemId = string;
 
 export type ItemSelector = string[];
 
-export type ItemDropTarget<Item> = {
+export type ItemDropTarget = {
   itemSelector: ItemSelector;
-  data: Item;
   rect: DOMRect;
   indexWithinChildren: number;
   placement: Placement;

--- a/packages/design-system/src/components/tree/tree.tsx
+++ b/packages/design-system/src/components/tree/tree.tsx
@@ -65,7 +65,7 @@ export const Tree = <Data extends { id: string }>({
   const [dragItemSelector, setDragItemSelector] = useState<
     undefined | ItemSelector
   >();
-  const [dropTarget, setDropTarget] = useState<ItemDropTarget<Data>>();
+  const [dropTarget, setDropTarget] = useState<ItemDropTarget>();
 
   const getDropTargetElement = useCallback(
     (id: string): HTMLElement | null | undefined =>
@@ -76,9 +76,7 @@ export const Tree = <Data extends { id: string }>({
   const [shiftedDropTarget, setHorizontalShift] = useHorizontalShift({
     dragItemSelector,
     dropTarget,
-    root,
     getIsExpanded,
-    getItemPath,
     getItemChildren,
     canAcceptChild,
   });
@@ -91,7 +89,7 @@ export const Tree = <Data extends { id: string }>({
     };
   };
 
-  const useHoldHandler = useHold<ItemDropTarget<Data>>({
+  const useHoldHandler = useHold<ItemDropTarget>({
     isEqual: (a, b) => areItemSelectorsEqual(a.itemSelector, b.itemSelector),
     holdTimeThreshold: 600,
     onHold: (dropTarget) => {


### PR DESCRIPTION
- root and getItemPath are no longer required
- dropTarget.data with instance no longer used, only selector is necessary

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
