### PR TITLE
Support cross-project instance copy paste

### DIFF
--- a/apps/builder/app/shared/array-utils.test.ts
+++ b/apps/builder/app/shared/array-utils.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "@jest/globals";
-import { removeByMutable } from "./array-utils";
+import {
+  getMapValuesBy,
+  getMapValuesByKeysSet,
+  removeByMutable,
+} from "./array-utils";
 
 test("removeByMutable", () => {
   const array = [
@@ -32,4 +36,29 @@ test("removeByMutable", () => {
       },
     ]
   `);
+});
+
+test("getMapValuesByKeysSet", () => {
+  const map = new Map([
+    [1, "value1"],
+    [2, "value2"],
+    [3, "value3"],
+    [4, "value4"],
+    [5, "value5"],
+  ]);
+  const keys = new Set([2, 4]);
+  expect(getMapValuesByKeysSet(map, keys)).toEqual(["value2", "value4"]);
+});
+
+test("getMapValuesBy", () => {
+  const map = new Map([
+    [1, "value1"],
+    [2, "value2"],
+    [3, "value3"],
+    [4, "value4"],
+    [5, "value5"],
+  ]);
+  expect(
+    getMapValuesBy(map, (value) => value.includes("3") || value.includes("5"))
+  ).toEqual(["value3", "value5"]);
 });

--- a/apps/builder/app/shared/array-utils.ts
+++ b/apps/builder/app/shared/array-utils.ts
@@ -11,3 +11,30 @@ export const removeByMutable = <Item>(
     }
   }
 };
+
+export const getMapValuesByKeysSet = <Key, Value>(
+  map: Map<Key, Value>,
+  keys: Set<Key>
+) => {
+  const values: Value[] = [];
+  for (const key of keys) {
+    const value = map.get(key);
+    if (value !== undefined) {
+      values.push(value);
+    }
+  }
+  return values;
+};
+
+export const getMapValuesBy = <Key, Value>(
+  map: Map<Key, Value>,
+  predicate: Predicate<Value>
+) => {
+  const values: Value[] = [];
+  for (const value of map.values()) {
+    if (predicate(value)) {
+      values.push(value);
+    }
+  }
+  return values;
+};

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -1,12 +1,14 @@
 import store from "immerhin";
 import { z } from "zod";
 import {
-  findTreeInstanceIdsExcludingSlotDescendants,
+  findTreeInstanceIds,
+  Instance,
   InstancesItem,
   Prop,
   StyleDecl,
   StyleSource,
   StyleSourceSelection,
+  StyleSourceSelections,
 } from "@webstudio-is/project-build";
 import {
   propsStore,
@@ -20,14 +22,15 @@ import {
 import {
   type InstanceSelector,
   findClosestDroppableTarget,
-  findSubtreeLocalStyleSources,
   insertInstancesCopyMutable,
   insertPropsCopyMutable,
   insertStylesCopyMutable,
   insertStyleSourcesCopyMutable,
   insertStyleSourceSelectionsCopyMutable,
+  findSubtreeLocalStyleSources,
 } from "../tree-utils";
 import { deleteInstance } from "../instance-utils";
+import { getMapValuesBy, getMapValuesByKeysSet } from "../array-utils";
 
 const version = "@webstudio/instance/v0.1";
 
@@ -41,6 +44,23 @@ const InstanceData = z.object({
 
 type InstanceData = z.infer<typeof InstanceData>;
 
+const findTreeStyleSourceIds = (
+  styleSourceSelections: StyleSourceSelections,
+  treeInstanceIds: Set<Instance["id"]>
+) => {
+  const treeStyleSourceIds = new Set<StyleSource["id"]>();
+  for (const { instanceId, values } of styleSourceSelections.values()) {
+    // skip selections outside of tree
+    if (treeInstanceIds.has(instanceId) === false) {
+      continue;
+    }
+    for (const styleSourceId of values) {
+      treeStyleSourceIds.add(styleSourceId);
+    }
+  }
+  return treeStyleSourceIds;
+};
+
 const getTreeData = (targetInstanceSelector: InstanceSelector) => {
   // @todo tell user they can't copy or cut root
   if (targetInstanceSelector.length === 1) {
@@ -49,57 +69,33 @@ const getTreeData = (targetInstanceSelector: InstanceSelector) => {
 
   const [targetInstanceId] = targetInstanceSelector;
   const instances = instancesStore.get();
-  const treeInstanceIds = findTreeInstanceIdsExcludingSlotDescendants(
-    instances,
-    targetInstanceId
-  );
-  const styleSources = styleSourcesStore.get();
+  const treeInstanceIds = findTreeInstanceIds(instances, targetInstanceId);
   const styleSourceSelections = styleSourceSelectionsStore.get();
-  const subtreeLocalStyleSourceIds = findSubtreeLocalStyleSources(
-    treeInstanceIds,
-    styleSources,
-    styleSourceSelections
+  const treeStyleSourceIds = findTreeStyleSourceIds(
+    styleSourceSelections,
+    treeInstanceIds
   );
 
   // first item is guaranteed root of copied tree
-  const treeInstances: InstancesItem[] = [];
-  for (const instanceId of treeInstanceIds) {
-    const instance = instances.get(instanceId);
-    if (instance) {
-      treeInstances.push(instance);
-    }
-  }
+  const treeInstances = getMapValuesByKeysSet(instances, treeInstanceIds);
 
-  const treeStyleSources: StyleSource[] = [];
-  for (const styleSourceId of subtreeLocalStyleSourceIds) {
-    const styleSource = styleSources.get(styleSourceId);
-    if (styleSource) {
-      treeStyleSources.push(styleSource);
-    }
-  }
+  const treeProps = getMapValuesBy(propsStore.get(), (prop) =>
+    treeInstanceIds.has(prop.instanceId)
+  );
 
-  const props = propsStore.get();
-  const treeProps: Prop[] = [];
-  for (const prop of props.values()) {
-    if (treeInstanceIds.has(prop.instanceId)) {
-      treeProps.push(prop);
-    }
-  }
+  const treeStyleSourceSelections = getMapValuesByKeysSet(
+    styleSourceSelections,
+    treeInstanceIds
+  );
 
-  const treeStyleSourceSelections: StyleSourceSelection[] = [];
-  for (const styleSourceSelection of styleSourceSelections.values()) {
-    if (treeInstanceIds.has(styleSourceSelection.instanceId)) {
-      treeStyleSourceSelections.push(styleSourceSelection);
-    }
-  }
+  const treeStyleSources = getMapValuesByKeysSet(
+    styleSourcesStore.get(),
+    treeStyleSourceIds
+  );
 
-  const styles = stylesStore.get();
-  const treeStyles: StyleDecl[] = [];
-  for (const styleDecl of styles.values()) {
-    if (subtreeLocalStyleSourceIds.has(styleDecl.styleSourceId)) {
-      treeStyles.push(styleDecl);
-    }
-  }
+  const treeStyles = getMapValuesBy(stylesStore.get(), (styleDecl) =>
+    treeStyleSourceIds.has(styleDecl.styleSourceId)
+  );
 
   return {
     instances: treeInstances,
@@ -150,15 +146,34 @@ export const onPaste = (clipboardData: string) => {
       stylesStore,
     ],
     (instances, styleSources, props, styleSourceSelections, styles) => {
+      // @todo implement paste of sharable data
+
       const copiedInstanceIds = insertInstancesCopyMutable(
         instances,
         data.instances,
         dropTarget
       );
+
+      // find all local style sources of copied instances
+      const newStyleSourceIds = findSubtreeLocalStyleSources(
+        new Set(copiedInstanceIds.values()),
+        new Map(
+          data.styleSources.map((styleSource) => [styleSource.id, styleSource])
+        ),
+        new Map(
+          data.styleSourceSelections.map((styleSourceSelection) => [
+            styleSourceSelection.instanceId,
+            styleSourceSelection,
+          ])
+        )
+      );
+
       const copiedStyleSourceIds = insertStyleSourcesCopyMutable(
         styleSources,
-        data.styleSources
+        data.styleSources,
+        newStyleSourceIds
       );
+
       insertPropsCopyMutable(props, data.props, copiedInstanceIds);
       insertStyleSourceSelectionsCopyMutable(
         styleSourceSelections,

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -146,8 +146,6 @@ export const onPaste = (clipboardData: string) => {
       stylesStore,
     ],
     (instances, styleSources, props, styleSourceSelections, styles) => {
-      // @todo implement paste of sharable data
-
       const copiedInstanceIds = insertInstancesCopyMutable(
         instances,
         data.instances,


### PR DESCRIPTION
Here a little refactored copy paste instance plugin.

Now we copy all data including slots and tokens though paste write them as is or do not write at all if already exist.

This let us to not do unnecessary patches for copy paste within project while still have whole UI pasted in different project.

There is still a problem with pasting styles which always have different breakpoint ids in each project. We will need to implement merging in other PR.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @rpominov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
