### PR TITLE
Simplify assets uploading

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -45,7 +45,6 @@ import {
 import { type Settings, useClientSettings } from "./shared/client-settings";
 import { getBuildUrl } from "~/shared/router-utils";
 import { useCopyPaste } from "~/shared/copy-paste";
-import { AssetsProvider } from "./shared/assets";
 import type { Asset } from "@webstudio-is/asset-uploader";
 import { useSearchParams } from "@remix-run/react";
 import { useSyncInitializeOnce } from "~/shared/hook-utils";
@@ -316,40 +315,38 @@ export const Builder = ({
   });
 
   return (
-    <AssetsProvider projectId={project.id} authToken={authToken}>
-      <ChromeWrapper isPreviewMode={isPreviewMode}>
-        <Topbar gridArea="header" project={project} publish={publish} />
-        <Main>
-          <Workspace onTransitionEnd={onTransitionEnd} publish={publish}>
-            <CanvasIframe
-              ref={iframeRefCallback}
-              src={canvasUrl}
-              pointerEvents={isCanvasPointerEventsEnabled ? "auto" : "none"}
-              title={project.title}
-              css={{
-                height: "100%",
-                width: "100%",
-              }}
-            />
-          </Workspace>
-        </Main>
-        <SidePanel gridArea="sidebar" isPreviewMode={isPreviewMode}>
-          <SidebarLeft publish={publish} />
-        </SidePanel>
-        <NavigatorPanel
-          isPreviewMode={isPreviewMode}
-          navigatorLayout={navigatorLayout}
-        />
-        <SidePanel
-          gridArea="inspector"
-          isPreviewMode={isPreviewMode}
-          css={{ overflow: "hidden" }}
-        >
-          <Inspector publish={publish} navigatorLayout={navigatorLayout} />
-        </SidePanel>
-        {isPreviewMode === false && <Footer />}
-        <BlockingAlerts />
-      </ChromeWrapper>
-    </AssetsProvider>
+    <ChromeWrapper isPreviewMode={isPreviewMode}>
+      <Topbar gridArea="header" project={project} publish={publish} />
+      <Main>
+        <Workspace onTransitionEnd={onTransitionEnd} publish={publish}>
+          <CanvasIframe
+            ref={iframeRefCallback}
+            src={canvasUrl}
+            pointerEvents={isCanvasPointerEventsEnabled ? "auto" : "none"}
+            title={project.title}
+            css={{
+              height: "100%",
+              width: "100%",
+            }}
+          />
+        </Workspace>
+      </Main>
+      <SidePanel gridArea="sidebar" isPreviewMode={isPreviewMode}>
+        <SidebarLeft publish={publish} />
+      </SidePanel>
+      <NavigatorPanel
+        isPreviewMode={isPreviewMode}
+        navigatorLayout={navigatorLayout}
+      />
+      <SidePanel
+        gridArea="inspector"
+        isPreviewMode={isPreviewMode}
+        css={{ overflow: "hidden" }}
+      >
+        <Inspector publish={publish} navigatorLayout={navigatorLayout} />
+      </SidePanel>
+      {isPreviewMode === false && <Footer />}
+      <BlockingAlerts />
+    </ChromeWrapper>
   );
 };

--- a/packages/asset-uploader/src/patch.ts
+++ b/packages/asset-uploader/src/patch.ts
@@ -35,5 +35,7 @@ export const patchAssets = async (
       deletedAssetIds.push(assetId);
     }
   }
-  deleteAssets({ projectId, ids: deletedAssetIds }, context);
+  if (deletedAssetIds.length !== 0) {
+    deleteAssets({ projectId, ids: deletedAssetIds }, context);
+  }
 };


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1335

- with persistent fetcher there is no need in assets provider
- replaced async FileReader api with sync URL.createObjectURL for preview while uploading

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
