### PR TITLE
Migrate style computing to instance selectors

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
@@ -18,7 +18,7 @@ import {
   Separator,
 } from "@webstudio-is/design-system";
 import { UndoIcon } from "@webstudio-is/icons";
-import { instancesIndexStore, useBreakpoints } from "~/shared/nano-states";
+import { instancesStore, useBreakpoints } from "~/shared/nano-states";
 import { type StyleInfo, type StyleSource, getStyleSource } from "./style-info";
 
 const PropertyPopoverContent = ({
@@ -33,7 +33,7 @@ const PropertyPopoverContent = ({
   onReset: () => void;
 }) => {
   const [breakpoints] = useBreakpoints();
-  const { instancesById } = useStore(instancesIndexStore);
+  const instances = useStore(instancesStore);
 
   if (styleSource === "local") {
     return (
@@ -71,7 +71,7 @@ const PropertyPopoverContent = ({
 
             if (styleValueInfo?.inherited) {
               const { value, instanceId } = styleValueInfo.inherited;
-              const instance = instancesById.get(instanceId);
+              const instance = instances.get(instanceId);
               return (
                 <DeprecatedText2 key={property} color="hint">
                   Resetting will change {property} to inherited {toValue(value)}{" "}
@@ -108,7 +108,7 @@ const PropertyPopoverContent = ({
 
         if (styleValueInfo?.inherited) {
           const { instanceId } = styleValueInfo.inherited;
-          const instance = instancesById.get(instanceId);
+          const instance = instances.get(instanceId);
           return (
             <DeprecatedText2 key={property} color="hint">
               {property} value is inherited from {instance?.component}

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
@@ -2,9 +2,9 @@ import { test, expect } from "@jest/globals";
 import type {
   Breakpoints,
   Instance,
+  Instances,
   StyleDecl,
 } from "@webstudio-is/project-build";
-import { createInstancesIndex } from "~/shared/tree-utils";
 import {
   getCascadedBreakpointIds,
   getCascadedInfo,
@@ -19,14 +19,14 @@ const breakpoints: Breakpoints = new Map([
 ]);
 
 const selectedBreakpointId = "3";
-const selectedInstanceId = "3";
+const selectedInstanceSelector = ["3", "2", "1"];
 const cascadedBreakpointIds = getCascadedBreakpointIds(
   breakpoints,
   selectedBreakpointId
 );
 
 const cascadingStylesByInstanceId = new Map<Instance["id"], StyleDecl[]>();
-cascadingStylesByInstanceId.set(selectedInstanceId, [
+cascadingStylesByInstanceId.set(selectedInstanceSelector[0], [
   {
     breakpointId: "1",
     styleSourceId: "styleSourceId",
@@ -60,26 +60,35 @@ cascadingStylesByInstanceId.set(selectedInstanceId, [
   },
 ]);
 
-const rootInstance: Instance = {
-  type: "instance",
-  id: "1",
-  component: "Box",
-  children: [
+const instances: Instances = new Map([
+  [
+    "1",
+    {
+      type: "instance",
+      id: "1",
+      component: "Box",
+      children: [{ type: "id", value: "2" }],
+    },
+  ],
+  [
+    "2",
     {
       type: "instance",
       id: "2",
       component: "Box",
-      children: [
-        {
-          type: "instance",
-          id: "3",
-          component: "Box",
-          children: [],
-        },
-      ],
+      children: [{ type: "id", value: "3" }],
     },
   ],
-};
+  [
+    "3",
+    {
+      type: "instance",
+      id: "3",
+      component: "Box",
+      children: [],
+    },
+  ],
+]);
 
 const inheritingStylesByInstanceId = new Map<Instance["id"], StyleDecl[]>();
 inheritingStylesByInstanceId.set("1", [
@@ -121,7 +130,7 @@ test("compute cascaded styles", () => {
   expect(
     getCascadedInfo(
       cascadingStylesByInstanceId,
-      selectedInstanceId,
+      selectedInstanceSelector[0],
       cascadedBreakpointIds
     )
   ).toMatchInlineSnapshot(`
@@ -147,12 +156,11 @@ test("compute cascaded styles", () => {
 });
 
 test("compute inherited styles", () => {
-  const instancesIndex = createInstancesIndex(rootInstance);
   expect(
     getInheritedInfo(
-      instancesIndex,
+      instances,
       inheritingStylesByInstanceId,
-      selectedInstanceId,
+      selectedInstanceSelector,
       cascadedBreakpointIds,
       selectedBreakpointId
     )

--- a/apps/builder/app/builder/features/style-panel/style-settings.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-settings.tsx
@@ -97,8 +97,12 @@ export type StyleSettingsProps = {
 
 const useParentStyle = () => {
   const selectedInstanceSelector = useStore(selectedInstanceSelectorStore);
-  const parentInstanceId = selectedInstanceSelector?.[1];
-  const parentInstanceStyleData = useInstanceStyleData(parentInstanceId);
+  const parentInstanceSelector =
+    // root does not have parent
+    selectedInstanceSelector?.length === 1
+      ? undefined
+      : selectedInstanceSelector?.slice(1);
+  const parentInstanceStyleData = useInstanceStyleData(parentInstanceSelector);
   return parentInstanceStyleData;
 };
 

--- a/apps/builder/app/canvas/collapsed.ts
+++ b/apps/builder/app/canvas/collapsed.ts
@@ -6,7 +6,7 @@ import {
 } from "~/builder/features/style-panel/shared/style-info";
 import {
   breakpointsContainer,
-  instancesIndexStore,
+  instancesStore,
   stylesIndexStore,
 } from "~/shared/nano-states";
 import { selectedBreakpointStore } from "~/shared/nano-states/breakpoints";
@@ -44,7 +44,7 @@ const getInstanceSize = (instanceId: string) => {
   const breakpoints = breakpointsContainer.get();
   const selectedBreakpoint = selectedBreakpointStore.get();
   const { stylesByInstanceId } = stylesIndexStore.get();
-  const instancesIndex = instancesIndexStore.get();
+  const instances = instancesStore.get();
   const selectedBreakpointId = selectedBreakpoint?.id;
 
   if (selectedBreakpointId === undefined) {
@@ -59,7 +59,7 @@ const getInstanceSize = (instanceId: string) => {
     selectedBreakpointId
   );
 
-  const presetStyle = getPresetStyle(instancesIndex, instanceId);
+  const presetStyle = getPresetStyle(instances, instanceId);
 
   const cascadedStyle = getCascadedInfo(stylesByInstanceId, instanceId, [
     ...cascadedBreakpointIds,

--- a/apps/builder/app/shared/tree-utils.test.ts
+++ b/apps/builder/app/shared/tree-utils.test.ts
@@ -12,11 +12,9 @@ import type {
 import {
   type InstanceSelector,
   cloneStyles,
-  createInstancesIndex,
   findClosestDroppableTarget,
   findSubtreeLocalStyleSources,
   getAncestorInstanceSelector,
-  getInstanceAncestorsAndSelf,
   insertInstancesCopyMutable,
   insertInstancesMutable,
   insertPropsCopyMutable,
@@ -29,19 +27,6 @@ import {
 const expectString = expect.any(String) as unknown as string;
 
 const createInstance = (
-  id: Instance["id"],
-  component: string,
-  children: Instance[]
-): Instance => {
-  return {
-    type: "instance",
-    id,
-    component,
-    children: children,
-  };
-};
-
-const createInstancesItem = (
   id: Instance["id"],
   component: string,
   children: InstancesItem["children"]
@@ -59,7 +44,7 @@ const createInstancePair = (
   component: string,
   children: InstancesItem["children"]
 ): [Instance["id"], InstancesItem] => {
-  return [id, createInstancesItem(id, component, children)];
+  return [id, createInstance(id, component, children)];
 };
 
 const createProp = (id: string, instanceId: string): Prop => {
@@ -200,10 +185,8 @@ test("insert instances tree into target", () => {
   insertInstancesMutable(
     instances,
     [
-      createInstancesItem("inserted1", "Box", [
-        { type: "id", value: "inserted2" },
-      ]),
-      createInstancesItem("inserted2", "Box", []),
+      createInstance("inserted1", "Box", [{ type: "id", value: "inserted2" }]),
+      createInstance("inserted2", "Box", []),
     ],
     ["inserted1"],
     {
@@ -231,10 +214,8 @@ test("insert instances tree into target", () => {
   insertInstancesMutable(
     instances,
     [
-      createInstancesItem("inserted3", "Box", [
-        { type: "id", value: "inserted4" },
-      ]),
-      createInstancesItem("inserted4", "Box", []),
+      createInstance("inserted3", "Box", [{ type: "id", value: "inserted4" }]),
+      createInstance("inserted4", "Box", []),
     ],
     ["inserted3"],
     {
@@ -357,36 +338,6 @@ test("reparent instance into target", () => {
   );
 });
 
-test("get path from instance and its ancestors", () => {
-  const rootInstance: Instance = createInstance("root", "Box", [
-    createInstance("box1", "Box", []),
-    createInstance("box2", "Box", [
-      createInstance("box3", "Box", [
-        createInstance("child1", "Box", []),
-        createInstance("child2", "Box", []),
-      ]),
-    ]),
-    createInstance("box4", "Box", []),
-  ]);
-  const instancesIndex = createInstancesIndex(rootInstance);
-
-  expect(getInstanceAncestorsAndSelf(instancesIndex, "box3")).toEqual([
-    rootInstance,
-
-    createInstance("box2", "Box", [
-      createInstance("box3", "Box", [
-        createInstance("child1", "Box", []),
-        createInstance("child2", "Box", []),
-      ]),
-    ]),
-
-    createInstance("box3", "Box", [
-      createInstance("child1", "Box", []),
-      createInstance("child2", "Box", []),
-    ]),
-  ]);
-});
-
 test("insert tree of instances copy and provide map from ids map", () => {
   const instances = new Map([
     createInstancePair("1", "Body", [
@@ -398,11 +349,11 @@ test("insert tree of instances copy and provide map from ids map", () => {
     createInstancePair("4", "Box", []),
   ]);
   const copiedInstances = [
-    createInstancesItem("2", "Box", [
+    createInstance("2", "Box", [
       { type: "id", value: "3" },
       { type: "text", value: "text" },
     ]),
-    createInstancesItem("3", "Box", []),
+    createInstance("3", "Box", []),
   ];
   const copiedInstanceIds = insertInstancesCopyMutable(
     instances,

--- a/apps/builder/app/shared/tree-utils.ts
+++ b/apps/builder/app/shared/tree-utils.ts
@@ -195,20 +195,6 @@ export const reparentInstanceMutable = (
   }
 };
 
-export const getInstanceAncestorsAndSelf = (
-  instancesIndex: InstancesIndex,
-  instanceId: Instance["id"]
-) => {
-  const { instancesById, parentInstancesById } = instancesIndex;
-  const path = [];
-  let instance = instancesById.get(instanceId);
-  while (instance) {
-    path.unshift(instance);
-    instance = parentInstancesById.get(instance.id);
-  }
-  return path;
-};
-
 export const cloneStyles = (
   styles: Styles,
   clonedStyleSourceIds: Map<Instance["id"], Instance["id"]>


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1116

This is the last one slots blocker for sure.

Refactored inherited styles to compute from selectors and got rid of legacy traverser utility.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
