### PR TITLE
Remove isEditable option from style source

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.tsx
@@ -247,7 +247,6 @@ const renameStyleSource = (id: StyleSource["id"], label: string) => {
 type StyleSourceInputItem = {
   id: string;
   label: string;
-  isEditable: boolean;
   state: ItemState;
   source: ItemSource;
 };
@@ -262,7 +261,6 @@ const convertToInputItem = (
     return {
       id: styleSource.id,
       label: "Local",
-      isEditable: false,
       state,
       source: styleSource.type,
     };
@@ -270,7 +268,6 @@ const convertToInputItem = (
   return {
     id: styleSource.id,
     label: styleSource.name,
-    isEditable: true,
     state,
     source: styleSource.type,
   };

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.stories.tsx
@@ -11,7 +11,6 @@ type Item = {
   id: string;
   label: string;
   source: ItemSource;
-  isEditable: boolean;
   state: ItemState;
 };
 
@@ -19,7 +18,6 @@ const localItem: Item = {
   id: nanoid(),
   label: "Local",
   source: "local",
-  isEditable: false,
   state: "selected",
 };
 
@@ -28,21 +26,18 @@ const getItems = (): Array<Item> => [
     id: nanoid(),
     label: "Token",
     source: "token",
-    isEditable: true,
     state: "unselected",
   },
   {
     id: nanoid(),
     label: "Tag",
     source: "tag",
-    isEditable: true,
     state: "unselected",
   },
   {
     id: nanoid(),
     label: "State",
     source: "state",
-    isEditable: true,
     state: "unselected",
   },
 ];
@@ -56,7 +51,6 @@ const createItem = (
     id: nanoid(),
     label,
     source: "token",
-    isEditable: true,
     state: "selected",
   };
   const nextValue = value.map((item) => {
@@ -109,7 +103,6 @@ export const WithTruncatedItem: ComponentStory<
       label:
         "Local Something Something Something Something Something Something Something Something Something Something Something",
       source: "local",
-      isEditable: true,
       state: "selected",
     },
   ]);
@@ -141,7 +134,6 @@ export const Complete: ComponentStory<typeof StyleSourceInput> = () => {
       label: "Disabled",
       source: "token",
 
-      isEditable: true,
       state: "disabled",
     },
   ]);

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
@@ -50,7 +50,6 @@ import { StyleSourceBadge } from "./style-source-badge";
 type IntermediateItem = {
   id: string;
   label: string;
-  isEditable: boolean;
   state: ItemState;
   source: ItemSource;
   isAdded?: boolean;
@@ -136,7 +135,6 @@ const TextFieldBase: ForwardRefRenderFunction<
           isEditing={item.id === editingItemId}
           state={item.state}
           source={item.source}
-          isEditable={item.isEditable}
           onChangeEditing={(isEditing) => {
             onEditItem?.(isEditing ? item.id : undefined);
           }}
@@ -206,7 +204,6 @@ const matchOrSuggestToCreate = (
       label: search.trim(),
       state: "unselected",
       source: "token",
-      isEditable: true,
       isAdded: false,
     });
   }
@@ -299,7 +296,6 @@ export const StyleSourceInput = (
       state: "unselected",
       id: "",
       source: "local",
-      isEditable: true,
     },
     selectedItem: undefined,
     match: matchOrSuggestToCreate,

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
@@ -358,7 +358,6 @@ type StyleSourceProps = {
   id: string;
   label: string;
   menuItems: ReactNode;
-  isEditable: boolean;
   isEditing: boolean;
   isDragging: boolean;
   state: ItemState;
@@ -373,7 +372,6 @@ export const StyleSource = ({
   label,
   state,
   menuItems,
-  isEditable,
   isEditing,
   isDragging,
   source,
@@ -387,7 +385,7 @@ export const StyleSource = ({
   return (
     <SourceButton state={state} source={source} id={id} ref={ref}>
       <EditableText
-        isEditable={isEditable}
+        isEditable={source !== "local"}
         isEditing={isEditing}
         onChangeEditing={onChangeEditing}
         onClick={() => {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/807

isEditable is inferrable from the local "source" of style source. And no need to be passed into every item.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
