### PR TITLE
Fix asset returned not existed parameters

### DIFF
--- a/packages/asset-uploader/src/utils/format-asset.ts
+++ b/packages/asset-uploader/src/utils/format-asset.ts
@@ -5,24 +5,38 @@ import { getAssetPath } from "./get-asset-path";
 import { type Asset, ImageMeta } from "../schema";
 
 export const formatAsset = (asset: DbAsset): Asset => {
-  const base = { ...asset, path: getAssetPath(asset) };
+  const path = getAssetPath(asset);
 
   const isFont = FONT_FORMATS.has(asset.format as FontFormat);
 
   if (isFont) {
     return {
-      ...base,
+      id: asset.id,
+      name: asset.name,
+      path,
+      description: asset.description,
+      location: asset.location,
+      projectId: asset.projectId,
+      size: asset.size,
+
       type: "font",
-      createdAt: base.createdAt.toISOString(),
+      createdAt: asset.createdAt.toISOString(),
       format: asset.format as FontFormat,
       meta: FontMeta.parse(JSON.parse(asset.meta)),
     };
   }
 
   return {
-    ...base,
+    id: asset.id,
+    name: asset.name,
+    path,
+    description: asset.description,
+    location: asset.location,
+    projectId: asset.projectId,
+    size: asset.size,
     type: "image",
-    createdAt: base.createdAt.toISOString(),
+    format: asset.format,
+    createdAt: asset.createdAt.toISOString(),
     meta: ImageMeta.parse(JSON.parse(asset.meta)),
   };
 };


### PR DESCRIPTION
## Description

`status` property returned in asset and killed saas type checks. Again because of spread

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
