### PR TITLE
Render tree with normalized data

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/navigator/navigator.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/navigator/navigator.tsx
@@ -2,9 +2,9 @@ import { useCallback } from "react";
 import { useStore } from "@nanostores/react";
 import { Flex } from "@webstudio-is/design-system";
 import {
+  rootInstanceStore,
   selectedInstanceSelectorStore,
   hoveredInstanceSelectorStore,
-  useRootInstance,
 } from "~/shared/nano-states";
 import { InstanceTree } from "~/builder/shared/tree";
 import { reparentInstance } from "~/shared/instance-utils";
@@ -18,15 +18,15 @@ type NavigatorProps = {
 
 export const Navigator = ({ isClosable, onClose }: NavigatorProps) => {
   const selectedInstanceSelector = useStore(selectedInstanceSelectorStore);
-  const [rootInstance] = useRootInstance();
+  const rootInstance = useStore(rootInstanceStore);
 
   const handleDragEnd = useCallback(
     (payload: {
       itemSelector: InstanceSelector;
-      dropTarget: { itemId: string; position: number | "end" };
+      dropTarget: { itemSelector: InstanceSelector; position: number | "end" };
     }) => {
       reparentInstance(payload.itemSelector[0], {
-        parentId: payload.dropTarget.itemId,
+        parentId: payload.dropTarget.itemSelector[0],
         position: payload.dropTarget.position,
       });
     },

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -78,6 +78,16 @@ export const useSetInstances = (
   });
 };
 
+export const rootInstanceStore = computed(
+  [instancesStore, selectedPageStore],
+  (instances, selectedPage) => {
+    if (selectedPage === undefined) {
+      return undefined;
+    }
+    return instances.get(selectedPage.rootInstanceId);
+  }
+);
+
 // @todo will be removed soon
 const denormalizeTree = (
   instances: Instances,

--- a/packages/design-system/src/components/tree/item-utils.ts
+++ b/packages/design-system/src/components/tree/item-utils.ts
@@ -20,11 +20,7 @@ export const getElementByItemSelector = (
     .map((id) => `[data-drop-target-id="${id}"]`)
     .reverse()
     .join(" ");
-  const [itemId] = itemSelector;
-  return (
-    root?.querySelector(`${domSelector} [data-item-button-id="${itemId}"]`) ??
-    undefined
-  );
+  return root?.querySelector(domSelector) ?? undefined;
 };
 
 export const getItemSelectorFromElement = (element: Element) => {

--- a/packages/design-system/src/components/tree/test-tree-data.ts
+++ b/packages/design-system/src/components/tree/test-tree-data.ts
@@ -52,7 +52,7 @@ export const reparent = (
   }: {
     itemSelector: ItemSelector;
     dropTarget: {
-      itemId: string;
+      itemSelector: ItemSelector;
       position: number | "end";
     };
   }
@@ -62,7 +62,7 @@ export const reparent = (
     const path = getItemPath(draft, itemId);
     const item = path[path.length - 1];
     const currentParent = path[path.length - 2];
-    const newParent = findItemById(draft, dropTarget.itemId);
+    const newParent = findItemById(draft, dropTarget.itemSelector[0]);
 
     if (
       item === undefined ||

--- a/packages/design-system/src/components/tree/tree.stories.tsx
+++ b/packages/design-system/src/components/tree/tree.stories.tsx
@@ -1,7 +1,7 @@
 import type { ComponentMeta } from "@storybook/react";
 import { useState } from "react";
 import { Tree } from "./tree";
-import { findItemById, getItemPath, Item, reparent } from "./test-tree-data";
+import { findItemById, Item, reparent } from "./test-tree-data";
 import { Flex } from "../flex";
 import { TreeItemLabel, TreeItemBody } from "./tree-node";
 import type { ItemSelector } from "./item-utils";
@@ -73,8 +73,6 @@ export const StressTest = ({ animate }: { animate: boolean }) => {
   return (
     <Flex css={{ width: 300, height: 500, flexDirection: "column" }}>
       <Tree
-        findItemById={findItemById}
-        getItemPath={getItemPath}
         canAcceptChild={(itemId) =>
           findItemById(root, itemId)?.canAcceptChildren ?? false
         }


### PR DESCRIPTION
We finally able to use normalized data to render tree. A few last improvements in tree drag and drop add support for slots with duplicating ids within tree.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
