### PR TITLE
Enable typescript preserveValueImports

### DIFF
--- a/apps/builder/app/builder/features/props-panel/props-panel.tsx
+++ b/apps/builder/app/builder/features/props-panel/props-panel.tsx
@@ -14,7 +14,7 @@ import {
   Separator,
   Flex,
   Text,
-  CSS,
+  type CSS,
 } from "@webstudio-is/design-system";
 import { ChevronDownIcon } from "@webstudio-is/icons";
 import type { Publish } from "~/shared/pubsub";

--- a/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
@@ -2,9 +2,9 @@ import { useMemo } from "react";
 import { usePress } from "@react-aria/interactions";
 import {
   type ComponentName,
+  type WsComponentMeta,
   getComponentMeta,
   getComponentNames,
-  WsComponentMeta,
   componentCategories,
 } from "@webstudio-is/react-sdk";
 import {

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import store from "immerhin";
-import { useState, useCallback, ComponentProps } from "react";
+import { useState, useCallback, type ComponentProps } from "react";
 import { useStore } from "@nanostores/react";
 import { useDebouncedCallback } from "use-debounce";
 import { useUnmount } from "react-use";

--- a/apps/builder/app/builder/features/style-panel/controls/color/color-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/color/color-control.tsx
@@ -2,8 +2,8 @@ import { Flex } from "@webstudio-is/design-system";
 import { toValue } from "@webstudio-is/css-engine";
 import type { ControlProps } from "../../style-sections";
 import {
+  type CssColorPickerValueInput,
   ColorPicker,
-  CssColorPickerValueInput,
 } from "../../shared/color-picker";
 import { colord } from "colord";
 import { getStyleSource } from "../../shared/style-info";

--- a/apps/builder/app/builder/features/style-panel/controls/font-weight/font-weight-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/font-weight/font-weight-control.tsx
@@ -1,5 +1,5 @@
 import { Select } from "@webstudio-is/design-system";
-import { FontWeight, fontWeights } from "@webstudio-is/fonts";
+import { type FontWeight, fontWeights } from "@webstudio-is/fonts";
 import { toValue } from "@webstudio-is/css-engine";
 import { useMemo } from "react";
 import { useAssets } from "~/builder/shared/assets";

--- a/apps/builder/app/builder/features/style-panel/controls/position/css-value-input-container.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/position/css-value-input-container.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, useState } from "react";
+import { type ComponentProps, useState } from "react";
 import type { StyleValue, StyleProperty } from "@webstudio-is/css-data";
 import { Box, EnhancedTooltip } from "@webstudio-is/design-system";
 import {

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.tsx
@@ -24,7 +24,7 @@ import type {
 } from "../../shared/use-style-data";
 
 import {
-  DeleteBackgroundProperty,
+  type DeleteBackgroundProperty,
   isBackgroundLayeredProperty,
   isBackgroundStyleValue,
   type SetBackgroundProperty,

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.ts
@@ -1,8 +1,8 @@
 import type { LayersValue, StyleValue } from "@webstudio-is/css-data";
 import {
+  type StyleInfo,
+  type StyleValueInfo,
   getStyleSource,
-  StyleInfo,
-  StyleValueInfo,
 } from "../../shared/style-info";
 import type {
   CreateBatchUpdate,

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-size.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-size.tsx
@@ -5,7 +5,11 @@ import { toPascalCase } from "../../shared/keyword-utils";
 import { parseCssValue } from "../../shared/parse-css-value";
 import type { ControlProps } from "../../style-sections";
 import { CssValueInputContainer } from "../../controls/position/css-value-input-container";
-import { StyleValue, TupleValue, TupleValueItem } from "@webstudio-is/css-data";
+import {
+  type StyleValue,
+  TupleValue,
+  TupleValueItem,
+} from "@webstudio-is/css-data";
 import type { SetValue } from "../../shared/use-style-data";
 
 const StyleKeywordAuto = { type: "keyword" as const, value: "auto" };

--- a/apps/builder/app/builder/features/style-panel/sections/layout/shared/flex-grid.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/layout/shared/flex-grid.tsx
@@ -7,7 +7,7 @@ import {
 import { toValue } from "@webstudio-is/css-engine";
 import { DotFilledIcon } from "@webstudio-is/icons";
 import type { CreateBatchUpdate } from "../../../shared/use-style-data";
-import { getStyleSource, StyleInfo } from "../../../shared/style-info";
+import { getStyleSource, type StyleInfo } from "../../../shared/style-info";
 import { theme } from "@webstudio-is/design-system";
 
 export const FlexGrid = ({

--- a/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { colord, extend, type RgbaColor } from "colord";
 import namesPlugin from "colord/plugins/names";
-import { ColorResult, RGBColor, SketchPicker } from "react-color";
+import { type ColorResult, type RGBColor, SketchPicker } from "react-color";
 import type {
   InvalidValue,
   KeywordValue,

--- a/apps/builder/app/builder/features/style-panel/shared/configs.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/configs.ts
@@ -2,7 +2,7 @@ import type { StyleProperty, AppliesTo } from "@webstudio-is/css-data";
 import { keywordValues, properties } from "@webstudio-is/css-data";
 import { humanizeString } from "~/shared/string-utils";
 import {
-  IconRecords,
+  type IconRecords,
   AlignContentStartIcon,
   AlignContentEndIcon,
   AlignContentCenterIcon,

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
@@ -36,7 +36,7 @@ import {
 } from "react";
 import { mergeRefs } from "@react-aria/utils";
 import {
-  ItemSource,
+  type ItemSource,
   menuCssVars,
   StyleSource,
   type ItemState,

--- a/apps/builder/app/builder/features/workspace/canvas-iframe.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-iframe.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import { CSS, css } from "@webstudio-is/design-system";
+import { type CSS, css } from "@webstudio-is/design-system";
 
 const iframeStyle = css({
   border: "none",

--- a/apps/builder/app/builder/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
@@ -13,7 +13,7 @@ import {
 } from "@webstudio-is/icons";
 import { selectedInstanceSelectorStore } from "~/shared/nano-states";
 import {
-  TextToolbarState,
+  type TextToolbarState,
   textToolbarStore,
 } from "~/shared/nano-states/canvas";
 import type { Publish } from "~/shared/pubsub";

--- a/apps/builder/app/builder/shared/assets/asset-upload.tsx
+++ b/apps/builder/app/builder/shared/assets/asset-upload.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useRef } from "react";
+import { type ChangeEvent, useRef } from "react";
 import { Button, Flex, Tooltip } from "@webstudio-is/design-system";
 import { UploadIcon } from "@webstudio-is/icons";
 import type { AssetType } from "@webstudio-is/asset-uploader";

--- a/apps/builder/app/builder/shared/assets/use-assets.tsx
+++ b/apps/builder/app/builder/shared/assets/use-assets.tsx
@@ -10,7 +10,7 @@ import { useStore } from "@nanostores/react";
 import warnOnce from "warn-once";
 import { useFetcher } from "@remix-run/react";
 import {
-  AssetType,
+  type AssetType,
   idsFormDataFieldName,
   MAX_UPLOAD_SIZE,
   toBytes,

--- a/apps/builder/app/builder/shared/assets/use-search.tsx
+++ b/apps/builder/app/builder/shared/assets/use-search.tsx
@@ -1,4 +1,8 @@
-import { ChangeEventHandler, KeyboardEventHandler, useState } from "react";
+import {
+  type ChangeEventHandler,
+  type KeyboardEventHandler,
+  useState,
+} from "react";
 
 type UseSearch = {
   onCancel: () => void;

--- a/apps/builder/app/builder/shared/floating-panel/floating-panel-provider.tsx
+++ b/apps/builder/app/builder/shared/floating-panel/floating-panel-provider.tsx
@@ -1,4 +1,4 @@
-import { createContext, RefObject } from "react";
+import { createContext, type RefObject } from "react";
 
 export const FloatingPanelContext = createContext<{
   container: RefObject<HTMLElement>;

--- a/apps/builder/app/builder/shared/floating-panel/floating-panel.tsx
+++ b/apps/builder/app/builder/shared/floating-panel/floating-panel.tsx
@@ -7,7 +7,7 @@ import {
   FloatingPanelPopoverTitle,
 } from "@webstudio-is/design-system";
 import {
-  MutableRefObject,
+  type MutableRefObject,
   useContext,
   useEffect,
   useRef,

--- a/apps/builder/app/canvas/features/text-editor/interop.test.ts
+++ b/apps/builder/app/canvas/features/text-editor/interop.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@jest/globals";
 import { createHeadlessEditor } from "@lexical/headless";
 import { LinkNode } from "@lexical/link";
 import type { Instance, InstancesItem } from "@webstudio-is/project-build";
-import { $convertToLexical, $convertToUpdates, Refs } from "./interop";
+import { $convertToLexical, $convertToUpdates, type Refs } from "./interop";
 
 const createInstance = (
   id: Instance["id"],

--- a/apps/builder/app/canvas/features/webstudio-component/link.ts
+++ b/apps/builder/app/canvas/features/webstudio-component/link.ts
@@ -1,5 +1,5 @@
 import type { MouseEvent } from "react";
-import { findPageByIdOrPath, Page } from "@webstudio-is/project-build";
+import { findPageByIdOrPath, type Page } from "@webstudio-is/project-build";
 import { pagesStore, isPreviewModeStore } from "~/shared/nano-states";
 import { publish } from "~/shared/pubsub";
 

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, FormEvent, useEffect } from "react";
+import { type MouseEvent, type FormEvent, useEffect } from "react";
 import { Suspense, lazy, useCallback, useMemo, useRef } from "react";
 import { useStore } from "@nanostores/react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
@@ -24,8 +24,8 @@ import {
 import { textEditingInstanceSelectorStore } from "~/shared/nano-states/instances";
 import { useCssRules } from "~/canvas/shared/styles";
 import {
+  type InstanceSelector,
   areInstanceSelectorsEqual,
-  InstanceSelector,
 } from "~/shared/tree-utils";
 import { SelectedInstanceConnector } from "./selected-instance-connector";
 import { handleLinkClick } from "./link";

--- a/apps/builder/app/dashboard/projects/project-card.tsx
+++ b/apps/builder/app/dashboard/projects/project-card.tsx
@@ -12,7 +12,7 @@ import {
 } from "@webstudio-is/design-system";
 import { MenuIcon } from "@webstudio-is/icons";
 import type { DashboardProject } from "@webstudio-is/prisma-client";
-import { KeyboardEvent, useEffect, useRef, useState } from "react";
+import { type KeyboardEvent, useEffect, useRef, useState } from "react";
 import { builderPath, getPublishedUrl } from "~/shared/router-utils";
 import {
   RenameProjectDialog,

--- a/apps/builder/app/routes/login/index.tsx
+++ b/apps/builder/app/routes/login/index.tsx
@@ -1,8 +1,8 @@
 import {
   type LoaderArgs,
+  type TypedResponse,
   redirect,
   json,
-  TypedResponse,
 } from "@remix-run/node";
 import { findAuthenticatedUser } from "~/services/auth.server";
 import env from "~/env/env.server";

--- a/apps/builder/app/services/auth.server.ts
+++ b/apps/builder/app/services/auth.server.ts
@@ -7,7 +7,7 @@ import { sessionStorage } from "~/services/session.server";
 import { sentryException } from "~/shared/sentry";
 import { AUTH_PROVIDERS } from "~/shared/session";
 import { authCallbackPath } from "~/shared/router-utils";
-import { getUserById, User } from "~/shared/db/user.server";
+import { getUserById, type User } from "~/shared/db/user.server";
 import env from "~/env/env.server";
 
 const url =

--- a/apps/builder/app/shared/share-project/share-project-container.tsx
+++ b/apps/builder/app/shared/share-project/share-project-container.tsx
@@ -1,4 +1,4 @@
-import { ShareProject, LinkOptions } from "./share-project";
+import { ShareProject, type LinkOptions } from "./share-project";
 import { createTrpcRemixProxy } from "~/shared/remix/trpc-remix-proxy";
 import type { AuthorizationTokensRouter } from "@webstudio-is/authorization-token";
 import { authorizationTokenPath, builderUrl } from "~/shared/router-utils";

--- a/apps/builder/app/shared/shortcuts/shortcuts.ts
+++ b/apps/builder/app/shared/shortcuts/shortcuts.ts
@@ -1,4 +1,4 @@
-import { Options, useHotkeys } from "react-hotkeys-hook";
+import { type Options, useHotkeys } from "react-hotkeys-hook";
 import store from "immerhin";
 import {
   zoomIn,

--- a/packages/asset-uploader/src/db/load.ts
+++ b/packages/asset-uploader/src/db/load.ts
@@ -1,4 +1,4 @@
-import { prisma, Project } from "@webstudio-is/prisma-client";
+import { prisma, type Project } from "@webstudio-is/prisma-client";
 import type { Asset } from "../schema";
 import { formatAsset } from "../utils/format-asset";
 import {

--- a/packages/asset-uploader/src/utils/get-asset-path.test.ts
+++ b/packages/asset-uploader/src/utils/get-asset-path.test.ts
@@ -6,7 +6,7 @@ import {
   test,
   expect,
 } from "@jest/globals";
-import { Asset, Location } from "@webstudio-is/prisma-client";
+import { type Asset, Location } from "@webstudio-is/prisma-client";
 
 const commonAsset: Asset = {
   id: "sa-546",

--- a/packages/asset-uploader/src/utils/get-asset-path.ts
+++ b/packages/asset-uploader/src/utils/get-asset-path.ts
@@ -1,4 +1,4 @@
-import { Asset as DbAsset, Location } from "@webstudio-is/prisma-client";
+import { type Asset as DbAsset, Location } from "@webstudio-is/prisma-client";
 import { FsEnv, S3Env } from "../schema";
 import path from "path";
 

--- a/packages/design-system/src/components/__DEPRECATED__/popover.tsx
+++ b/packages/design-system/src/components/__DEPRECATED__/popover.tsx
@@ -7,7 +7,7 @@ import { Flex } from "../flex";
 import { DeprecatedIconButton } from "./icon-button";
 import { DeprecatedText2 } from "./text2";
 import { Separator } from "../separator";
-import { styled, CSS } from "../../stitches.config";
+import { styled, type CSS } from "../../stitches.config";
 import { theme } from "../../stitches.config";
 
 type PopoverProps = React.ComponentProps<typeof PopoverPrimitive.Root> & {

--- a/packages/design-system/src/components/avatar.tsx
+++ b/packages/design-system/src/components/avatar.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { styled, VariantProps, CSS } from "../stitches.config";
+import { styled, type VariantProps, type CSS } from "../stitches.config";
 import * as AvatarPrimitive from "@radix-ui/react-avatar";
 import { Box } from "./box";
 import { Status } from "./status";

--- a/packages/design-system/src/components/combobox.tsx
+++ b/packages/design-system/src/components/combobox.tsx
@@ -1,14 +1,14 @@
 import {
+  type ComponentProps,
+  type ChangeEvent,
+  type ReactNode,
+  type Ref,
+  type ForwardRefRenderFunction,
   useState,
   forwardRef,
   useCallback,
-  type ComponentProps,
-  type ForwardRefRenderFunction,
   useEffect,
   useRef,
-  type ChangeEvent,
-  type ReactNode,
-  Ref,
 } from "react";
 // @todo:
 //   react-popper "is an internal utility, not intended for public usage"

--- a/packages/design-system/src/components/component-card.tsx
+++ b/packages/design-system/src/components/component-card.tsx
@@ -3,7 +3,7 @@
  * https://www.figma.com/file/sfCE7iLS0k25qCxiifQNLE/%F0%9F%93%9A-Webstudio-Library?node-id=2608-8921
  */
 
-import { forwardRef, type ElementRef, ComponentProps } from "react";
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
 import { textVariants } from "../";
 import { css, theme } from "../stitches.config";
 

--- a/packages/design-system/src/components/css-value-list-item.tsx
+++ b/packages/design-system/src/components/css-value-list-item.tsx
@@ -1,4 +1,10 @@
-import { type ComponentProps, forwardRef, Ref, Children, useMemo } from "react";
+import {
+  type ComponentProps,
+  type Ref,
+  forwardRef,
+  Children,
+  useMemo,
+} from "react";
 import { styled } from "../stitches.config";
 import { Flex } from "./flex";
 import { theme } from "../stitches.config";

--- a/packages/design-system/src/components/enhanced-tooltip.tsx
+++ b/packages/design-system/src/components/enhanced-tooltip.tsx
@@ -1,9 +1,9 @@
 import React, {
-  Ref,
-  useRef,
-  useState,
+  type Ref,
   type ComponentProps,
   type FocusEvent,
+  useRef,
+  useState,
   createContext,
   useContext,
   useMemo,

--- a/packages/design-system/src/components/floating-panel.tsx
+++ b/packages/design-system/src/components/floating-panel.tsx
@@ -3,7 +3,12 @@
  * https://www.figma.com/file/sfCE7iLS0k25qCxiifQNLE/%F0%9F%93%9A-Webstudio-Library?node-id=4%3A2679&t=6Q0l4j0CBvXkuKYp-0
  */
 
-import { forwardRef, Ref, type ReactNode, type ComponentProps } from "react";
+import {
+  forwardRef,
+  type Ref,
+  type ReactNode,
+  type ComponentProps,
+} from "react";
 import { CrossIcon } from "@webstudio-is/icons";
 import { css, theme } from "../stitches.config";
 import { Button } from "./button";

--- a/packages/design-system/src/components/position-grid.tsx
+++ b/packages/design-system/src/components/position-grid.tsx
@@ -1,4 +1,4 @@
-import { KeyboardEventHandler, useState } from "react";
+import { type KeyboardEventHandler, useState } from "react";
 import { css, theme } from "../stitches.config";
 import { Box } from "./box";
 import { Grid } from "./grid";

--- a/packages/design-system/src/components/primitives/create-content-controller.stories.tsx
+++ b/packages/design-system/src/components/primitives/create-content-controller.stories.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, RefObject } from "react";
+import { useState, useRef, useEffect, type RefObject } from "react";
 import { createContentController } from "./create-content-controller";
 
 const useContentController = ({

--- a/packages/design-system/src/components/primitives/dnd/placement-indicator.tsx
+++ b/packages/design-system/src/components/primitives/dnd/placement-indicator.tsx
@@ -7,7 +7,7 @@ import {
   getPlacementInside,
   getPlacementNextTo,
 } from "./geometry-utils";
-import { defaultGetValidChildren, DropTarget } from "./use-drop";
+import { defaultGetValidChildren, type DropTarget } from "./use-drop";
 
 const placementStyle = {
   boxSizing: "content-box",

--- a/packages/design-system/src/components/primitives/numeric-gesture-control.stories.tsx
+++ b/packages/design-system/src/components/primitives/numeric-gesture-control.stories.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, RefObject } from "react";
+import { useRef, useEffect, type RefObject } from "react";
 import {
   numericScrubControl,
   type NumericScrubValue,

--- a/packages/design-system/src/components/select.stories.tsx
+++ b/packages/design-system/src/components/select.stories.tsx
@@ -2,7 +2,7 @@ import type { ComponentStory } from "@storybook/react";
 import { RowGapIcon } from "@webstudio-is/icons";
 import React from "react";
 import { NestedIconLabel } from "./nested-icon-label";
-import { Select, SelectOption } from "./select";
+import { Select, type SelectOption } from "./select";
 
 export default {
   component: Select,

--- a/packages/design-system/src/components/select.tsx
+++ b/packages/design-system/src/components/select.tsx
@@ -1,5 +1,10 @@
 import * as Primitive from "@radix-ui/react-select";
-import React, { ReactNode, Ref, useMemo, type ComponentProps } from "react";
+import React, {
+  type ReactNode,
+  type Ref,
+  type ComponentProps,
+  useMemo,
+} from "react";
 import {
   menuCss,
   itemCss,

--- a/packages/design-system/src/components/sidebar-tabs.tsx
+++ b/packages/design-system/src/components/sidebar-tabs.tsx
@@ -1,6 +1,6 @@
 // @todo this should be a local customization in sidebar left, not a reusable component
 import React from "react";
-import { CSS, styled } from "../stitches.config";
+import { type CSS, styled } from "../stitches.config";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
 import { theme } from "../stitches.config";
 

--- a/packages/design-system/src/components/slider.tsx
+++ b/packages/design-system/src/components/slider.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { styled, CSS } from "../stitches.config";
+import { styled, type CSS } from "../stitches.config";
 import * as SliderPrimitive from "@radix-ui/react-slider";
 import { theme } from "../stitches.config";
 

--- a/packages/design-system/src/components/tabs.tsx
+++ b/packages/design-system/src/components/tabs.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { styled, CSS } from "../stitches.config";
+import { styled, type CSS } from "../stitches.config";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
 import { DeprecatedText2 } from "./__DEPRECATED__/text2";
 import { theme } from "../stitches.config";

--- a/packages/design-system/src/components/text-area.tsx
+++ b/packages/design-system/src/components/text-area.tsx
@@ -3,7 +3,7 @@
  * https://www.figma.com/file/sfCE7iLS0k25qCxiifQNLE/%F0%9F%93%9A-Webstudio-Library?node-id=4-3389
  */
 
-import { type ComponentProps, forwardRef, Ref } from "react";
+import { type ComponentProps, type Ref, forwardRef } from "react";
 import { type CSS, css, theme } from "../stitches.config";
 import { textVariants } from "./text";
 

--- a/packages/design-system/src/components/tooltip.tsx
+++ b/packages/design-system/src/components/tooltip.tsx
@@ -1,4 +1,4 @@
-import React, { Ref, Fragment, type ComponentProps } from "react";
+import React, { type Ref, Fragment, type ComponentProps } from "react";
 import { styled } from "../stitches.config";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { Box } from "./box";

--- a/packages/design-system/src/components/tree/horizontal-shift.test.ts
+++ b/packages/design-system/src/components/tree/horizontal-shift.test.ts
@@ -3,7 +3,7 @@ import { renderHook, act } from "@testing-library/react-hooks";
 import type { Placement } from "../primitives/dnd";
 import { useHorizontalShift } from "./horizontal-shift";
 import type { ItemDropTarget, ItemId, ItemSelector } from "./item-utils";
-import { findItemById, getItemPath, Item } from "./test-tree-data";
+import { type Item, findItemById, getItemPath } from "./test-tree-data";
 
 const box1: Item = { canAcceptChildren: true, id: "box1", children: [] };
 const box2: Item = { canAcceptChildren: true, id: "box2", children: [] };

--- a/packages/design-system/src/components/tree/tree.stories.tsx
+++ b/packages/design-system/src/components/tree/tree.stories.tsx
@@ -1,7 +1,7 @@
 import type { ComponentMeta } from "@storybook/react";
 import { useState } from "react";
 import { Tree } from "./tree";
-import { findItemById, Item, reparent } from "./test-tree-data";
+import { type Item, findItemById, reparent } from "./test-tree-data";
 import { Flex } from "../flex";
 import { TreeItemLabel, TreeItemBody } from "./tree-node";
 import type { ItemDropTarget, ItemSelector } from "./item-utils";

--- a/packages/design-system/src/components/tree/tree.tsx
+++ b/packages/design-system/src/components/tree/tree.tsx
@@ -2,7 +2,7 @@ import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useState, useMemo, useRef, useCallback, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { ListPositionIndicator } from "../list-position-indicator";
-import { TreeNode, INDENT, TreeItemRenderProps } from "./tree-node";
+import { TreeNode, INDENT, type TreeItemRenderProps } from "./tree-node";
 import {
   useHold,
   useDrop,

--- a/packages/fonts/src/font-data.ts
+++ b/packages/fonts/src/font-data.ts
@@ -1,6 +1,6 @@
 import type { FontFormat, VariationAxes } from "./schema";
 import { create as createFontKit } from "fontkit";
-import { FontWeight, fontWeights } from "./font-weights";
+import { type FontWeight, fontWeights } from "./font-weights";
 
 // @todo sumbit this to definitely typed, they are not up to date
 declare module "fontkit" {
@@ -12,7 +12,7 @@ declare module "fontkit" {
 }
 
 export const styles = ["normal", "italic", "oblique"] as const;
-type Style = typeof styles[number];
+type Style = (typeof styles)[number];
 
 export const parseSubfamily = (subfamily: string) => {
   const subfamilyLow = subfamily.toLowerCase();

--- a/packages/http-client/tsconfig.json
+++ b/packages/http-client/tsconfig.json
@@ -3,7 +3,7 @@
   "include": ["src", "../../@types/**/*.d.ts"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2020"],
-    "module": "commonjs",
+    "module": "ES2020",
     "target": "ES2020",
     "baseUrl": ".",
     "outDir": "./lib",

--- a/packages/project-build/src/db/build.ts
+++ b/packages/project-build/src/db/build.ts
@@ -1,9 +1,9 @@
 import { nanoid } from "nanoid";
 import {
+  type Build as DbBuild,
+  type Project,
   prisma,
-  Build as DbBuild,
   Prisma,
-  Project,
 } from "@webstudio-is/prisma-client";
 import type { AppContext } from "@webstudio-is/trpc-interface";
 import type { Build } from "../types";

--- a/packages/react-sdk/src/css/get-browser-style.ts
+++ b/packages/react-sdk/src/css/get-browser-style.ts
@@ -1,5 +1,10 @@
 import { detectFont } from "detect-font";
-import { keywordValues, Style, StyleValue, Unit } from "@webstudio-is/css-data";
+import {
+  type Style,
+  type StyleValue,
+  type Unit,
+  keywordValues,
+} from "@webstudio-is/css-data";
 import { properties, units } from "@webstudio-is/css-data";
 
 const unitsList = Object.values(units).flat();

--- a/packages/trpc-interface/src/shared/client.ts
+++ b/packages/trpc-interface/src/shared/client.ts
@@ -1,7 +1,7 @@
 import { createTRPCProxyClient, httpBatchLink } from "@trpc/client";
 import {
   sharedRouter,
-  TrpcInterfaceClient,
+  type TrpcInterfaceClient,
   type SharedRouter,
 } from "./shared-router";
 import { callerLink } from "../trpc-caller-link";

--- a/packages/trpc-interface/src/trpc-caller-link.ts
+++ b/packages/trpc-interface/src/trpc-caller-link.ts
@@ -1,7 +1,7 @@
 import type { AnyRouter } from "@trpc/server";
 // eslint-disable-next-line import/no-internal-modules
 import { observable } from "@trpc/server/observable";
-import { TRPCClientError, TRPCLink } from "@trpc/client";
+import { TRPCClientError, type TRPCLink } from "@trpc/client";
 
 type MemoryLinkOptions<TemplateRouter extends AnyRouter> = {
   appRouter: TemplateRouter;

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -16,6 +16,7 @@
     "jsx": "react-jsx",
     "resolveJsonModule": true,
     "noFallthroughCasesInSwitch": true,
-    "importsNotUsedAsValues": "error"
+    "importsNotUsedAsValues": "error",
+    "preserveValueImports": true
   }
 }


### PR DESCRIPTION
This option forces all type imports to have "type" specifier even though there are other value imports.

TS 5 forces it when new verbatimModuleSyntax is enabled.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
