### PR TITLE
Fix possible cyclic slot and hide its styles and props panels

### DIFF
--- a/apps/builder/app/builder/features/inspector/inspector.tsx
+++ b/apps/builder/app/builder/features/inspector/inspector.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useStore } from "@nanostores/react";
 import type { Publish } from "~/shared/pubsub";
 import {
@@ -49,6 +49,16 @@ export const Inspector = ({ publish, navigatorLayout }: InspectorProps) => {
   const selectedInstance = useStore(selectedInstanceStore);
   const tabsRef = useRef<HTMLDivElement>(null);
 
+  const [tab, setTab] = useState("style");
+
+  useEffect(() => {
+    if (selectedInstance?.component === "Slot") {
+      if (tab === "style" || tab === "props") {
+        setTab("settings");
+      }
+    }
+  }, [selectedInstance, tab]);
+
   if (navigatorLayout === "docked") {
     return <NavigatorTreePreview />;
   }
@@ -68,29 +78,6 @@ export const Inspector = ({ publish, navigatorLayout }: InspectorProps) => {
     );
   }
 
-  if (selectedInstance.component === "Slot") {
-    return (
-      <EnhancedTooltipProvider
-        delayDuration={1600}
-        disableHoverableContent={false}
-        skipDelayDuration={0}
-      >
-        <FloatingPanelProvider container={tabsRef}>
-          <Flex as={Tabs} defaultValue="settings" grow ref={tabsRef}>
-            <TabsList>
-              <TabsTrigger value="settings">
-                <DeprecatedText2>Settings</DeprecatedText2>
-              </TabsTrigger>
-            </TabsList>
-            <TabsContent value="settings" css={contentStyle}>
-              <SettingsPanel />
-            </TabsContent>
-          </Flex>
-        </FloatingPanelProvider>
-      </EnhancedTooltipProvider>
-    );
-  }
-
   return (
     <EnhancedTooltipProvider
       delayDuration={1600}
@@ -98,13 +85,19 @@ export const Inspector = ({ publish, navigatorLayout }: InspectorProps) => {
       skipDelayDuration={0}
     >
       <FloatingPanelProvider container={tabsRef}>
-        <Flex as={Tabs} defaultValue="style" grow ref={tabsRef}>
+        <Flex as={Tabs} grow ref={tabsRef} value={tab} onValueChange={setTab}>
           <TabsList>
-            <TabsTrigger value="style">
+            <TabsTrigger
+              value="style"
+              disabled={selectedInstance.component === "Slot"}
+            >
               <DeprecatedText2>Style</DeprecatedText2>
             </TabsTrigger>
             {/* @note: events would be part of props */}
-            <TabsTrigger value="props">
+            <TabsTrigger
+              value="props"
+              disabled={selectedInstance.component === "Slot"}
+            >
               <DeprecatedText2>Properties</DeprecatedText2>
             </TabsTrigger>
             <TabsTrigger value="settings">

--- a/apps/builder/app/builder/features/inspector/inspector.tsx
+++ b/apps/builder/app/builder/features/inspector/inspector.tsx
@@ -68,6 +68,29 @@ export const Inspector = ({ publish, navigatorLayout }: InspectorProps) => {
     );
   }
 
+  if (selectedInstance.component === "Slot") {
+    return (
+      <EnhancedTooltipProvider
+        delayDuration={1600}
+        disableHoverableContent={false}
+        skipDelayDuration={0}
+      >
+        <FloatingPanelProvider container={tabsRef}>
+          <Flex as={Tabs} defaultValue="settings" grow ref={tabsRef}>
+            <TabsList>
+              <TabsTrigger value="settings">
+                <DeprecatedText2>Settings</DeprecatedText2>
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="settings" css={contentStyle}>
+              <SettingsPanel />
+            </TabsContent>
+          </Flex>
+        </FloatingPanelProvider>
+      </EnhancedTooltipProvider>
+    );
+  }
+
   return (
     <EnhancedTooltipProvider
       delayDuration={1600}


### PR DESCRIPTION
One cyclic case I missed. When paste slot into itself as target then check miss unresolved fragment inside. Here added additional check before copying and covered with tests.

For slots show only settings panel.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
