### PR TITLE
Upload files without creating assets

### DIFF
--- a/apps/builder/app/builder/shared/assets/use-assets.tsx
+++ b/apps/builder/app/builder/shared/assets/use-assets.tsx
@@ -8,7 +8,10 @@ import {
   idsFormDataFieldName,
 } from "@webstudio-is/asset-uploader";
 import { toast } from "@webstudio-is/design-system";
-import { sanitizeS3Key } from "@webstudio-is/asset-uploader";
+import {
+  sanitizeS3Key,
+  MAX_ASSETS_PER_PROJECT,
+} from "@webstudio-is/asset-uploader";
 import { restAssetsPath } from "~/shared/router-utils";
 import type { AssetContainer } from "./types";
 import { usePersistentFetcher } from "~/shared/fetcher";
@@ -151,6 +154,20 @@ export const useUploadAsset = () => {
     if (projectId === undefined) {
       return;
     }
+
+    const assetsCount = assetsStore.get().size;
+    const newFilesCount = files.length;
+    const count = assetsCount + newFilesCount;
+    if (count > MAX_ASSETS_PER_PROJECT) {
+      toast.error(
+        `The maximum number of assets per project is ${MAX_ASSETS_PER_PROJECT}.`
+      );
+    }
+    const possibleNewFilesCount = Math.max(
+      0,
+      MAX_ASSETS_PER_PROJECT - assetsCount
+    );
+    files = files.slice(0, possibleNewFilesCount);
 
     try {
       const filesData = getFilesData(type, files);

--- a/apps/builder/app/routes/rest.assets.$projectId.tsx
+++ b/apps/builder/app/routes/rest.assets.$projectId.tsx
@@ -43,10 +43,7 @@ export const action = async (
         context
       );
       return {
-        uploadedAssets: assets.map((asset) => ({
-          ...asset,
-          status: "uploaded",
-        })),
+        uploadedAssets: assets,
       };
     }
   } catch (error) {

--- a/packages/asset-uploader/src/constants.ts
+++ b/packages/asset-uploader/src/constants.ts
@@ -1,3 +1,5 @@
 export const DEFAULT_UPLOAD_PATH = "public/s/uploads";
 // By default using Vercel's limit https://vercel.com/docs/concepts/limits/overview#serverless-function-payload-size-limit
 export const MAX_UPLOAD_SIZE = "4.5";
+
+export const MAX_ASSETS_PER_PROJECT = 50;

--- a/packages/asset-uploader/src/db/create.ts
+++ b/packages/asset-uploader/src/db/create.ts
@@ -1,18 +1,11 @@
 import type { FontMeta } from "@webstudio-is/fonts";
-import {
-  prisma,
-  type Location,
-  type Project,
-  type Asset,
-} from "@webstudio-is/prisma-client";
-import { Env, type ImageMeta } from "../schema";
+import type { Location, Project, Asset } from "@webstudio-is/prisma-client";
+import type { ImageMeta } from "../schema";
 import { formatAsset } from "../utils/format-asset";
 import {
   authorizeProject,
   type AppContext,
 } from "@webstudio-is/trpc-interface/server";
-
-const env = Env.parse(process.env);
 
 type BaseOptions = {
   id: string;
@@ -30,13 +23,11 @@ type Options =
     } & BaseOptions)
   | ({ type: "font"; meta: FontMeta } & BaseOptions);
 
-export const createAssetWithLimit = async (
+export const createAsset = async (
   projectId: Project["id"],
   uploadAsset: () => Promise<Options>,
   context: AppContext
 ) => {
-  let updated: { id: string } | undefined;
-
   const canEdit = await authorizeProject.hasProjectPermit(
     { projectId, permit: "edit" },
     context
@@ -46,91 +37,21 @@ export const createAssetWithLimit = async (
     throw new Error("You don't have access to create this project assets");
   }
 
-  try {
-    /**
-     * sometimes for example on request timeout we don't know what happened to the "UPLOADING" asset,
-     * so we don't take into account assets with the "UPLOADING" status that were created more
-     * than UPLOADING_STALE_TIMEOUT milliseconds ago
-     **/
-    const UPLOADING_STALE_TIMEOUT = 1000 * 60 * 30; // 30 minutes
+  const asset = await uploadAsset();
 
-    const count = await prisma.asset.count({
-      where: {
-        OR: [
-          { projectId, status: "UPLOADED" },
-          {
-            projectId,
-            status: "UPLOADING",
-            createdAt: { gt: new Date(Date.now() - UPLOADING_STALE_TIMEOUT) },
-          },
-        ],
-      },
-    });
+  const size = asset.size ?? 0;
+  const { id, meta, format, name, location } = asset;
 
-    if (count >= env.MAX_ASSETS_PER_PROJECT) {
-      /**
-       * Here is right to write `Max ${MAX_ASSETS_PER_PROJECT}` but see the comment below,
-       * it's probable that the user can exceed the limit a little bit.
-       * So it can be a little bit strange that the limit is 5 but the user already has 7.
-       **/
-      throw new Error(`The maximum number of assets per project is ${count}.`);
-    }
-
-    /**
-     * Create a temporary "UPLOADING" asset, so it can be counted in the next query
-     * Assumptions:
-     * - it's possible to create more assets than MAX_ASSETS_PER_PROJECT,
-     *   but for now we assume that the time since the `count` query above and the `create` query below is negligible,
-     *   and some kind of rate limiting exists on API.
-     * Also no locking exists in Prisma, and no raw query locking like
-     * "SELECT id FROM "Project" where id=? FOR UPDATE;" is shareable between sqlite and postgres.
-     **/
-
-    updated = await prisma.asset.create({
-      data: {
-        projectId,
-        status: "UPLOADING",
-        format: "unknown",
-        location: "REMOTE",
-        name: "unknown",
-        size: 0,
-      },
-      select: {
-        id: true,
-      },
-    });
-
-    const asset = await uploadAsset();
-
-    const size = asset.size ?? 0;
-    const { id, meta, format, name, location } = asset;
-
-    const dbAsset = await prisma.asset.update({
-      where: {
-        id_projectId: { id: updated.id, projectId },
-      },
-      data: {
-        id,
-        location,
-        name,
-        size,
-        format,
-        projectId,
-        meta: JSON.stringify(meta),
-        status: "UPLOADED",
-      },
-    });
-
-    return formatAsset(dbAsset);
-  } catch (error) {
-    if (updated) {
-      await prisma.asset.delete({
-        where: {
-          id_projectId: { id: updated.id, projectId },
-        },
-      });
-    }
-
-    throw error;
-  }
+  return formatAsset({
+    status: "UPLOADED",
+    id,
+    projectId,
+    format,
+    size,
+    name,
+    description: null,
+    location,
+    createdAt: new Date(),
+    meta: JSON.stringify(meta),
+  });
 };

--- a/packages/asset-uploader/src/patch.ts
+++ b/packages/asset-uploader/src/patch.ts
@@ -1,5 +1,5 @@
 import { type Patch, applyPatches } from "immer";
-import type { Project } from "@webstudio-is/prisma-client";
+import { prisma, type Project } from "@webstudio-is/prisma-client";
 import {
   type AppContext,
   authorizeProject,
@@ -8,6 +8,10 @@ import { type Asset, Assets } from "./schema";
 import { deleteAssets } from "./delete";
 import { loadByProject } from "./db/load";
 
+/**
+ * patchAssets can only delete or add assets
+ * update patches are ignored
+ */
 export const patchAssets = async (
   { projectId }: { projectId: Project["id"] },
   patches: Array<Patch>,
@@ -38,4 +42,28 @@ export const patchAssets = async (
   if (deletedAssetIds.length !== 0) {
     deleteAssets({ projectId, ids: deletedAssetIds }, context);
   }
+
+  // add new assets found in patched version
+  const addedAssets: Asset[] = [];
+  for (const [assetId, asset] of patchedAssets) {
+    // skip stubbed assets
+    if (asset === undefined) {
+      continue;
+    }
+    if (assets.has(assetId) === false) {
+      addedAssets.push(asset);
+    }
+  }
+  await prisma.asset.createMany({
+    data: addedAssets.map((asset) => ({
+      id: asset.id,
+      location: asset.location,
+      name: asset.name,
+      size: asset.size,
+      format: asset.format,
+      projectId: asset.projectId,
+      meta: JSON.stringify(asset.meta),
+      status: "UPLOADED",
+    })),
+  });
 };

--- a/packages/asset-uploader/src/targets/fs/upload.ts
+++ b/packages/asset-uploader/src/targets/fs/upload.ts
@@ -7,7 +7,7 @@ import {
 } from "@remix-run/node";
 import { Location } from "@webstudio-is/prisma-client";
 import { getAssetData } from "../../utils/get-asset-data";
-import { createAssetWithLimit } from "../../db";
+import { createAsset } from "../../db";
 import { FILE_DIRECTORY } from "./file-path";
 import { Asset, idsFormDataFieldName } from "../../schema";
 import { getUniqueFilename } from "../../utils/get-unique-filename";
@@ -35,10 +35,10 @@ export const uploadToFs = async (
   },
   context: AppContext
 ): Promise<Array<Asset>> => {
-  const asset = await createAssetWithLimit(
+  const asset = await createAsset(
     projectId,
     async () => {
-      const uploadHandler = await unstableCreateFileUploadHandler({
+      const uploadHandler = unstableCreateFileUploadHandler({
         maxPartSize: maxSize,
         directory: FILE_DIRECTORY,
         file: ({ filename }) => getUniqueFilename(sanitizeS3Key(filename)),

--- a/packages/asset-uploader/src/targets/s3/upload.ts
+++ b/packages/asset-uploader/src/targets/s3/upload.ts
@@ -11,7 +11,7 @@ import { Location } from "@webstudio-is/prisma-client";
 import { S3Env } from "../../schema";
 import { toUint8Array } from "../../utils/to-uint8-array";
 import { getAssetData, AssetData } from "../../utils/get-asset-data";
-import { createAssetWithLimit } from "../../db";
+import { createAsset } from "../../db";
 import { idsFormDataFieldName, type Asset } from "../../schema";
 import { getUniqueFilename } from "../../utils/get-unique-filename";
 import { getS3Client } from "./client";
@@ -42,7 +42,7 @@ export const uploadToS3 = async (
   },
   context: AppContext
 ): Promise<Array<Asset>> => {
-  const asset = await createAssetWithLimit(
+  const asset = await createAsset(
     projectId,
     async () => {
       const uploadHandler = createUploadHandler(MAX_FILES_PER_REQUEST);


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1335

Now we use assets endpoint only to upload asset and them add its data with store patch. This means assets are now fully handled with patches.

## Code Review

- [ ] hi @rpominov, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
