### PR TITLE
Fix tree level to render root without collapse icon

### DIFF
--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -445,10 +445,8 @@ export const TreeNode = <Data extends { id: string }>({
   const itemSelector = [itemData.id, ...(parentSelector ?? [])];
 
   const itemIsHidden = isItemHidden(itemData.id);
-  const isAlwaysExpanded = itemIsHidden;
-  if (itemIsHidden === false) {
-    level += 1;
-  }
+  // hidden items and root are always expanded
+  const isAlwaysExpanded = itemIsHidden || level === 0;
 
   const isExpandable = itemChildren.length > 0;
   const isExpanded = getIsExpanded(itemSelector) || isAlwaysExpanded;
@@ -514,7 +512,7 @@ export const TreeNode = <Data extends { id: string }>({
                 itemData={child}
                 parentSelector={itemSelector}
                 parentIsSelected={isSelected || parentIsSelected}
-                level={level}
+                level={itemIsHidden ? level : level + 1}
                 {...commonProps}
               />
             ))

--- a/packages/design-system/src/components/tree/tree.stories.tsx
+++ b/packages/design-system/src/components/tree/tree.stories.tsx
@@ -109,7 +109,11 @@ export const StressTest = ({ animate }: { animate: boolean }) => {
             <TreeItemLabel>{props.itemData.id}</TreeItemLabel>
           </TreeItemBody>
         )}
-        onDragEnd={(payload) => setRoot((root) => reparent(root, payload))}
+        onDragEnd={(payload) => {
+          setRoot((root) => reparent(root, payload));
+          setDragItemSelector(undefined);
+          setDropTarget(undefined);
+        }}
         onCancel={() => {
           setDragItemSelector(undefined);
           setDropTarget(undefined);


### PR DESCRIPTION
Lost pixel caught this issue with tree. Level is incremented inconsistenly. Here incremented only for nested tree node.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
