### PR TITLE
Store style states in db

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.tsx
@@ -13,7 +13,9 @@ import { useStore } from "@nanostores/react";
 import {
   availableStyleSourcesStore,
   selectedInstanceSelectorStore,
+  selectedInstanceStatesByStyleSourceIdStore,
   selectedInstanceStyleSourcesStore,
+  selectedOrLastStyleSourceSelectorStore,
   selectedStyleSourceSelectorStore,
   styleSourceSelectionsStore,
   styleSourcesStore,
@@ -244,22 +246,19 @@ type StyleSourceInputItem = {
   label: string;
   disabled: boolean;
   source: ItemSource;
+  states: string[];
 };
 
-const convertToInputItem = (styleSource: StyleSource): StyleSourceInputItem => {
-  if (styleSource.type === "local") {
-    return {
-      id: styleSource.id,
-      label: "Local",
-      disabled: false,
-      source: styleSource.type,
-    };
-  }
+const convertToInputItem = (
+  styleSource: StyleSource,
+  states: string[]
+): StyleSourceInputItem => {
   return {
     id: styleSource.id,
-    label: styleSource.name,
+    label: styleSource.type === "local" ? "Local" : styleSource.name,
     disabled: false,
     source: styleSource.type,
+    states,
   };
 };
 
@@ -269,13 +268,19 @@ export const StyleSourcesSection = () => {
     selectedInstanceStyleSourcesStore
   );
   const items = availableStyleSources.map((styleSource) =>
-    convertToInputItem(styleSource)
+    convertToInputItem(styleSource, [])
+  );
+  const selectedInstanceStatesByStyleSourceId = useStore(
+    selectedInstanceStatesByStyleSourceIdStore
   );
   const value = selectedInstanceStyleSources.map((styleSource) =>
-    convertToInputItem(styleSource)
+    convertToInputItem(
+      styleSource,
+      selectedInstanceStatesByStyleSourceId.get(styleSource.id) ?? []
+    )
   );
-  const selectedStyleSourceSelector = useStore(
-    selectedStyleSourceSelectorStore
+  const selectedOrLastStyleSourceSelector = useStore(
+    selectedOrLastStyleSourceSelectorStore
   );
 
   const [editingItemId, setEditingItemId] = useState<
@@ -291,7 +296,7 @@ export const StyleSourcesSection = () => {
       <StyleSourceInput
         items={items}
         value={value}
-        selectedItemSelector={selectedStyleSourceSelector}
+        selectedItemSelector={selectedOrLastStyleSourceSelector}
         onCreateItem={createStyleSource}
         onSelectAutocompleteItem={({ id }) => {
           addStyleSourceToInstace(id);

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.stories.tsx
@@ -12,6 +12,7 @@ type Item = {
   label: string;
   source: ItemSource;
   disabled: boolean;
+  states: string[];
 };
 
 const localItem: Item = {
@@ -19,6 +20,7 @@ const localItem: Item = {
   label: "Local",
   source: "local",
   disabled: false,
+  states: [],
 };
 
 const getItems = (): Array<Item> => [
@@ -27,12 +29,14 @@ const getItems = (): Array<Item> => [
     label: "Token",
     source: "token",
     disabled: false,
+    states: [],
   },
   {
     id: nanoid(),
     label: "Tag",
     source: "tag",
     disabled: false,
+    states: [],
   },
 ];
 
@@ -46,6 +50,7 @@ const createItem = (
     label,
     source: "token",
     disabled: false,
+    states: [],
   };
   setValue([...value, item]);
 };
@@ -90,6 +95,7 @@ export const WithTruncatedItem: ComponentStory<
         "Local Something Something Something Something Something Something Something Something Something Something Something",
       source: "local",
       disabled: false,
+      states: [],
     },
   ]);
   return (
@@ -121,6 +127,7 @@ export const Complete: ComponentStory<typeof StyleSourceInput> = () => {
       label: "Disabled",
       source: "token",
       disabled: true,
+      states: [],
     },
   ]);
   const [selectedItemSelector, setSelectedItemSelector] = useState<

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -225,7 +225,7 @@ export const useSetStyleSourceSelections = (
   });
 };
 
-type StyleSourceSelector = {
+export type StyleSourceSelector = {
   styleSourceId: StyleSource["id"];
   state?: string;
 };
@@ -317,6 +317,36 @@ export const selectedInstanceIntanceToTagStore = atom<
   undefined | Map<Instance["id"], HtmlTags>
 >();
 
+export const selectedInstanceStatesByStyleSourceIdStore = computed(
+  [stylesStore, styleSourceSelectionsStore, selectedInstanceSelectorStore],
+  (styles, styleSourceSelections, selectedInstanceSelector) => {
+    const statesByStyleSourceId = new Map<StyleSource["id"], string[]>();
+    if (selectedInstanceSelector === undefined) {
+      return statesByStyleSourceId;
+    }
+    const styleSourceIds = new Set(
+      styleSourceSelections.get(selectedInstanceSelector[0])?.values
+    );
+    for (const styleDecl of styles.values()) {
+      if (
+        styleDecl.state === undefined ||
+        styleSourceIds.has(styleDecl.styleSourceId) === false
+      ) {
+        continue;
+      }
+      let states = statesByStyleSourceId.get(styleDecl.styleSourceId);
+      if (states === undefined) {
+        states = [];
+        statesByStyleSourceId.set(styleDecl.styleSourceId, states);
+      }
+      if (states.includes(styleDecl.state) === false) {
+        states.push(styleDecl.state);
+      }
+    }
+    return statesByStyleSourceId;
+  }
+);
+
 export const selectedInstanceStyleSourcesStore = computed(
   [
     styleSourceSelectionsStore,
@@ -350,6 +380,20 @@ export const selectedInstanceStyleSourcesStore = computed(
       });
     }
     return selectedInstanceStyleSources;
+  }
+);
+
+export const selectedOrLastStyleSourceSelectorStore = computed(
+  [selectedInstanceStyleSourcesStore, selectedStyleSourceSelectorStore],
+  (styleSources, selectedStyleSourceSelector) => {
+    if (selectedStyleSourceSelector !== undefined) {
+      return selectedStyleSourceSelector;
+    }
+    const lastStyleSource = styleSources.at(-1);
+    if (lastStyleSource !== undefined) {
+      return { styleSourceId: lastStyleSource.id };
+    }
+    return undefined;
   }
 );
 

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -393,7 +393,7 @@ export const selectedOrLastStyleSourceSelectorStore = computed(
     if (lastStyleSource !== undefined) {
       return { styleSourceId: lastStyleSource.id };
     }
-    return undefined;
+    return;
   }
 );
 

--- a/apps/builder/app/shared/tree-utils.test.ts
+++ b/apps/builder/app/shared/tree-utils.test.ts
@@ -10,6 +10,7 @@ import type {
   StyleSource,
   StyleSourceSelection,
 } from "@webstudio-is/project-build";
+import { getStyleDeclKey } from "@webstudio-is/project-build";
 import {
   type InstanceSelector,
   cloneStyles,
@@ -117,10 +118,16 @@ const createStyleDecl = (
 const createStyleDeclPair = (
   styleSourceId: string,
   breakpointId: string,
+  state?: string,
   value?: string
 ) => {
   return [
-    `${styleSourceId}:${breakpointId}:width`,
+    getStyleDeclKey({
+      styleSourceId,
+      breakpointId,
+      state,
+      property: "width",
+    }),
     createStyleDecl(styleSourceId, breakpointId, value),
   ] as const;
 };
@@ -780,12 +787,12 @@ test("insert styles copy and apply new style source ids", () => {
 
 test("clone styles with appled new style source ids", () => {
   const styles: Styles = new Map([
-    [`styleSource1:bp1:width`, createStyleDecl("styleSource1", "bp1")],
-    [`styleSource2:bp2:width`, createStyleDecl("styleSource2", "bp2")],
-    [`styleSource1:bp3:width`, createStyleDecl("styleSource1", "bp3")],
-    [`styleSource3:bp4:width`, createStyleDecl("styleSource3", "bp4")],
-    [`styleSource1:bp5:width`, createStyleDecl("styleSource1", "bp5")],
-    [`styleSource3:bp6:width`, createStyleDecl("styleSource3", "bp6")],
+    createStyleDeclPair("styleSource1", "bp1"),
+    createStyleDeclPair("styleSource2", "bp2"),
+    createStyleDeclPair("styleSource1", "bp3"),
+    createStyleDeclPair("styleSource3", "bp4"),
+    createStyleDeclPair("styleSource1", "bp5"),
+    createStyleDeclPair("styleSource3", "bp6"),
   ]);
   const clonedStyleSourceIds = new Map<StyleSource["id"], StyleSource["id"]>();
   clonedStyleSourceIds.set("styleSource2", "newStyleSource2");

--- a/packages/project-build/src/db/styles.ts
+++ b/packages/project-build/src/db/styles.ts
@@ -133,6 +133,7 @@ export const parseStyles = async (
     const styleDecl = {
       styleSourceId: storedStyleDecl.styleSourceId,
       breakpointId: storedStyleDecl.breakpointId,
+      state: storedStyleDecl.state,
       property: storedStyleDecl.property,
       value: parseValue(storedStyleDecl.value, assetsMap),
     };
@@ -189,6 +190,7 @@ export const serializeStyles = (styles: Styles) => {
       return {
         breakpointId: styleDecl.breakpointId,
         styleSourceId: styleDecl.styleSourceId,
+        state: styleDecl.state,
         property: styleDecl.property,
         value: serializeValue(styleDecl.value),
       };

--- a/packages/project-build/src/schema/styles.ts
+++ b/packages/project-build/src/schema/styles.ts
@@ -64,8 +64,9 @@ export type StyleDeclKey = string;
 export const getStyleDeclKey = (
   styleDecl: Omit<StyleDecl, "value">
 ): StyleDeclKey => {
-  return `${styleDecl.styleSourceId}:${styleDecl.breakpointId}:${styleDecl.property
-    }:${styleDecl.state ?? ""}`;
+  return `${styleDecl.styleSourceId}:${styleDecl.breakpointId}:${
+    styleDecl.property
+  }:${styleDecl.state ?? ""}`;
 };
 
 export const Styles = z.map(z.string() as z.ZodType<StyleDeclKey>, StyleDecl);

--- a/packages/project-build/src/schema/styles.ts
+++ b/packages/project-build/src/schema/styles.ts
@@ -36,6 +36,7 @@ const StoredLayersValue = z.object({
 export const StoredStyleDecl = z.object({
   styleSourceId: z.string(),
   breakpointId: z.string(),
+  state: z.optional(z.string()),
   // @todo can't figure out how to make property to be enum
   property: z.string() as z.ZodType<StyleProperty>,
   value: z.union([StoredImageValue, StoredLayersValue, SharedStyleValue]),
@@ -50,6 +51,7 @@ export type StoredStyles = z.infer<typeof StoredStyles>;
 export const StyleDecl = z.object({
   styleSourceId: z.string(),
   breakpointId: z.string(),
+  state: z.optional(z.string()),
   // @todo can't figure out how to make property to be enum
   property: z.string() as z.ZodType<StyleProperty>,
   value: z.union([ImageValue, LayersValue, SharedStyleValue]),
@@ -62,7 +64,8 @@ export type StyleDeclKey = string;
 export const getStyleDeclKey = (
   styleDecl: Omit<StyleDecl, "value">
 ): StyleDeclKey => {
-  return `${styleDecl.styleSourceId}:${styleDecl.breakpointId}:${styleDecl.property}`;
+  return `${styleDecl.styleSourceId}:${styleDecl.breakpointId}:${styleDecl.property
+    }:${styleDecl.state ?? ""}`;
 };
 
 export const Styles = z.map(z.string() as z.ZodType<StyleDeclKey>, StyleDecl);

--- a/packages/react-sdk/src/css/style-rules.test.ts
+++ b/packages/react-sdk/src/css/style-rules.test.ts
@@ -1,75 +1,60 @@
 import { test, expect } from "@jest/globals";
-import type {
+import {
+  getStyleDeclKey,
+  StyleDecl,
   Styles,
   StyleSourceSelections,
 } from "@webstudio-is/project-build";
 import { getStyleRules } from "./style-rules";
 
+const createStyleDeclPair = (styleDecl: StyleDecl) => {
+  return [getStyleDeclKey(styleDecl), styleDecl] as const;
+};
+
 test("compute styles from different style sources", () => {
   const styles: Styles = new Map([
-    [
-      "styleSource1:a:width",
-      {
-        breakpointId: "a",
-        styleSourceId: "styleSource1",
-        property: "width",
-        value: { type: "unit", value: 10, unit: "px" },
-      },
-    ],
-    [
-      "styleSource2:a:display",
-      {
-        breakpointId: "a",
-        styleSourceId: "styleSource2",
-        property: "display",
-        value: { type: "keyword", value: "block" },
-      },
-    ],
-    [
-      "styleSource4:a:color",
-      {
-        breakpointId: "a",
-        styleSourceId: "styleSource4",
-        property: "color",
-        value: { type: "keyword", value: "green" },
-      },
-    ],
-    [
-      "styleSource4:a:width",
-      {
-        breakpointId: "a",
-        styleSourceId: "styleSource4",
-        property: "width",
-        value: { type: "keyword", value: "min-content" },
-      },
-    ],
-    [
-      "styleSource3:a:color",
-      {
-        breakpointId: "a",
-        styleSourceId: "styleSource3",
-        property: "color",
-        value: { type: "keyword", value: "red" },
-      },
-    ],
-    [
-      "styleSource5:b:color",
-      {
-        breakpointId: "b",
-        styleSourceId: "styleSource5",
-        property: "color",
-        value: { type: "keyword", value: "orange" },
-      },
-    ],
-    [
-      "styleSource6:a:color",
-      {
-        breakpointId: "a",
-        styleSourceId: "styleSource6",
-        property: "color",
-        value: { type: "keyword", value: "blue" },
-      },
-    ],
+    createStyleDeclPair({
+      breakpointId: "a",
+      styleSourceId: "styleSource1",
+      property: "width",
+      value: { type: "unit", value: 10, unit: "px" },
+    }),
+    createStyleDeclPair({
+      breakpointId: "a",
+      styleSourceId: "styleSource2",
+      property: "display",
+      value: { type: "keyword", value: "block" },
+    }),
+    createStyleDeclPair({
+      breakpointId: "a",
+      styleSourceId: "styleSource4",
+      property: "color",
+      value: { type: "keyword", value: "green" },
+    }),
+    createStyleDeclPair({
+      breakpointId: "a",
+      styleSourceId: "styleSource4",
+      property: "width",
+      value: { type: "keyword", value: "min-content" },
+    }),
+    createStyleDeclPair({
+      breakpointId: "a",
+      styleSourceId: "styleSource3",
+      property: "color",
+      value: { type: "keyword", value: "red" },
+    }),
+    createStyleDeclPair({
+      breakpointId: "b",
+      styleSourceId: "styleSource5",
+      property: "color",
+      value: { type: "keyword", value: "orange" },
+    }),
+    createStyleDeclPair({
+      breakpointId: "a",
+      styleSourceId: "styleSource6",
+      property: "color",
+      value: { type: "keyword", value: "blue" },
+    }),
   ]);
   const styleSourceSelections: StyleSourceSelections = new Map([
     [


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/807

- added indicator state has styles in style source menu
- added style state to schema
- save state styles changed from style panel


<img width="175" alt="Screenshot 2023-04-06 at 19 10 55" src="https://user-images.githubusercontent.com/5635476/230375421-dabab617-4e15-4784-a27b-1ba92549f7ff.png">

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
