### PR TITLE
Drop item state from style sources

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.tsx
@@ -8,11 +8,7 @@ import {
   type StyleSourceSelections,
   getStyleDeclKey,
 } from "@webstudio-is/project-build";
-import {
-  type ItemSource,
-  type ItemState,
-  StyleSourceInput,
-} from "./style-source";
+import { type ItemSource, StyleSourceInput } from "./style-source";
 import { useStore } from "@nanostores/react";
 import {
   availableStyleSourcesStore,
@@ -247,28 +243,23 @@ const renameStyleSource = (id: StyleSource["id"], label: string) => {
 type StyleSourceInputItem = {
   id: string;
   label: string;
-  state: ItemState;
+  disabled: boolean;
   source: ItemSource;
 };
 
-const convertToInputItem = (
-  styleSource: StyleSource,
-  selectedStyleSource?: StyleSource["id"]
-): StyleSourceInputItem => {
-  const state: ItemState =
-    selectedStyleSource === styleSource.id ? "selected" : "unselected";
+const convertToInputItem = (styleSource: StyleSource): StyleSourceInputItem => {
   if (styleSource.type === "local") {
     return {
       id: styleSource.id,
       label: "Local",
-      state,
+      disabled: false,
       source: styleSource.type,
     };
   }
   return {
     id: styleSource.id,
     label: styleSource.name,
-    state,
+    disabled: false,
     source: styleSource.type,
   };
 };
@@ -283,7 +274,7 @@ export const StyleSourcesSection = () => {
     convertToInputItem(styleSource)
   );
   const value = selectedInstanceStyleSources.map((styleSource) =>
-    convertToInputItem(styleSource, selectedStyleSource?.id)
+    convertToInputItem(styleSource)
   );
 
   const [editingItemId, setEditingItemId] = useState<
@@ -299,6 +290,7 @@ export const StyleSourcesSection = () => {
       <StyleSourceInput
         items={items}
         value={value}
+        selectedItemId={selectedStyleSource?.id}
         onCreateItem={createStyleSource}
         onSelectAutocompleteItem={({ id }) => {
           addStyleSourceToInstace(id);

--- a/apps/builder/app/builder/features/style-panel/style-source/index.ts
+++ b/apps/builder/app/builder/features/style-panel/style-source/index.ts
@@ -1,3 +1,3 @@
 export * from "./style-source-input";
 export * from "./style-source-badge";
-export { type ItemState, type ItemSource } from "./style-source";
+export type { ItemSource } from "./style-source";

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-badge.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-badge.stories.tsx
@@ -15,9 +15,6 @@ export const All: ComponentStory<typeof StyleSourceBadge> = () => {
       <StyleSourceBadge source="token" variant="small">
         Token
       </StyleSourceBadge>
-      <StyleSourceBadge source="state" variant="small">
-        State
-      </StyleSourceBadge>
     </Flex>
   );
 };

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-badge.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-badge.tsx
@@ -16,9 +16,6 @@ export const StyleSourceBadge = styled(DeprecatedText2, {
       tag: {
         backgroundColor: theme.colors.backgroundStyleSourceTag,
       },
-      state: {
-        backgroundColor: theme.colors.backgroundStyleSourceState,
-      },
     },
   },
 });

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.stories.tsx
@@ -1,7 +1,7 @@
 import { nanoid } from "nanoid";
 import type { ComponentStory } from "@storybook/react";
 import { useState } from "react";
-import { StyleSourceInput, type ItemState, type ItemSource } from ".";
+import { StyleSourceInput, type ItemSource } from ".";
 
 export default {
   component: StyleSourceInput,
@@ -11,14 +11,14 @@ type Item = {
   id: string;
   label: string;
   source: ItemSource;
-  state: ItemState;
+  disabled: boolean;
 };
 
 const localItem: Item = {
   id: nanoid(),
   label: "Local",
   source: "local",
-  state: "selected",
+  disabled: false,
 };
 
 const getItems = (): Array<Item> => [
@@ -26,19 +26,13 @@ const getItems = (): Array<Item> => [
     id: nanoid(),
     label: "Token",
     source: "token",
-    state: "unselected",
+    disabled: false,
   },
   {
     id: nanoid(),
     label: "Tag",
     source: "tag",
-    state: "unselected",
-  },
-  {
-    id: nanoid(),
-    label: "State",
-    source: "state",
-    state: "unselected",
+    disabled: false,
   },
 ];
 
@@ -51,18 +45,9 @@ const createItem = (
     id: nanoid(),
     label,
     source: "token",
-    state: "selected",
+    disabled: false,
   };
-  const nextValue = value.map((item) => {
-    if (item.state === "selected") {
-      return {
-        ...item,
-        state: "unselected" as const,
-      };
-    }
-    return item;
-  });
-  setValue([...nextValue, item]);
+  setValue([...value, item]);
 };
 
 const removeItem = (
@@ -80,6 +65,7 @@ export const Basic: ComponentStory<typeof StyleSourceInput> = () => {
       css={{ width: 300 }}
       items={getItems()}
       value={value}
+      selectedItemId={localItem.id}
       onCreateItem={(label) => {
         createItem(label, value, setValue);
       }}
@@ -103,7 +89,7 @@ export const WithTruncatedItem: ComponentStory<
       label:
         "Local Something Something Something Something Something Something Something Something Something Something Something",
       source: "local",
-      state: "selected",
+      disabled: false,
     },
   ]);
   return (
@@ -111,6 +97,7 @@ export const WithTruncatedItem: ComponentStory<
       css={{ width: 300 }}
       items={getItems()}
       value={value}
+      selectedItemId={value[0].id}
       onCreateItem={(label) => {
         createItem(label, value, setValue);
       }}
@@ -133,10 +120,12 @@ export const Complete: ComponentStory<typeof StyleSourceInput> = () => {
       id: nanoid(),
       label: "Disabled",
       source: "token",
-
-      state: "disabled",
+      disabled: true,
     },
   ]);
+  const [selectedItemId, setSelectedItemId] = useState<undefined | Item["id"]>(
+    localItem.id
+  );
   const [editingItemId, setEditingItemId] = useState<undefined | Item["id"]>();
 
   return (
@@ -144,19 +133,10 @@ export const Complete: ComponentStory<typeof StyleSourceInput> = () => {
       css={{ width: 300 }}
       items={getItems()}
       value={value}
+      selectedItemId={selectedItemId}
       editingItemId={editingItemId}
       onSelectItem={(itemToSelect) => {
-        setValue(
-          value.map((item) => {
-            if (item.id === itemToSelect?.id) {
-              return { ...item, state: "selected" };
-            }
-            if (item.state === "selected") {
-              return { ...item, state: "unselected" };
-            }
-            return item;
-          })
-        );
+        setSelectedItemId(itemToSelect?.id);
       }}
       onEditItem={setEditingItemId}
       onCreateItem={(label) => {
@@ -182,7 +162,7 @@ export const Complete: ComponentStory<typeof StyleSourceInput> = () => {
         setValue(
           value.map((item) => {
             if (item.id === itemIdToDisable) {
-              return { ...item, state: "disabled" };
+              return { ...item, disabled: true };
             }
             return item;
           })
@@ -192,7 +172,7 @@ export const Complete: ComponentStory<typeof StyleSourceInput> = () => {
         setValue(
           value.map((item) => {
             if (item.id === itemIdToEnable) {
-              return { ...item, state: "unselected" };
+              return { ...item, disabled: false };
             }
             return item;
           })

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
@@ -78,11 +78,6 @@ const MenuTrigger = styled("button", {
           background: theme.colors.backgroundButtonHover,
         },
       },
-      state: {
-        "&:hover": {
-          background: theme.colors.backgroundButtonHover,
-        },
-      },
     },
   },
 });
@@ -110,9 +105,6 @@ const MenuTriggerGradient = styled(Box, {
       },
       tag: {
         background: theme.colors.backgroundStyleSourceGradientTag,
-      },
-      state: {
-        background: theme.colors.backgroundStyleSourceGradientState,
       },
     },
   },
@@ -143,9 +135,7 @@ const Menu = (props: MenuProps) => {
   );
 };
 
-export type ItemState = "unselected" | "selected" | "disabled";
-
-export type ItemSource = "token" | "tag" | "state" | "local";
+export type ItemSource = "token" | "tag" | "local";
 
 const useEditableText = ({
   isEditable,
@@ -306,44 +296,47 @@ const StyledSourceButton = styled(Box, {
       tag: {
         backgroundColor: theme.colors.backgroundStyleSourceTag,
       },
-      state: {
-        backgroundColor: theme.colors.backgroundStyleSourceState,
-      },
     },
-    state: {
-      selected: {},
-      unselected: {
+    selected: {
+      true: {},
+      false: {
         "&:not(:hover)": {
           backgroundColor: theme.colors.backgroundStyleSourceNeutral,
         },
       },
-      disabled: {
+    },
+    disabled: {
+      true: {
         "&:not(:hover)": {
           backgroundColor: theme.colors.backgroundStyleSourceDisabled,
         },
       },
+      false: {},
     },
   },
   defaultVariants: {
-    state: "unselected",
+    selected: false,
+    disabled: false,
   },
 });
 
 type SourceButtonProps = {
   id: string;
-  state: ItemState;
+  selected: boolean;
+  disabled: boolean;
   source: ItemSource;
   children: Array<JSX.Element | boolean>;
 };
 
 const SourceButton = forwardRef<HTMLDivElement, SourceButtonProps>(
-  ({ id, state, source, children }, ref) => {
+  ({ id, selected, disabled, source, children }, ref) => {
     return (
       <StyledSourceButton
-        state={state}
+        selected={selected}
+        disabled={disabled}
         source={source}
         data-id={id}
-        aria-current={state === "selected"}
+        aria-current={selected}
         role="button"
         ref={ref}
       >
@@ -358,9 +351,10 @@ type StyleSourceProps = {
   id: string;
   label: string;
   menuItems: ReactNode;
+  selected: boolean;
+  disabled: boolean;
   isEditing: boolean;
   isDragging: boolean;
-  state: ItemState;
   source: ItemSource;
   onSelect: () => void;
   onChangeValue: (value: string) => void;
@@ -370,8 +364,9 @@ type StyleSourceProps = {
 export const StyleSource = ({
   id,
   label,
-  state,
   menuItems,
+  selected,
+  disabled,
   isEditing,
   isDragging,
   source,
@@ -383,13 +378,19 @@ export const StyleSource = ({
   const showMenu = isEditing === false && isDragging === false;
 
   return (
-    <SourceButton state={state} source={source} id={id} ref={ref}>
+    <SourceButton
+      selected={selected}
+      disabled={disabled}
+      source={source}
+      id={id}
+      ref={ref}
+    >
       <EditableText
         isEditable={source !== "local"}
         isEditing={isEditing}
         onChangeEditing={onChangeEditing}
         onClick={() => {
-          if (state !== "disabled" && isEditing === false) {
+          if (disabled === false && isEditing === false) {
             onSelect();
           }
         }}


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/807

We gonna have more complicated selected state with style source "states" so better split it into separate prop and simplify disabled state with boolean.

Also dropped "state" style source.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
