### PR TITLE
Hide outline on mouse out

### DIFF
--- a/apps/builder/app/canvas/instance-hovering.ts
+++ b/apps/builder/app/canvas/instance-hovering.ts
@@ -41,6 +41,7 @@ export const subscribeInstanceHovering = () => {
     mouseOutTimeoutId = setTimeout(() => {
       hoveredElement = undefined;
       hoveredInstanceSelectorStore.set(undefined);
+      hoveredInstanceOutlineStore.set(undefined);
     }, 100);
   };
 


### PR DESCRIPTION
## Description

1. If you mouse over and then mouse out directly to the side, without hovering other instances, the instance outline gets stuck


## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
