### PR TITLE
Support minWidth and maxWith in media queries, both are optional

### DIFF
--- a/apps/builder/app/builder/features/breakpoints/use-update-canvas-width.ts
+++ b/apps/builder/app/builder/features/breakpoints/use-update-canvas-width.ts
@@ -36,7 +36,7 @@ export const useUpdateCanvasWidth = () => {
       : maxWidthBelowNextBreakpoint;
 
     const width = Math.max(
-      selectedBreakpoint.minWidth,
+      selectedBreakpoint.minWidth ?? 0,
       initialMaxAvailableWidth,
       minWidth
     );

--- a/apps/builder/app/builder/features/breakpoints/width-setting.tsx
+++ b/apps/builder/app/builder/features/breakpoints/width-setting.tsx
@@ -27,13 +27,13 @@ export const WidthSetting = () => {
   // We want to enable unconstrained resizing in a preview mode
   const min = isPreviewMode
     ? minWidth
-    : Math.max(minWidth, selectedBreakpoint.minWidth);
+    : Math.max(minWidth, selectedBreakpoint.minWidth ?? 0);
 
   const max = isPreviewMode
     ? maxWidth
     : Math.min(
         maxWidth,
-        nextBreakpoint ? nextBreakpoint.minWidth - 1 : maxWidth
+        nextBreakpoint ? (nextBreakpoint.minWidth ?? 1) - 1 : maxWidth
       );
 
   return (

--- a/apps/builder/app/builder/shared/breakpoints/will-render.ts
+++ b/apps/builder/app/builder/shared/breakpoints/will-render.ts
@@ -1,4 +1,7 @@
 import type { Breakpoint } from "@webstudio-is/project-build";
 
-export const willRender = (breakpoint: Breakpoint, canvasWidth: number) =>
-  canvasWidth >= breakpoint.minWidth;
+export const willRender = (breakpoint: Breakpoint, canvasWidth: number) => {
+  const minWidth = breakpoint.minWidth ?? 0;
+  const maxWidth = breakpoint.maxWidth ?? Number.MAX_SAFE_INTEGER;
+  return canvasWidth >= minWidth && canvasWidth <= maxWidth;
+};

--- a/packages/css-engine/src/core/css-engine.test.ts
+++ b/packages/css-engine/src/core/css-engine.test.ts
@@ -29,6 +29,45 @@ describe("CssEngine", () => {
 
   beforeEach(reset);
 
+  test("minWidth media rule", () => {
+    engine.addMediaRule("0", { minWidth: 0 });
+    engine.addStyleRule(".c1", {
+      style: { color: { type: "keyword", value: "red" } },
+      breakpoint: "0",
+    });
+    expect(engine.cssText).toMatchInlineSnapshot(`
+      "@media all and (min-width: 0px) {
+        .c1 { color: red }
+      }"
+    `);
+  });
+
+  test("maxWidth media rule", () => {
+    engine.addMediaRule("0", { maxWidth: 1000 });
+    engine.addStyleRule(".c1", {
+      style: { color: { type: "keyword", value: "red" } },
+      breakpoint: "0",
+    });
+    expect(engine.cssText).toMatchInlineSnapshot(`
+      "@media all and (max-width: 1000px) {
+        .c1 { color: red }
+      }"
+    `);
+  });
+
+  test("maxWidth and maxWith media rule", () => {
+    engine.addMediaRule("0", { maxWidth: 1000, minWidth: 360 });
+    engine.addStyleRule(".c1", {
+      style: { color: { type: "keyword", value: "red" } },
+      breakpoint: "0",
+    });
+    expect(engine.cssText).toMatchInlineSnapshot(`
+      "@media all and (min-width: 360px) and (max-width: 1000px) {
+        .c1 { color: red }
+      }"
+    `);
+  });
+
   test("use default media rule when there is no matching one registered", () => {
     engine.addStyleRule(".c", {
       style: style0,

--- a/packages/css-engine/src/core/rules.ts
+++ b/packages/css-engine/src/core/rules.ts
@@ -106,15 +106,12 @@ export class MediaRule {
     let conditionText = "";
     const { minWidth, maxWidth } = this.options;
     if (minWidth !== undefined) {
-      conditionText = `min-width: ${minWidth}px`;
+      conditionText = ` and (min-width: ${minWidth}px)`;
     }
     if (maxWidth !== undefined) {
-      conditionText = `max-width: ${maxWidth}px`;
+      conditionText += ` and (max-width: ${maxWidth}px)`;
     }
-    if (conditionText) {
-      conditionText = `and (${conditionText}) `;
-    }
-    return `@media ${this.#mediaType} ${conditionText}{\n${rules.join(
+    return `@media ${this.#mediaType}${conditionText} {\n${rules.join(
       "\n"
     )}\n}`;
   }

--- a/packages/project-build/src/schema/breakpoints.ts
+++ b/packages/project-build/src/schema/breakpoints.ts
@@ -5,7 +5,8 @@ const BreakpointId = z.string();
 export const Breakpoint = z.object({
   id: BreakpointId,
   label: z.string(),
-  minWidth: z.number(),
+  minWidth: z.number().optional(),
+  maxWidth: z.number().optional(),
 });
 
 export type Breakpoint = z.infer<typeof Breakpoint>;

--- a/packages/project/src/shared/breakpoints/sort.ts
+++ b/packages/project/src/shared/breakpoints/sort.ts
@@ -6,6 +6,6 @@ import type { Breakpoints } from "@webstudio-is/project-build";
  */
 export const sort = (breakpoints: Breakpoints) => {
   return Array.from(breakpoints.values()).sort((breakpointA, breakpointB) => {
-    return breakpointA.minWidth - breakpointB.minWidth;
+    return (breakpointA.minWidth ?? 0) - (breakpointB.minWidth ?? 0);
   });
 };


### PR DESCRIPTION
## Description

This is in preparation for supporting webflow breakpoints which use a combination of min and max width
## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
