### PR TITLE
Drop chromatic from dependencies

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -80,8 +80,6 @@ jobs:
 
       - uses: ./.github/actions/ci-setup
 
-      - run: DATABASE_URL="-" AUTH_SECRET="-" pnpm build
-
       - name: Chromatic
         id: chromatic
         uses: chromaui/action@v1

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -78,8 +78,6 @@ jobs:
         with:
           fetch-depth: 2 # we need to fetch at least parent commit to satisfy Chromatic
 
-      - uses: ./.github/actions/ci-setup
-
       - name: Chromatic
         id: chromatic
         uses: chromaui/action@v1

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -52,9 +52,6 @@ jobs:
 
       - uses: ./.github/actions/ci-setup
 
-      # only packages have to be built as they might be imported by Storybooks
-      - run: pnpm build-packages
-
       - name: Chromatic
         id: chromatic
         uses: chromaui/action@v1

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -78,6 +78,8 @@ jobs:
         with:
           fetch-depth: 2 # we need to fetch at least parent commit to satisfy Chromatic
 
+      - uses: ./.github/actions/ci-setup
+
       - name: Chromatic
         id: chromatic
         uses: chromaui/action@v1

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@storybook/react": "^6.5.16",
     "@types/css-tree": "^2.0.0",
     "@webstudio-is/eslint-config-custom": "workspace:^",
-    "chromatic": "^6.11.4",
     "nano-staged": "^0.8.0",
     "prettier": "2.8.7",
     "simple-git-hooks": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "private": true,
   "scripts": {
     "build": "turbo run build",
-    "build-packages": "turbo run build --filter=\"!@webstudio-is/builder\"",
     "size-test": "turbo run size-test",
     "checks": "turbo run checks",
     "dev": "pnpm run --parallel --recursive dev",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "build": "turbo run build",
+    "build-packages": "turbo run build --filter=\"!@webstudio-is/builder\"",
     "size-test": "turbo run size-test",
     "checks": "turbo run checks",
     "dev": "pnpm run --parallel --recursive dev",

--- a/packages/storybook-config/index.js
+++ b/packages/storybook-config/index.js
@@ -8,4 +8,12 @@ module.exports = {
   core: {
     builder: "@storybook/builder-vite",
   },
+  async viteFinal(config) {
+    return {
+      ...config,
+      resolve: {
+        conditions: ["source", "import", "module", "browser", "default"],
+      },
+    };
+  },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,6 @@ importers:
       '@webstudio-is/eslint-config-custom':
         specifier: workspace:^
         version: link:packages/eslint-config-custom
-      chromatic:
-        specifier: ^6.11.4
-        version: 6.11.4
       nano-staged:
         specifier: ^0.8.0
         version: 0.8.0
@@ -10051,14 +10048,6 @@ packages:
   /chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
-    dev: true
-
-  /chromatic@6.11.4:
-    resolution: {integrity: sha512-f1TcuIXKjGUuOjPuwFF44kzbuEcESFcDxHzrzWPLmHuC90dV8HLxbufqYaTOBYMO/rJ32Zftb7S9pXuF/Rhfog==}
-    hasBin: true
-    dependencies:
-      '@discoveryjs/json-ext': 0.5.7
-      '@types/webpack-env': 1.18.0
     dev: true
 
   /chrome-trace-event@1.0.3:


### PR DESCRIPTION
We probably don't need to have chromatic in dependencies.
Especially since the latest version is getting 20MB bigger

https://packagephobia.com/result?p=chromatic

Also removed builds from chromatic workflows, "source" export condition allows to avoid it.

## Code Review

- [ ] hi @Andarist, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
