### PR TITLE
Compute bounding box by children when display: contents

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/layout/layout.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/layout/layout.tsx
@@ -28,6 +28,7 @@ import {
   CssValueInput,
 } from "../../shared/css-value-input";
 import { theme } from "@webstudio-is/design-system";
+import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 
 const GapLinked = ({
   isLinked,
@@ -331,6 +332,9 @@ const orderedDisplayValues = [
   "inline",
   "none",
 ];
+if (isFeatureEnabled("displayContents")) {
+  orderedDisplayValues.push("contents");
+}
 
 const compareDisplayValues = (a: { name: string }, b: { name: string }) => {
   const aIndex = orderedDisplayValues.indexOf(a.name);

--- a/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
+++ b/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
@@ -11,6 +11,7 @@ import {
   rootInstanceContainer,
   selectedInstanceBrowserStyleStore,
 } from "~/shared/nano-states";
+import { getAllElementsBoundingBox } from "~/shared/dom-utils";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
@@ -25,7 +26,7 @@ const updateOutlineRect = (element: HTMLElement) => {
   publish({
     type: "updateSelectedInstanceOutline",
     payload: {
-      rect: element.getBoundingClientRect(),
+      rect: getAllElementsBoundingBox(element),
     },
   });
 };
@@ -35,7 +36,7 @@ const showOutline = (element: HTMLElement) => {
     type: "updateSelectedInstanceOutline",
     payload: {
       visible: true,
-      rect: element.getBoundingClientRect(),
+      rect: getAllElementsBoundingBox(element),
     },
   });
 };

--- a/apps/builder/app/canvas/instance-hovering.ts
+++ b/apps/builder/app/canvas/instance-hovering.ts
@@ -7,6 +7,7 @@ import {
 } from "~/shared/nano-states";
 import { subscribeScrollState } from "~/shared/dom-hooks";
 import {
+  getAllElementsBoundingBox,
   getElementByInstanceSelector,
   getInstanceSelectorFromElement,
 } from "~/shared/dom-utils";
@@ -63,7 +64,7 @@ export const subscribeInstanceHovering = () => {
     hoveredInstanceOutlineStore.set({
       label: instance.label,
       component: instance.component,
-      rect: element.getBoundingClientRect(),
+      rect: getAllElementsBoundingBox(element),
     });
   }, 50);
 

--- a/apps/builder/app/shared/dom-utils.ts
+++ b/apps/builder/app/shared/dom-utils.ts
@@ -36,3 +36,53 @@ export const getElementByInstanceSelector = (
     .join(" ");
   return document.querySelector(domSelector) ?? undefined;
 };
+
+type Rect = {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+};
+
+const sumRects = (first: Rect, second: Rect) => {
+  return {
+    top: Math.min(first.top, second.top),
+    right: Math.max(first.right, second.right),
+    bottom: Math.max(first.bottom, second.bottom),
+    left: Math.min(first.left, second.left),
+  };
+};
+
+export const getAllElementsBoundingBox = (element: Element): DOMRect => {
+  const rect = element.getBoundingClientRect();
+  if (element.children.length === 0) {
+    return rect;
+  }
+  // possible display: contents
+  if (rect.width !== 0 || rect.height !== 0) {
+    return rect;
+  }
+
+  const rects: Rect[] = [];
+
+  for (const child of element.children) {
+    const childRect = getAllElementsBoundingBox(child);
+    // possible display: contents
+    if (childRect.width !== 0 || childRect.height !== 0) {
+      const { top, right, bottom, left } = childRect;
+      rects.push({ top, right, bottom, left });
+    }
+  }
+
+  if (rects.length === 0) {
+    return rect;
+  }
+
+  const { top, right, bottom, left } = rects.reduce(sumRects);
+  return DOMRect.fromRect({
+    x: left,
+    y: top,
+    height: bottom - top,
+    width: right - left,
+  });
+};

--- a/packages/feature-flags/src/flags.ts
+++ b/packages/feature-flags/src/flags.ts
@@ -2,3 +2,4 @@ export const example = false;
 export const dark = false;
 export const propertyReset = false;
 export const unsupportedBrowsers = false;
+export const displayContents = false;


### PR DESCRIPTION
Slots have display: contents to not affect layout. So we need a way to show correct hover and selected state. Here's added utility to traverse all descendants and get their rects and then compute the sum of those rects.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

Added ability to set display: contents from UI under features flag.

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
