### PR TITLE
Fix enter

### DIFF
--- a/apps/builder/app/canvas/shared/use-shortcuts.ts
+++ b/apps/builder/app/canvas/shared/use-shortcuts.ts
@@ -2,6 +2,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { shortcuts, options } from "~/shared/shortcuts";
 import { publish, useSubscribe } from "~/shared/pubsub";
 import { isPreviewModeStore } from "~/shared/nano-states";
+import { enterEditingMode } from "~/shared/nano-states/instances";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
@@ -27,7 +28,8 @@ export const useShortcuts = () => {
     preview: togglePreviewMode,
     breakpointsMenu: publishOpenBreakpointsMenu,
     esc: publishCancelCurrentDrag,
-  } as const;
+    enter: enterEditingMode,
+  } as const satisfies Record<keyof typeof shortcuts, unknown>;
 
   useHotkeys(shortcuts.preview, shortcutHandlerMap.preview, options, []);
 
@@ -39,6 +41,8 @@ export const useShortcuts = () => {
   );
 
   useHotkeys(shortcuts.esc, shortcutHandlerMap.esc, options, []);
+
+  useHotkeys(shortcuts.enter, shortcutHandlerMap.enter, {}, []);
 
   // Shortcuts from the parent window
   useSubscribe("shortcut", ({ name }) => {

--- a/apps/builder/app/shared/dom-utils.ts
+++ b/apps/builder/app/shared/dom-utils.ts
@@ -34,7 +34,7 @@ export const getElementByInstanceSelector = (
     .map((id) => `[${idAttribute}="${id}"]`)
     .reverse()
     .join(" ");
-  return document.querySelector(domSelector) ?? undefined;
+  return document.querySelector<HTMLElement>(domSelector) ?? undefined;
 };
 
 type Rect = {

--- a/apps/builder/app/shared/nano-states/instances.ts
+++ b/apps/builder/app/shared/nano-states/instances.ts
@@ -33,7 +33,8 @@ export const enterEditingMode = (event?: KeyboardEvent) => {
     return;
   }
 
-  // Enter click can be intercepted from builder and element can be unfocused
+  // When an event is triggered from the Builder,
+  // the canvas element may be unfocused, so it's important to focus the element on the canvas.
   element.focus();
 
   // Prevents inserting a newline when entering text-editing mode

--- a/apps/builder/app/shared/nano-states/instances.ts
+++ b/apps/builder/app/shared/nano-states/instances.ts
@@ -1,16 +1,18 @@
 import { atom } from "nanostores";
 import { getComponentMeta } from "@webstudio-is/react-sdk";
+
 import type { InstanceSelector } from "../tree-utils";
 import {
   selectedInstanceSelectorStore,
   selectedInstanceStore,
 } from "./nano-states";
+import { getElementByInstanceSelector } from "../dom-utils";
 
 export const textEditingInstanceSelectorStore = atom<
   undefined | InstanceSelector
 >();
 
-export const enterEditingMode = (event: KeyboardEvent) => {
+export const enterEditingMode = (event?: KeyboardEvent) => {
   const selectedInstanceSelector = selectedInstanceSelectorStore.get();
   const selectedInstance = selectedInstanceStore.get();
   if (
@@ -19,12 +21,24 @@ export const enterEditingMode = (event: KeyboardEvent) => {
   ) {
     return;
   }
+
   const meta = getComponentMeta(selectedInstance.component);
-  if (meta?.type === "rich-text") {
-    // Prevents inserting a newline when entering text-editing mode
-    event.preventDefault();
-    textEditingInstanceSelectorStore.set(selectedInstanceSelector);
+  if (meta?.type !== "rich-text") {
+    return;
   }
+
+  const element = getElementByInstanceSelector(selectedInstanceSelector);
+
+  if (element === undefined) {
+    return;
+  }
+
+  // Enter click can be intercepted from builder and element can be unfocused
+  element.focus();
+
+  // Prevents inserting a newline when entering text-editing mode
+  event?.preventDefault();
+  textEditingInstanceSelectorStore.set(selectedInstanceSelector);
 };
 
 export const escapeSelection = () => {

--- a/apps/builder/app/shared/shortcuts/shortcuts.ts
+++ b/apps/builder/app/shared/shortcuts/shortcuts.ts
@@ -5,13 +5,14 @@ import {
   zoomOut,
   selectBreakpointByOrderNumber,
 } from "../nano-states/breakpoints";
-import { enterEditingMode, escapeSelection } from "../nano-states/instances";
+import { escapeSelection } from "../nano-states/instances";
 import { deleteSelectedInstance } from "../instance-utils";
 
 export const shortcuts = {
   esc: "esc",
   preview: "meta+shift+p, ctrl+shift+p",
   breakpointsMenu: "meta+b, ctrl+b",
+  enter: "enter",
 } as const;
 
 export const options: Options = {
@@ -91,7 +92,17 @@ export const useSharedShortcuts = () => {
     []
   );
 
-  useHotkeys("enter", enterEditingMode, {}, []);
+  /*
+  useHotkeys(
+    "enter",
+    (event) => {
+      console.log("enter", event);
+      enterEditingMode(event);
+    },
+    {},
+    []
+  );
+  */
 
   useHotkeys("esc", escapeSelection, { enableOnContentEditable: true }, []);
 };


### PR DESCRIPTION
## Description

Currently when you click Enter inside the builder when focused on Rich Text nothing happens.
Here I forward enter event into the Canvas and focus RT element before Editing mode

ref #1359

## Steps for reproduction

Click RT node in Navigator, press Enter, edit text
<img width="820" alt="image" src="https://user-images.githubusercontent.com/5077042/229862820-62bc3f50-1290-49e3-856e-1fab2fb50eae.png">



## Code Review

- [x] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
