### PR TITLE
Refactor style source menu

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.tsx
@@ -284,7 +284,7 @@ export const StyleSourcesSection = () => {
         onSelectAutocompleteItem={({ id }) => {
           addStyleSourceToInstace(id);
         }}
-        onRemoveItem={({ id }) => {
+        onRemoveItem={(id) => {
           removeStyleSourceFromInstance(id);
         }}
         onDuplicateItem={(id) => {

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.stories.tsx
@@ -72,14 +72,11 @@ const createItem = (
 };
 
 const removeItem = (
-  itemToRemove: Item,
+  itemIdToRemove: Item["id"],
   value: Array<Item>,
   setValue: (value: Array<Item>) => void
 ) => {
-  if (itemToRemove.source === "local") {
-    return;
-  }
-  setValue(value.filter((item) => item.id !== itemToRemove.id));
+  setValue(value.filter((item) => item.id !== itemIdToRemove));
 };
 
 export const Basic: ComponentStory<typeof StyleSourceInput> = () => {
@@ -95,8 +92,8 @@ export const Basic: ComponentStory<typeof StyleSourceInput> = () => {
       onSelectAutocompleteItem={(item) => {
         setValue([...value, item]);
       }}
-      onRemoveItem={(itemToRemove) => {
-        removeItem(itemToRemove, value, setValue);
+      onRemoveItem={(itemId) => {
+        removeItem(itemId, value, setValue);
       }}
       onSort={setValue}
     />
@@ -189,20 +186,20 @@ export const Complete: ComponentStory<typeof StyleSourceInput> = () => {
           })
         );
       }}
-      onDisableItem={(itemToDisable) => {
+      onDisableItem={(itemIdToDisable) => {
         setValue(
           value.map((item) => {
-            if (item.id === itemToDisable.id) {
+            if (item.id === itemIdToDisable) {
               return { ...item, state: "disabled" };
             }
             return item;
           })
         );
       }}
-      onEnableItem={(itemToEnable) => {
+      onEnableItem={(itemIdToEnable) => {
         setValue(
           value.map((item) => {
-            if (item.id === itemToEnable.id) {
+            if (item.id === itemIdToEnable) {
               return { ...item, state: "unselected" };
             }
             return item;


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/807

Moved style source menu up to style source input. This way we will not need to drill a lot of callbacks and only pass menu element.

Later we will add even more callbacks. So this just simplifies further development.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
