### PR TITLE
Replace mitt with nanoevents

### DIFF
--- a/apps/builder/app/canvas/shared/scroll-state.ts
+++ b/apps/builder/app/canvas/shared/scroll-state.ts
@@ -1,7 +1,11 @@
-import mitt from "mitt";
+import { createNanoEvents } from "nanoevents";
 
 // Using a JS emitter to avoid overhead with subscribing scroll event directly on the DOM by many listeners
-const emitter = mitt();
+const emitter = createNanoEvents<{
+  scrollStart: () => void;
+  scroll: () => void;
+  scrollEnd: () => void;
+}>();
 
 if (typeof window === "object") {
   const eventOptions = {
@@ -51,13 +55,13 @@ export const subscribeScrollState = ({
   onScrollStart = noop,
   onScrollEnd = noop,
 }: UseScrollState) => {
-  emitter.on("scrollStart", onScrollStart);
-  emitter.on("scroll", onScroll);
-  emitter.on("scrollEnd", onScrollEnd);
+  const unsubscribeScrollStart = emitter.on("scrollStart", onScrollStart);
+  const unsubscribeScroll = emitter.on("scroll", onScroll);
+  const unsubscribeScrollEnd = emitter.on("scrollEnd", onScrollEnd);
 
   return () => {
-    emitter.off("scrollStart", onScrollStart);
-    emitter.off("scroll", onScroll);
-    emitter.off("scrollEnd", onScrollEnd);
+    unsubscribeScrollStart();
+    unsubscribeScroll();
+    unsubscribeScrollEnd();
   };
 };

--- a/apps/builder/app/shared/pubsub/index.ts
+++ b/apps/builder/app/shared/pubsub/index.ts
@@ -4,13 +4,7 @@ import { createPubsub } from "@webstudio-is/react-sdk";
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface PubsubMap {}
 
-export const {
-  publish,
-  usePublish,
-  useSubscribe,
-  useSubscribeAll,
-  subscribe,
-  subscribeAll,
-} = createPubsub<PubsubMap>();
+export const { publish, usePublish, useSubscribe, subscribe } =
+  createPubsub<PubsubMap>();
 export type Publish = typeof publish;
 export type UsePublish = typeof usePublish;

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -70,7 +70,7 @@
     "mdast-util-from-markdown": "^1.3.0",
     "micromark": "^3.1.0",
     "micromark-extension-gfm": "^2.0.1",
-    "mitt": "^3.0.0",
+    "nanoevents": "^7.0.1",
     "nanoid": "^3.2.0",
     "nanostores": "^0.7.1",
     "no-case": "^3.0.4",

--- a/apps/builder/remix.config.js
+++ b/apps/builder/remix.config.js
@@ -16,6 +16,7 @@ module.exports = {
     /@webstudio-is\/(?!prisma-client)/,
     "pretty-bytes",
     "djb2a",
+    "nanoevents",
     "nanostores",
     "@nanostores/react",
     /micromark/,

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -59,7 +59,7 @@
     "@webstudio-is/project-build": "workspace:^",
     "detect-font": "^0.1.5",
     "html-tags": "^3.2.0",
-    "mitt": "^3.0.0",
+    "nanoevents": "^7.0.1",
     "nanostores": "^0.7.1"
   },
   "exports": {

--- a/packages/react-sdk/src/pubsub/create.ts
+++ b/packages/react-sdk/src/pubsub/create.ts
@@ -1,4 +1,4 @@
-import mitt from "mitt";
+import { createNanoEvents } from "nanoevents";
 import { useCallback, useEffect, useRef } from "react";
 
 export const createPubsub = <PublishMap>() => {
@@ -7,9 +7,8 @@ export const createPubsub = <PublishMap>() => {
       ? { type: Type; payload?: PublishMap[Type] }
       : { type: Type; payload: PublishMap[Type] };
 
-  // `mitt` has a somewhat annoying overload for `*` type that makes it hard to wrap in a generic context
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const emitter = mitt<Record<any, any>>();
+  const emitter = createNanoEvents<Record<any, any>>();
 
   if (typeof window === "object") {
     window.addEventListener(
@@ -62,47 +61,15 @@ export const createPubsub = <PublishMap>() => {
       onAction: (payload: PublishMap[Type]) => void
     ) {
       useEffect(() => {
-        emitter.on(type, onAction);
-        return () => {
-          emitter.off(type, onAction);
-        };
+        return emitter.on(type, onAction);
       }, [type, onAction]);
-    },
-
-    useSubscribeAll(
-      onAction: <Type extends keyof PublishMap>(
-        type: Type,
-        payload: PublishMap[Type]
-      ) => void
-    ) {
-      useEffect(() => {
-        emitter.on("*", onAction);
-        return () => {
-          emitter.off("*", onAction);
-        };
-      }, [onAction]);
     },
 
     subscribe<Type extends keyof PublishMap>(
       type: Type,
       onAction: (payload: PublishMap[Type]) => void
     ) {
-      emitter.on(type, onAction);
-      return () => {
-        emitter.off(type, onAction);
-      };
-    },
-
-    subscribeAll(
-      onAction: <Type extends keyof PublishMap>(
-        type: Type,
-        payload: PublishMap[Type]
-      ) => void
-    ) {
-      emitter.on("*", onAction);
-      return () => {
-        emitter.off("*", onAction);
-      };
+      return emitter.on(type, onAction);
     },
   };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,9 +207,9 @@ importers:
       micromark-extension-gfm:
         specifier: ^2.0.1
         version: 2.0.1
-      mitt:
-        specifier: ^3.0.0
-        version: 3.0.0
+      nanoevents:
+        specifier: ^7.0.1
+        version: 7.0.1
       nanoid:
         specifier: ^3.2.0
         version: 3.3.4
@@ -1178,9 +1178,9 @@ importers:
       html-tags:
         specifier: ^3.2.0
         version: 3.2.0
-      mitt:
-        specifier: ^3.0.0
-        version: 3.0.0
+      nanoevents:
+        specifier: ^7.0.1
+        version: 7.0.1
       nanostores:
         specifier: ^0.7.1
         version: 0.7.1
@@ -15524,10 +15524,6 @@ packages:
       stream-each: 1.2.3
       through2: 2.0.5
 
-  /mitt@3.0.0:
-    resolution: {integrity: sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==}
-    dev: false
-
   /mixin-deep@1.3.2:
     resolution: {integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==}
     engines: {node: '>=0.10.0'}
@@ -15625,6 +15621,11 @@ packages:
     dependencies:
       picocolors: 1.0.0
     dev: true
+
+  /nanoevents@7.0.1:
+    resolution: {integrity: sha512-o6lpKiCxLeijK4hgsqfR6CNToPyRU3keKyyI6uwuHRvpRTbZ0wXw51WRgyldVugZqoJfkGFrjrIenYH3bfEO3Q==}
+    engines: {node: ^14.0.0 || ^16.0.0 || >=18.0.0}
+    dev: false
 
   /nanoid@3.3.4:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,7 @@
       "outputs": ["lib/**", "dist/**", "build/**", "api/**", "public/build/**"]
     },
     "checks": {
-      "dependsOn": ["^checks"]
+      "dependsOn": ["build", "^checks"]
     },
     "storybook:build": {
       "dependsOn": ["build"],


### PR DESCRIPTION
nanoevents doesn't have `*` we stopped using recently, have simpler api with unsubscribe function and allows to avoid patch upcoming changes https://github.com/webstudio-is/webstudio-builder/pull/1351.

## Code Review

- [ ] hi @andarit, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
