### PR TITLE
Fix drop target when sort navigator tree

### DIFF
--- a/packages/design-system/src/components/tree/tree.tsx
+++ b/packages/design-system/src/components/tree/tree.tsx
@@ -158,7 +158,7 @@ export const Tree = <Data extends { id: string }>({
         return dropTarget;
       }
 
-      const newDropItemSelector = dropTarget.data.slice();
+      let newDropItemSelector = dropTarget.data.slice();
 
       if (dropTarget.area === "top" || dropTarget.area === "bottom") {
         newDropItemSelector.shift();
@@ -178,7 +178,7 @@ export const Tree = <Data extends { id: string }>({
       if (ancestorIndex === -1) {
         return getFallbackDropTarget();
       }
-      newDropItemSelector.slice(ancestorIndex);
+      newDropItemSelector = newDropItemSelector.slice(ancestorIndex);
 
       const element = getElementByItemSelector(
         rootRef.current ?? undefined,


### PR DESCRIPTION
Element was not swapped because slice was not reasigned so canAcceptChild didn't really work.

## Code Review

- [ ] hi @rpominov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
