### PR TITLE
Refactor insert and reparent operations with selectors

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
@@ -17,8 +17,9 @@ import {
 import { PlusIcon } from "@webstudio-is/icons";
 import { findClosestDroppableTarget } from "~/shared/tree-utils";
 import {
-  instancesIndexStore,
+  instancesStore,
   selectedInstanceSelectorStore,
+  selectedPageStore,
 } from "~/shared/nano-states";
 import { useSubscribe, type Publish } from "~/shared/pubsub";
 import {
@@ -176,10 +177,16 @@ export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
             <ComponentCard
               onClick={() => {
                 onSetActiveTab("none");
+                const selectedPage = selectedPageStore.get();
+                if (selectedPage === undefined) {
+                  return;
+                }
                 const dropTarget = findClosestDroppableTarget(
-                  instancesIndexStore.get(),
-                  // @todo accept instance Selector
-                  selectedInstanceSelectorStore.get()?.[0]
+                  instancesStore.get(),
+                  // fallback to root as drop target
+                  selectedInstanceSelectorStore.get() ?? [
+                    selectedPage.rootInstanceId,
+                  ]
                 );
                 insertNewComponentInstance(component, dropTarget);
               }}

--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -25,8 +25,8 @@ export const NavigatorTree = () => {
       itemSelector: InstanceSelector;
       dropTarget: { itemSelector: InstanceSelector; position: number | "end" };
     }) => {
-      reparentInstance(payload.itemSelector[0], {
-        parentId: payload.dropTarget.itemSelector[0],
+      reparentInstance(payload.itemSelector, {
+        parentSelector: payload.dropTarget.itemSelector,
         position: payload.dropTarget.position,
       });
     },

--- a/apps/builder/app/canvas/shared/use-drag-drop.ts
+++ b/apps/builder/app/canvas/shared/use-drag-drop.ts
@@ -297,13 +297,13 @@ export const useDragAndDrop = () => {
     if (dropTarget && dragPayload && isCanceled === false) {
       if (dragPayload.type === "insert") {
         insertNewComponentInstance(dragPayload.dragComponent, {
-          parentId: dropTarget.itemSelector[0],
+          parentSelector: dropTarget.itemSelector,
           position: dropTarget.indexWithinChildren,
         });
       }
       if (dragPayload.type === "reparent") {
-        reparentInstance(dragPayload.dragInstanceSelector[0], {
-          parentId: dropTarget.itemSelector[0],
+        reparentInstance(dragPayload.dragInstanceSelector, {
+          parentSelector: dropTarget.itemSelector,
           position: dropTarget.indexWithinChildren,
         });
       }

--- a/apps/builder/app/shared/copy-paste/plugin-markdown.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-markdown.ts
@@ -13,7 +13,6 @@ import {
   insertInstancesMutable,
 } from "../tree-utils";
 import {
-  instancesIndexStore,
   instancesStore,
   propsStore,
   selectedInstanceSelectorStore,
@@ -216,11 +215,9 @@ export const onPaste = (clipboardData: string) => {
   const instanceSelector = selectedInstanceSelectorStore.get() ?? [
     selectedPage.rootInstanceId,
   ];
-  const [targetInstanceId] = instanceSelector;
   const dropTarget = findClosestDroppableTarget(
-    instancesIndexStore.get(),
-    // @todo accept instance selector
-    targetInstanceId
+    instancesStore.get(),
+    instanceSelector
   );
   store.createTransaction([instancesStore, propsStore], (instances, props) => {
     insertInstancesMutable(instances, data.instances, data.rootIds, dropTarget);

--- a/apps/builder/app/shared/tree-utils.test.ts
+++ b/apps/builder/app/shared/tree-utils.test.ts
@@ -152,40 +152,60 @@ test("get instance selector", () => {
 });
 
 test("find closest droppable target", () => {
-  const rootInstance = createInstance("root", "Body", [
-    createInstance("box1", "Box", [
-      createInstance("box11", "Box", []),
-      createInstance("box12", "Box", []),
-      createInstance("box13", "Box", []),
+  const instances = new Map([
+    createInstancePair("root", "Body", [
+      { type: "id", value: "box1" },
+      { type: "id", value: "box2" },
+      { type: "id", value: "box3" },
     ]),
-    createInstance("box2", "Box", [
-      createInstance("paragraph21", "Paragraph", [
-        createInstance("bold", "Bold", []),
-      ]),
-      createInstance("box22", "Box", []),
+    createInstancePair("box1", "Box", [
+      { type: "id", value: "box11" },
+      { type: "id", value: "box12" },
+      { type: "id", value: "box13" },
     ]),
-    createInstance("box3", "Box", [
-      createInstance("box31", "Box", []),
-      createInstance("box32", "Box", []),
-      createInstance("box33", "Box", []),
+    createInstancePair("box11", "Box", []),
+    createInstancePair("box12", "Box", []),
+    createInstancePair("box13", "Box", []),
+    createInstancePair("box2", "Box", [
+      { type: "id", value: "paragraph21" },
+      { type: "id", value: "box22" },
     ]),
+    createInstancePair("paragraph21", "Paragraph", [
+      { type: "id", value: "bold" },
+    ]),
+    createInstancePair("bold", "Bold", []),
+    createInstancePair("box22", "Box", []),
+    createInstancePair("box3", "Box", [
+      { type: "id", value: "box31" },
+      { type: "id", value: "box32" },
+      { type: "id", value: "box33" },
+    ]),
+    createInstancePair("box31", "Box", []),
+    createInstancePair("box32", "Box", []),
+    createInstancePair("box33", "Box", []),
   ]);
-  const instancesIndex = createInstancesIndex(rootInstance);
-  expect(findClosestDroppableTarget(instancesIndex, "bold")).toEqual({
-    parentId: "box2",
+  expect(
+    findClosestDroppableTarget(instances, [
+      "bold",
+      "paragraph21",
+      "box2",
+      "root",
+    ])
+  ).toEqual({
+    parentSelector: ["box2", "root"],
     position: 1,
   });
-  expect(findClosestDroppableTarget(instancesIndex, "box3")).toEqual({
-    parentId: "box3",
-    position: 3,
+  expect(findClosestDroppableTarget(instances, ["box3", "root"])).toEqual({
+    parentSelector: ["box3", "root"],
+    position: "end",
   });
-  expect(findClosestDroppableTarget(instancesIndex, "root")).toEqual({
-    parentId: "root",
-    position: 3,
+  expect(findClosestDroppableTarget(instances, ["root"])).toEqual({
+    parentSelector: ["root"],
+    position: "end",
   });
-  expect(findClosestDroppableTarget(instancesIndex, undefined)).toEqual({
-    parentId: "root",
-    position: 3,
+  expect(findClosestDroppableTarget(instances, ["box4", "root"])).toEqual({
+    parentSelector: ["root"],
+    position: "end",
   });
 });
 
@@ -212,7 +232,7 @@ test("insert instances tree into target", () => {
     ],
     ["inserted1"],
     {
-      parentId: "box1",
+      parentSelector: ["box1", "root"],
       position: 1,
     }
   );
@@ -243,7 +263,7 @@ test("insert instances tree into target", () => {
     ],
     ["inserted3"],
     {
-      parentId: "box1",
+      parentSelector: ["box1", "root"],
       position: "end",
     }
   );
@@ -290,7 +310,7 @@ test("reparent instance into target", () => {
   ]);
 
   reparentInstanceMutable(instances, ["target", "root"], {
-    parentId: "box1",
+    parentSelector: ["box1", "root"],
     position: 1,
   });
   expect(instances).toEqual(
@@ -314,7 +334,7 @@ test("reparent instance into target", () => {
   );
 
   reparentInstanceMutable(instances, ["target", "box1", "root"], {
-    parentId: "box1",
+    parentSelector: ["box1", "root"],
     position: 3,
   });
   expect(instances).toEqual(
@@ -338,7 +358,7 @@ test("reparent instance into target", () => {
   );
 
   reparentInstanceMutable(instances, ["target", "box1", "root"], {
-    parentId: "root",
+    parentSelector: ["root"],
     position: "end",
   });
   expect(instances).toEqual(
@@ -413,7 +433,7 @@ test("insert tree of instances copy and provide map from ids map", () => {
     instances,
     copiedInstances,
     {
-      parentId: "3",
+      parentSelector: ["3", "1"],
       position: 0,
     }
   );


### PR DESCRIPTION
- in many places root check can be replaced with selector.length === 1
- reparent and insert utilities now accept selectors
- findClosestDroppableTarget output end instead of last index and always fallback to root

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
