### PR TITLE
Enable reset, add cmd+click shortcut on property names

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
@@ -1,6 +1,5 @@
-import { useState, type ReactElement, type MouseEventHandler } from "react";
+import { useState, type ReactElement } from "react";
 import { useStore } from "@nanostores/react";
-import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import type { StyleProperty } from "@webstudio-is/css-data";
 import { toValue } from "@webstudio-is/css-engine";
 import {
@@ -11,11 +10,11 @@ import {
   DeprecatedText2,
   Label,
   Tooltip,
-  DeprecatedPopover,
-  DeprecatedPopoverContent,
-  DeprecatedPopoverPortal,
-  DeprecatedPopoverTrigger,
   Separator,
+  Popover,
+  PopoverTrigger,
+  PopoverPortal,
+  PopoverContent,
 } from "@webstudio-is/design-system";
 import { UndoIcon } from "@webstudio-is/icons";
 import { instancesStore, useBreakpoints } from "~/shared/nano-states";
@@ -30,7 +29,7 @@ const PropertyPopoverContent = ({
   properties: StyleProperty[];
   style: StyleInfo;
   styleSource: StyleSource;
-  onReset: MouseEventHandler<HTMLButtonElement>;
+  onReset: () => void;
 }) => {
   const [breakpoints] = useBreakpoints();
   const instances = useStore(instancesStore);
@@ -42,7 +41,7 @@ const PropertyPopoverContent = ({
           align="start"
           css={{ px: theme.spacing[4], py: theme.spacing[3] }}
         >
-          <Button onClick={onReset} prefix={<UndoIcon />}>
+          <Button onClick={() => onReset()} prefix={<UndoIcon />}>
             Reset
           </Button>
         </Flex>
@@ -124,7 +123,7 @@ type PropertyNameProps = {
   style: StyleInfo;
   property: StyleProperty | readonly StyleProperty[];
   label: string | ReactElement;
-  onReset: React.MouseEventHandler<HTMLButtonElement>;
+  onReset: () => void;
 };
 
 export const PropertyName = ({
@@ -154,27 +153,32 @@ export const PropertyName = ({
   if (isPopoverEnabled) {
     return (
       <Flex align="center">
-        <DeprecatedPopover modal open={isOpen} onOpenChange={setIsOpen}>
-          <DeprecatedPopoverTrigger
+        <Popover modal open={isOpen} onOpenChange={setIsOpen}>
+          <PopoverTrigger
             asChild
             aria-label="Show proprety description"
+            onClick={(event) => {
+              event.preventDefault();
+              if (event.metaKey) {
+                onReset();
+                return;
+              }
+              setIsOpen(true);
+            }}
           >
-            {labelElement}
-          </DeprecatedPopoverTrigger>
-          <DeprecatedPopoverPortal>
-            <DeprecatedPopoverContent
-              align="start"
-              onClick={() => setIsOpen(false)}
-            >
+            <span>{labelElement}</span>
+          </PopoverTrigger>
+          <PopoverPortal>
+            <PopoverContent align="start" onClick={() => setIsOpen(false)}>
               <PropertyPopoverContent
                 properties={properties}
                 style={style}
                 styleSource={styleSource}
                 onReset={onReset}
               />
-            </DeprecatedPopoverContent>
-          </DeprecatedPopoverPortal>
-        </DeprecatedPopover>
+            </PopoverContent>
+          </PopoverPortal>
+        </Popover>
       </Flex>
     );
   }

--- a/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
@@ -138,9 +138,7 @@ export const PropertyName = ({
     ...properties.map((property) => style[property])
   );
   const [isOpen, setIsOpen] = useState(false);
-  const isPopoverEnabled =
-    isFeatureEnabled("propertyReset") &&
-    (styleSource === "local" || styleSource === "remote");
+  const isPopoverEnabled = styleSource === "local" || styleSource === "remote";
 
   const labelElement =
     typeof label === "string" ? (

--- a/packages/design-system/src/components/popover.tsx
+++ b/packages/design-system/src/components/popover.tsx
@@ -5,6 +5,8 @@ import { Separator } from "./separator";
 
 export const Popover = Primitive.Root;
 
+export const PopoverPortal = Primitive.Portal;
+
 const contentStyle = css({
   border: `1px solid ${theme.colors.borderMain}`,
   boxShadow: `${theme.shadows.menuDropShadow}, inset 0 0 0 1px ${theme.colors.borderMenuInner}`,

--- a/packages/feature-flags/src/flags.ts
+++ b/packages/feature-flags/src/flags.ts
@@ -1,5 +1,4 @@
 export const example = false;
 export const dark = false;
-export const propertyReset = false;
 export const unsupportedBrowsers = false;
 export const displayContents = false;


### PR DESCRIPTION
## Description

1. Enabling the popover by default now, users need it asap (still unstyled)
2. Adding cmd+click for quick access to reset


## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
