### PR TITLE
Refactor canvas drag and drop to rely on instance selectors

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
@@ -9,7 +9,6 @@ import {
 } from "@webstudio-is/react-sdk";
 import { theme, Flex, useDrag, type Point } from "@webstudio-is/design-system";
 import { PlusIcon } from "@webstudio-is/icons";
-import { utils } from "@webstudio-is/project";
 import { findClosestDroppableTarget } from "~/shared/tree-utils";
 import {
   instancesIndexStore,
@@ -133,8 +132,8 @@ export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
       publish({
         type: "dragStart",
         payload: {
-          origin: "panel",
-          dragItem: utils.tree.createInstance({ component: componentName }),
+          type: "insert",
+          dragComponent: componentName,
         },
       });
       isCanvasPointerEventsEnabledStore.set(false);
@@ -150,7 +149,7 @@ export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
       setDragComponent(undefined);
       publish({
         type: "dragEnd",
-        payload: { origin: "panel", isCanceled },
+        payload: { isCanceled },
       });
       isCanvasPointerEventsEnabledStore.set(true);
     },

--- a/apps/builder/app/builder/features/workspace/canvas-tools/canvas-tools.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/canvas-tools.tsx
@@ -1,3 +1,4 @@
+import { useStore } from "@nanostores/react";
 import type { Publish } from "~/shared/pubsub";
 import { Box } from "@webstudio-is/design-system";
 import { PlacementIndicator } from "@webstudio-is/design-system";
@@ -7,6 +8,7 @@ import {
   useSubscribeScrollState,
   useDragAndDropState,
   useSubscribeDragAndDropState,
+  instancesStore,
 } from "~/shared/nano-states";
 import { HoveredInstanceOutline, SelectedInstanceOutline } from "./outline";
 import { useSubscribeTextToolbar, TextToolbar } from "./text-toolbar";
@@ -42,6 +44,7 @@ export const CanvasTools = ({ publish }: CanvasToolsProps) => {
   const [isPreviewMode] = useIsPreviewMode();
   const [isScrolling] = useIsScrolling();
   const [dragAndDropState] = useDragAndDropState();
+  const instances = useStore(instancesStore);
 
   if (
     dragAndDropState.isDragging &&
@@ -49,11 +52,12 @@ export const CanvasTools = ({ publish }: CanvasToolsProps) => {
     dragAndDropState.placementIndicator !== undefined
   ) {
     const { dropTarget, placementIndicator } = dragAndDropState;
-    return (
+    const dropTargetInstance = instances.get(dropTarget.itemSelector[0]);
+    return dropTargetInstance ? (
       <Box css={toolsStyle}>
         <Outline rect={placementIndicator.parentRect}>
           <Label
-            instance={dropTarget.instance}
+            instance={dropTargetInstance}
             instanceRect={placementIndicator.parentRect}
           />
         </Outline>
@@ -61,7 +65,7 @@ export const CanvasTools = ({ publish }: CanvasToolsProps) => {
           <PlacementIndicator placement={placementIndicator} />
         )}
       </Box>
-    );
+    ) : null;
   }
 
   if (isPreviewMode || isScrolling) {

--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -1,43 +1,24 @@
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import { useStore } from "@nanostores/react";
 import {
   hoveredInstanceSelectorStore,
-  instancesStore,
   rootInstanceStore,
   selectedInstanceSelectorStore,
   useDragAndDropState,
 } from "~/shared/nano-states";
-import { getInstanceSelector, InstanceSelector } from "~/shared/tree-utils";
+import type { InstanceSelector } from "~/shared/tree-utils";
 import { InstanceTree } from "./tree";
-import type { ItemDropTarget } from "@webstudio-is/design-system";
 import { reparentInstance } from "~/shared/instance-utils";
 
 export const NavigatorTree = () => {
-  const instances = useStore(instancesStore);
   const selectedInstanceSelector = useStore(selectedInstanceSelectorStore);
   const rootInstance = useStore(rootInstanceStore);
   const [state, setState] = useDragAndDropState();
 
-  const dragItemSelector = useMemo(() => {
-    if (state.dragItem?.id === undefined) {
-      return;
-    }
-    return getInstanceSelector(instances, state.dragItem.id);
-  }, [state.dragItem, instances]);
-
-  const dropTarget = useMemo((): undefined | ItemDropTarget => {
-    if (state.dropTarget === undefined) {
-      return;
-    }
-    return {
-      placement: state.dropTarget.placement,
-      indexWithinChildren: state.dropTarget.position,
-      itemSelector: getInstanceSelector(
-        instances,
-        state.dropTarget.instance.id
-      ),
-    };
-  }, [state.dropTarget, instances]);
+  const dragItemSelector =
+    state.dragPayload?.type === "reparent"
+      ? state.dragPayload.dragInstanceSelector
+      : undefined;
 
   const handleDragEnd = useCallback(
     (payload: {
@@ -61,31 +42,17 @@ export const NavigatorTree = () => {
       root={rootInstance}
       selectedItemSelector={selectedInstanceSelector}
       dragItemSelector={dragItemSelector}
-      dropTarget={dropTarget}
+      dropTarget={state.dropTarget}
       onSelect={selectedInstanceSelectorStore.set}
       onHover={hoveredInstanceSelectorStore.set}
-      onDragItemChange={(dragItemSelector) => {
-        const instances = instancesStore.get();
-        const instance = instances.get(dragItemSelector[0]);
-        if (instance === undefined) {
-          return;
-        }
-        setState({ ...state, dragItem: instance });
-      }}
-      onDropTargetChange={(dropTarget) => {
-        const instances = instancesStore.get();
-        const instance = instances.get(dropTarget.itemSelector[0]);
-        if (instance === undefined) {
-          return;
-        }
+      onDragItemChange={(dragInstanceSelector) => {
         setState({
           ...state,
-          dropTarget: {
-            placement: dropTarget.placement,
-            position: dropTarget.indexWithinChildren,
-            instance,
-          },
+          dragPayload: { type: "reparent", dragInstanceSelector },
         });
+      }}
+      onDropTargetChange={(dropTarget) => {
+        setState({ ...state, dropTarget });
       }}
       onDragEnd={handleDragEnd}
     />

--- a/apps/builder/app/canvas/shared/use-drag-drop.ts
+++ b/apps/builder/app/canvas/shared/use-drag-drop.ts
@@ -1,22 +1,17 @@
 import { useLayoutEffect, useRef } from "react";
-import { useStore } from "@nanostores/react";
+import type { Instance } from "@webstudio-is/project-build";
 import {
-  type DropTarget,
   type Point,
   type Placement,
+  type ItemDropTarget,
   useAutoScroll,
   useDrag,
   useDrop,
   computeIndicatorPlacement,
 } from "@webstudio-is/design-system";
-import {
-  type Instance,
-  type BaseInstance,
-  toBaseInstance,
-} from "@webstudio-is/project-build";
 import { getComponentMeta } from "@webstudio-is/react-sdk";
 import {
-  instancesIndexStore,
+  instancesStore,
   useRootInstance,
   useTextEditingInstanceId,
 } from "~/shared/nano-states";
@@ -26,12 +21,15 @@ import {
   reparentInstance,
 } from "~/shared/instance-utils";
 import {
+  getElementByInstanceSelector,
   getInstanceElementById,
   getInstanceIdFromElement,
+  getInstanceSelectorFromElement,
 } from "~/shared/dom-utils";
 import {
-  findClosestRichTextInstance,
-  getInstanceAncestorsAndSelf,
+  type InstanceSelector,
+  getAncestorInstanceSelector,
+  areInstanceSelectorsEqual,
 } from "~/shared/tree-utils";
 
 declare module "~/shared/pubsub" {
@@ -39,35 +37,59 @@ declare module "~/shared/pubsub" {
     dragEnd: DragEndPayload;
     dragMove: DragMovePayload;
     dragStart: DragStartPayload;
-    dropTargetChange: DropTargetChangePayload;
+    dropTargetChange: ItemDropTarget;
     placementIndicatorChange: Placement;
   }
 }
 
-export type DropTargetChangePayload = {
-  placement: DropTarget<null>["placement"];
-  position: number;
-  instance: BaseInstance;
-};
-
-export type DragStartPayload = {
-  origin: "panel" | "canvas";
-  dragItem: BaseInstance;
-};
+export type DragStartPayload =
+  | { type: "insert"; dragComponent: Instance["component"] }
+  | { type: "reparent"; dragInstanceSelector: InstanceSelector };
 
 export type DragEndPayload = {
-  origin: "panel" | "canvas";
   isCanceled: boolean;
 };
 
 export type DragMovePayload = { canvasCoordinates: Point };
 
+const findClosestRichTextInstanceSelector = (
+  instanceSelector: InstanceSelector
+) => {
+  const instances = instancesStore.get();
+  for (const instanceId of instanceSelector) {
+    const instance = instances.get(instanceId);
+    if (
+      instance !== undefined &&
+      getComponentMeta(instance.component)?.type === "rich-text"
+    ) {
+      return getAncestorInstanceSelector(instanceSelector, instanceId);
+    }
+  }
+  return;
+};
+
+const findClosestDroppableInstanceSelector = (
+  instanceSelector: InstanceSelector
+) => {
+  const instances = instancesStore.get();
+  for (const instanceId of instanceSelector) {
+    const instance = instances.get(instanceId);
+    if (instance !== undefined) {
+      const meta = getComponentMeta(instance.component);
+      if (meta?.type === "body" || meta?.type === "container") {
+        return getAncestorInstanceSelector(instanceSelector, instanceId);
+      }
+    }
+  }
+  return;
+};
+
 const initialState: {
-  dropTarget: DropTargetChangePayload | undefined;
-  dragItem: BaseInstance | undefined;
+  dropTarget: ItemDropTarget | undefined;
+  dragPayload: DragStartPayload | undefined;
 } = {
   dropTarget: undefined,
-  dragItem: undefined,
+  dragPayload: undefined,
 };
 
 const sharedDropOptions = {
@@ -80,8 +102,6 @@ const sharedDropOptions = {
 
 export const useDragAndDrop = () => {
   const [rootInstance] = useRootInstance();
-  const instancesIndex = useStore(instancesIndexStore);
-  const { instancesById } = instancesIndex;
   const [textEditingInstanceId] = useTextEditingInstanceId();
 
   const state = useRef({ ...initialState });
@@ -96,70 +116,74 @@ export const useDragAndDrop = () => {
       throw new Error("Could not find root instance element");
     }
 
-    return { element, data: rootInstance };
+    return { element, data: [rootInstance.id] };
   };
 
-  const dropHandlers = useDrop<Instance>({
+  const dropHandlers = useDrop<InstanceSelector>({
     ...sharedDropOptions,
 
     elementToData(element) {
-      const instanceId = getInstanceIdFromElement(element);
-      const instance =
-        instanceId === undefined ? undefined : instancesById.get(instanceId);
-
-      return instance || false;
+      const instanceSelector = getInstanceSelectorFromElement(element);
+      if (instanceSelector === undefined) {
+        return false;
+      }
+      return instanceSelector;
     },
 
     // This must be fast, it can be called multiple times per pointer move
     swapDropTarget(dropTarget) {
-      const { dragItem } = state.current;
+      const { dragPayload } = state.current;
 
-      if (!dropTarget || dragItem === undefined || rootInstance === undefined) {
+      if (
+        dropTarget === undefined ||
+        dragPayload === undefined ||
+        rootInstance === undefined
+      ) {
         return getDefaultDropTarget();
       }
 
-      if (dropTarget.data.id === rootInstance.id) {
+      const dropInstanceSelector = dropTarget.data;
+      if (dropInstanceSelector.length === 1) {
         return dropTarget;
       }
 
-      const path = getInstanceAncestorsAndSelf(
-        instancesIndex,
-        dropTarget.data.id
-      );
-      path.reverse();
-
+      const newDropInstanceSelector = dropInstanceSelector.slice();
       if (dropTarget.area !== "center") {
-        path.shift();
+        newDropInstanceSelector.shift();
       }
 
       // Don't allow to drop inside drag item or any of its children
-      const dragItemIndex = path.findIndex(
-        (instance) => instance.id === dragItem.id
-      );
-      if (dragItemIndex !== -1) {
-        path.splice(0, dragItemIndex + 1);
+      if (dragPayload.type === "reparent") {
+        const [dragInstanceId] = dragPayload.dragInstanceSelector;
+        const dragInstanceIndex =
+          newDropInstanceSelector.indexOf(dragInstanceId);
+        if (dragInstanceIndex !== -1) {
+          newDropInstanceSelector.splice(0, dragInstanceIndex + 1);
+        }
       }
 
-      const data = path.find((instance) => {
-        const meta = getComponentMeta(instance.component);
-        return meta?.type === "body" || meta?.type === "container";
-      });
-
-      if (data === undefined) {
+      const droppableInstanceSelector = findClosestDroppableInstanceSelector(
+        newDropInstanceSelector
+      );
+      if (droppableInstanceSelector === undefined) {
         return getDefaultDropTarget();
       }
 
-      if (data.id === dropTarget.data.id) {
+      if (
+        areInstanceSelectorsEqual(
+          dropInstanceSelector,
+          droppableInstanceSelector
+        )
+      ) {
         return dropTarget;
       }
 
-      const element = getInstanceElementById(data.id);
-
-      if (element === null) {
+      const element = getElementByInstanceSelector(droppableInstanceSelector);
+      if (element === undefined) {
         return getDefaultDropTarget();
       }
 
-      return { data, element };
+      return { data: droppableInstanceSelector, element };
     },
 
     onDropTargetChange(dropTarget) {
@@ -167,88 +191,54 @@ export const useDragAndDrop = () => {
         type: "dropTargetChange",
         payload: {
           placement: dropTarget.placement,
-          position: dropTarget.indexWithinChildren,
-          instance: toBaseInstance(dropTarget.data),
+          indexWithinChildren: dropTarget.indexWithinChildren,
+          itemSelector: dropTarget.data,
         },
-      });
-      publish({
-        type: "placementIndicatorChange",
-        payload: computeIndicatorPlacement({
-          ...sharedDropOptions,
-          element: dropTarget.element,
-          placement: dropTarget.placement,
-        }),
       });
     },
   });
 
-  const dragHandlers = useDrag<Instance>({
+  const dragHandlers = useDrag<InstanceSelector>({
     elementToData(element) {
-      if (rootInstance === undefined) {
+      const instanceSelector = getInstanceSelectorFromElement(element);
+      if (instanceSelector === undefined) {
         return false;
       }
-
-      const instanceId = getInstanceIdFromElement(element);
-      const instance =
-        instanceId === undefined ? undefined : instancesById.get(instanceId);
-
-      if (instance === undefined) {
+      // cannot drag root
+      if (instanceSelector.length === 1) {
         return false;
       }
-
-      // We can't drag if we are editing text
-      if (instance.id === textEditingInstanceId) {
+      // cannot drag while editing text
+      if (instanceSelector[0] === textEditingInstanceId) {
         return false;
       }
-
-      // Cannot drag root
-      if (instance.id === rootInstance.id) {
-        return false;
-      }
-
       // When trying to drag an instance inside editor, drag the editor instead
       return (
-        findClosestRichTextInstance(instancesIndexStore.get(), instance.id) ??
-        instance
+        findClosestRichTextInstanceSelector(instanceSelector) ??
+        instanceSelector
       );
     },
-    onStart({ data: instance }) {
-      state.current.dragItem = instance;
 
-      autoScrollHandlers.setEnabled(true);
-      dropHandlers.handleStart();
-
+    onStart({ data: dragInstanceSelector }) {
       publish({
         type: "dragStart",
         payload: {
-          origin: "canvas",
-          dragItem: toBaseInstance(instance),
+          type: "reparent",
+          dragInstanceSelector,
         },
       });
     },
     onMove: (point) => {
-      dropHandlers.handleMove(point);
-      autoScrollHandlers.handleMove(point);
+      publish({
+        type: "dragMove",
+        payload: { canvasCoordinates: point },
+      });
     },
     onEnd({ isCanceled }) {
-      dropHandlers.handleEnd({ isCanceled });
-      autoScrollHandlers.setEnabled(false);
-
       publish({
         type: "dragEnd",
-        payload: { origin: "canvas", isCanceled },
+        payload: { isCanceled },
       });
-
-      const { dropTarget, dragItem } = state.current;
-
-      if (dropTarget && dragItem && isCanceled === false) {
-        reparentInstance(dragItem.id, {
-          parentId: dropTarget.instance.id,
-          position: dropTarget.position,
-        });
-      }
-
-      state.current = { ...initialState };
     },
   });
 
@@ -275,12 +265,10 @@ export const useDragAndDrop = () => {
   // Handle drag from the panel
   // ================================================================
 
-  useSubscribe("dragStart", ({ origin, dragItem }) => {
-    if (origin === "panel") {
-      state.current.dragItem = dragItem;
-      autoScrollHandlers.setEnabled(true);
-      dropHandlers.handleStart();
-    }
+  useSubscribe("dragStart", (dragPayload) => {
+    state.current.dragPayload = dragPayload;
+    autoScrollHandlers.setEnabled(true);
+    dropHandlers.handleStart();
   });
 
   useSubscribe("dragMove", ({ canvasCoordinates }) => {
@@ -290,7 +278,7 @@ export const useDragAndDrop = () => {
 
   useSubscribe("dropTargetChange", (dropTarget) => {
     state.current.dropTarget = dropTarget;
-    const element = getInstanceElementById(dropTarget.instance.id) ?? undefined;
+    const element = getElementByInstanceSelector(dropTarget.itemSelector);
     if (element === undefined) {
       return;
     }
@@ -304,21 +292,26 @@ export const useDragAndDrop = () => {
     });
   });
 
-  useSubscribe("dragEnd", ({ origin, isCanceled }) => {
-    if (origin === "panel") {
-      dropHandlers.handleEnd({ isCanceled });
-      autoScrollHandlers.setEnabled(false);
+  useSubscribe("dragEnd", ({ isCanceled }) => {
+    dropHandlers.handleEnd({ isCanceled });
+    autoScrollHandlers.setEnabled(false);
+    const { dropTarget, dragPayload } = state.current;
 
-      const { dropTarget, dragItem } = state.current;
-
-      if (dropTarget && dragItem && isCanceled === false) {
-        insertNewComponentInstance(dragItem.component, {
-          parentId: dropTarget.instance.id,
-          position: dropTarget.position,
+    if (dropTarget && dragPayload && isCanceled === false) {
+      if (dragPayload.type === "insert") {
+        insertNewComponentInstance(dragPayload.dragComponent, {
+          parentId: dropTarget.itemSelector[0],
+          position: dropTarget.indexWithinChildren,
         });
       }
-
-      state.current = { ...initialState };
+      if (dragPayload.type === "reparent") {
+        reparentInstance(dragPayload.dragInstanceSelector[0], {
+          parentId: dropTarget.itemSelector[0],
+          position: dropTarget.indexWithinChildren,
+        });
+      }
     }
+
+    state.current = { ...initialState };
   });
 };

--- a/apps/builder/app/shared/dom-utils.ts
+++ b/apps/builder/app/shared/dom-utils.ts
@@ -2,10 +2,6 @@ import type { Instance } from "@webstudio-is/project-build";
 import { idAttribute } from "@webstudio-is/react-sdk";
 import type { InstanceSelector } from "./tree-utils";
 
-export const getInstanceElementById = (id: Instance["id"]) => {
-  return document.querySelector(`[${idAttribute}="${id}"]`);
-};
-
 export const getInstanceIdFromElement = (
   element: Element
 ): Instance["id"] | undefined => {

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -4,7 +4,7 @@ import { useStore } from "@nanostores/react";
 import { nanoid } from "nanoid";
 import type { AuthPermit } from "@webstudio-is/trpc-interface";
 import type { Asset } from "@webstudio-is/asset-uploader";
-import type { Placement } from "@webstudio-is/design-system";
+import type { ItemDropTarget, Placement } from "@webstudio-is/design-system";
 import type {
   Breakpoint,
   Breakpoints,
@@ -24,10 +24,7 @@ import type {
   StyleSourceSelections,
 } from "@webstudio-is/project-build";
 import type { Style } from "@webstudio-is/css-data";
-import type {
-  DropTargetChangePayload,
-  DragStartPayload,
-} from "~/canvas/shared/use-drag-drop";
+import type { DragStartPayload } from "~/canvas/shared/use-drag-drop";
 import type {
   AssetContainer,
   DeletingAssetContainer,
@@ -434,8 +431,8 @@ export const useTextEditingInstanceId = () =>
 export type DragAndDropState = {
   isDragging: boolean;
   origin?: "canvas" | "panel";
-  dropTarget?: DropTargetChangePayload;
-  dragItem?: DragStartPayload["dragItem"];
+  dropTarget?: ItemDropTarget;
+  dragPayload?: DragStartPayload;
   placementIndicator?: Placement;
 };
 const dragAndDropStateContainer = atom<DragAndDropState>({

--- a/apps/builder/app/shared/nano-states/use-subscribe-drag-drop-state.ts
+++ b/apps/builder/app/shared/nano-states/use-subscribe-drag-drop-state.ts
@@ -4,10 +4,10 @@ import { useDragAndDropState } from "./nano-states";
 export const useSubscribeDragAndDropState = () => {
   const [state, setState] = useDragAndDropState();
 
-  useSubscribe("dragStart", ({ origin, dragItem }) => {
+  useSubscribe("dragStart", (dragPayload) => {
     // It's possible that dropTargetChange comes before dragStart.
     // So it's important to spread the current ...state here.
-    setState({ ...state, isDragging: true, origin, dragItem });
+    setState({ ...state, isDragging: true, dragPayload });
   });
 
   useSubscribe("dropTargetChange", (dropTarget) => {

--- a/apps/builder/app/shared/tree-utils.test.ts
+++ b/apps/builder/app/shared/tree-utils.test.ts
@@ -14,7 +14,6 @@ import {
   cloneStyles,
   createInstancesIndex,
   findClosestDroppableTarget,
-  findClosestRichTextInstance,
   findSubtreeLocalStyleSources,
   getAncestorInstanceSelector,
   getInstanceSelector,
@@ -391,30 +390,6 @@ test("get path from instance and its ancestors", () => {
       createInstance("child2", "Box", []),
     ]),
   ]);
-});
-
-test("find closest rich text to instance", () => {
-  const rootInstance: Instance = createInstance("root", "Box", [
-    createInstance("box1", "Box", []),
-    createInstance("paragraph2", "Paragraph", [
-      createInstance("italic3", "Italic", [
-        createInstance("bold4", "Bold", []),
-        createInstance("box5", "Box", []),
-      ]),
-    ]),
-    createInstance("box6", "Box", []),
-  ]);
-  const instancesIndex = createInstancesIndex(rootInstance);
-
-  expect(findClosestRichTextInstance(instancesIndex, "bold4")?.id).toEqual(
-    "paragraph2"
-  );
-  expect(findClosestRichTextInstance(instancesIndex, "paragraph2")?.id).toEqual(
-    "paragraph2"
-  );
-  expect(findClosestRichTextInstance(instancesIndex, "box6")?.id).toEqual(
-    undefined
-  );
 });
 
 test("insert tree of instances copy and provide map from ids map", () => {

--- a/apps/builder/app/shared/tree-utils.ts
+++ b/apps/builder/app/shared/tree-utils.ts
@@ -230,17 +230,6 @@ export const getInstanceAncestorsAndSelf = (
   return path;
 };
 
-export const findClosestRichTextInstance = (
-  instancesIndex: InstancesIndex,
-  instanceId: Instance["id"]
-) => {
-  return getInstanceAncestorsAndSelf(instancesIndex, instanceId)
-    .reverse()
-    .find(
-      (instance) => getComponentMeta(instance.component)?.type === "rich-text"
-    );
-};
-
 export const cloneStyles = (
   styles: Styles,
   clonedStyleSourceIds: Map<Instance["id"], Instance["id"]>

--- a/packages/project-build/src/schema/instances.ts
+++ b/packages/project-build/src/schema/instances.ts
@@ -1,23 +1,11 @@
 import { z } from "zod";
 
-// This should be used when passing a lot of data is potentially costly.
-// For example, when passing data from an iframe.
-export type BaseInstance = {
+export type Instance = {
+  type: "instance";
   id: string;
   component: string;
   label?: string;
-};
-
-export type Instance = BaseInstance & {
-  type: "instance";
   children: Array<Instance | Text>;
-};
-
-export const toBaseInstance = (instance: Instance): BaseInstance => {
-  return {
-    id: instance.id,
-    component: instance.component,
-  };
 };
 
 export const Text = z.object({


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1116

Drag payload produce 2 kinds of actions insert and reparent and output tree compatible drop target.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @rpominov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
