### PR TITLE
Allow to hide any item in the tree

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
@@ -207,8 +207,7 @@ const PagesPanel = ({
           </>
         }
       />
-      <TreeNode
-        hideRoot
+      <TreeNode<PagesTreeNode>
         selectedItemSelector={[selectedPageId, pagesTree.id]}
         onSelect={selectTreeNode}
         itemData={pagesTree}
@@ -219,6 +218,7 @@ const PagesPanel = ({
           }
           return [];
         }}
+        isItemHidden={(itemId) => itemId === pagesTree.id}
         getIsExpanded={() => true}
       />
     </Box>

--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { useStore } from "@nanostores/react";
+import type { Instance } from "@webstudio-is/project-build";
 import {
   hoveredInstanceSelectorStore,
   rootInstanceStore,
@@ -7,9 +8,9 @@ import {
   useDragAndDropState,
 } from "~/shared/nano-states";
 import type { InstanceSelector } from "~/shared/tree-utils";
-import { InstanceTree } from "./tree";
 import { reparentInstance } from "~/shared/instance-utils";
 import { textEditingInstanceSelectorStore } from "~/shared/nano-states/instances";
+import { InstanceTree } from "./tree";
 
 export const NavigatorTree = () => {
   const selectedInstanceSelector = useStore(selectedInstanceSelectorStore);
@@ -20,6 +21,8 @@ export const NavigatorTree = () => {
     state.dragPayload?.type === "reparent"
       ? state.dragPayload.dragInstanceSelector
       : undefined;
+
+  const isItemHidden = useCallback((_instanceId: Instance["id"]) => false, []);
 
   const handleDragEnd = useCallback(
     (payload: {
@@ -49,6 +52,7 @@ export const NavigatorTree = () => {
       selectedItemSelector={selectedInstanceSelector}
       dragItemSelector={dragItemSelector}
       dropTarget={state.dropTarget}
+      isItemHidden={isItemHidden}
       onSelect={handleSelect}
       onHover={hoveredInstanceSelectorStore.set}
       onDragItemChange={(dragInstanceSelector) => {

--- a/packages/design-system/src/components/tree/horizontal-shift.test.ts
+++ b/packages/design-system/src/components/tree/horizontal-shift.test.ts
@@ -116,6 +116,7 @@ const render = (
         findItemById(tree, itemId)?.canAcceptChildren ?? false,
       getItemChildren: (itemId: ItemId) =>
         findItemById(tree, itemId)?.children ?? [],
+      isItemHidden: (_itemId: ItemId) => false,
     },
   });
 

--- a/packages/design-system/src/components/tree/horizontal-shift.ts
+++ b/packages/design-system/src/components/tree/horizontal-shift.ts
@@ -15,10 +15,12 @@ export const useHorizontalShift = <Data extends { id: ItemId }>({
   placementIndicator,
   getIsExpanded,
   canAcceptChild,
+  isItemHidden,
   getItemChildren,
 }: {
   getItemChildren: (itemId: ItemId) => Data[];
   canAcceptChild: (itemId: ItemId) => boolean;
+  isItemHidden: (itemId: ItemId) => boolean;
   dragItemSelector: undefined | ItemSelector;
   dropTarget: ItemDropTarget | undefined;
   placementIndicator: undefined | Placement;
@@ -36,8 +38,6 @@ export const useHorizontalShift = <Data extends { id: ItemId }>({
     ) {
       return undefined;
     }
-
-    const dragItemDepth = dragItemSelector.length - 1;
 
     const { itemSelector: dropItemSelector, indexWithinChildren } = dropTarget;
 
@@ -57,13 +57,21 @@ export const useHorizontalShift = <Data extends { id: ItemId }>({
       return { itemSelector: dropItemSelector, position: "end" };
     }
 
+    let dropHiddenCount = 0;
+    for (const itemId of dropItemSelector) {
+      if (isItemHidden(itemId)) {
+        dropHiddenCount += 1;
+      }
+    }
+
+    const dragItemDepth = dragItemSelector.length - 1;
     const currentDepth = dropItemSelector.length;
     const desiredDepth = dragItemDepth + horizontalShift;
 
     const withoutShift = {
       itemSelector: dropItemSelector,
       position: indexWithinChildren,
-      placement: shiftPlacement(currentDepth),
+      placement: shiftPlacement(currentDepth - dropHiddenCount),
     } as const;
 
     const [dragItemId] = dragItemSelector;
@@ -110,7 +118,7 @@ export const useHorizontalShift = <Data extends { id: ItemId }>({
       return {
         itemSelector: newParentSelector,
         position: newPosition,
-        placement: shiftPlacement(currentDepth - shifted),
+        placement: shiftPlacement(currentDepth - dropHiddenCount - shifted),
       };
     }
 
@@ -155,7 +163,7 @@ export const useHorizontalShift = <Data extends { id: ItemId }>({
       return {
         itemSelector: newParentSelector,
         position: "end",
-        placement: shiftPlacement(currentDepth + shifted),
+        placement: shiftPlacement(currentDepth - dropHiddenCount + shifted),
       };
     }
 
@@ -166,6 +174,7 @@ export const useHorizontalShift = <Data extends { id: ItemId }>({
     dragItemSelector,
     horizontalShift,
     canAcceptChild,
+    isItemHidden,
     getItemChildren,
     getIsExpanded,
   ]);

--- a/packages/design-system/src/components/tree/test-tree-data.ts
+++ b/packages/design-system/src/components/tree/test-tree-data.ts
@@ -4,6 +4,7 @@ import type { ItemSelector } from "./item-utils";
 export type Item = {
   id: string;
   canAcceptChildren: boolean;
+  isHidden?: boolean;
   children: Item[];
 };
 

--- a/packages/design-system/src/components/tree/tree.stories.tsx
+++ b/packages/design-system/src/components/tree/tree.stories.tsx
@@ -32,22 +32,29 @@ export const StressTest = ({ animate }: { animate: boolean }) => {
               canAcceptChildren: true,
               children: [
                 {
-                  id: `box-${index}.0.0`,
+                  id: `hidden-${index}.0.0`,
                   canAcceptChildren: true,
+                  isHidden: true,
                   children: [
                     {
                       id: `box-${index}.0.0.0`,
                       canAcceptChildren: true,
                       children: [
                         {
-                          id: `heading-${index}.1`,
-                          canAcceptChildren: false,
-                          children: [],
-                        },
-                        {
-                          id: `paragraph-${index}.1`,
-                          canAcceptChildren: false,
-                          children: [],
+                          id: `box-${index}.0.0.0.0`,
+                          canAcceptChildren: true,
+                          children: [
+                            {
+                              id: `heading-${index}.1`,
+                              canAcceptChildren: false,
+                              children: [],
+                            },
+                            {
+                              id: `paragraph-${index}.1`,
+                              canAcceptChildren: false,
+                              children: [],
+                            },
+                          ],
                         },
                       ],
                     },
@@ -77,11 +84,18 @@ export const StressTest = ({ animate }: { animate: boolean }) => {
   return (
     <Flex css={{ width: 300, height: 500, flexDirection: "column" }}>
       <Tree
-        canAcceptChild={(itemId) =>
-          findItemById(root, itemId)?.canAcceptChildren ?? false
-        }
+        canAcceptChild={(itemId) => {
+          const item = findItemById(root, itemId);
+          return (
+            (item?.canAcceptChildren ?? false) &&
+            (item?.isHidden ?? false) === false
+          );
+        }}
         canLeaveParent={() => true}
         getItemChildren={(itemId) => findItemById(root, itemId)?.children ?? []}
+        isItemHidden={(itemSelector) =>
+          findItemById(root, itemSelector[0])?.isHidden ?? false
+        }
         animate={animate}
         root={root}
         selectedItemSelector={selectedItemSelector}


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1116

We need this to hide Fragment instance in navigator which is an implicit child of slot with persistent id.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
