### PR TITLE
Provide asset path getter to css engine

### DIFF
--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useIsomorphicLayoutEffect } from "react-use";
 import { useStore } from "@nanostores/react";
+import type { Assets } from "@webstudio-is/asset-uploader";
 import {
   collapsedAttribute,
   componentAttribute,
@@ -187,13 +188,17 @@ const toVarStyleWithFallback = (instanceId: string, style: Style): Style => {
 
 const wrappedRulesMap = new Map<string, StyleRule | PlaintextRule>();
 
-const addRule = (id: string, cssRule: CssRule) => {
+const addRule = (id: string, cssRule: CssRule, assets: Assets) => {
   const key = id + cssRule.breakpoint;
   const selectorText = `[${idAttribute}="${id}"]`;
-  const rule = cssEngine.addStyleRule(selectorText, {
-    ...cssRule,
-    style: toVarStyleWithFallback(id, cssRule.style),
-  });
+  const rule = cssEngine.addStyleRule(
+    selectorText,
+    {
+      ...cssRule,
+      style: toVarStyleWithFallback(id, cssRule.style),
+    },
+    (assetId) => assets.get(assetId)?.path
+  );
   wrappedRulesMap.set(key, rule);
   return rule;
 };
@@ -214,6 +219,9 @@ export const useCssRules = ({
 
   useIsomorphicLayoutEffect(() => {
     const stylePerBreakpoint = new Map<string, Style>();
+    // expect assets to be up to date by the time styles are changed
+    // to avoid all styles rerendering when assets are changed
+    const assets = assetsStore.get();
 
     for (const item of instanceStyles) {
       let style = stylePerBreakpoint.get(item.breakpointId);
@@ -229,7 +237,7 @@ export const useCssRules = ({
       const rule = getRule(instanceId, breakpointId);
       // It's the first time the rule is being used
       if (rule === undefined) {
-        addRule(instanceId, { breakpoint: breakpointId, style });
+        addRule(instanceId, { breakpoint: breakpointId, style }, assets);
         continue;
       }
       // It's an update to an existing rule

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -291,7 +291,8 @@ const usePreviewStyle = () => {
     let rule = getRule(id, breakpoint.id);
 
     if (rule === undefined) {
-      rule = addRule(id, { breakpoint: breakpoint.id, style: {} });
+      const assets = assetsStore.get();
+      rule = addRule(id, { breakpoint: breakpoint.id, style: {} }, assets);
     }
 
     for (const update of updates) {

--- a/packages/css-engine/package.json
+++ b/packages/css-engine/package.json
@@ -17,6 +17,7 @@
     "storybook:build": "build-storybook"
   },
   "dependencies": {
+    "@webstudio-is/asset-uploader": "workspace:^",
     "@webstudio-is/fonts": "workspace:^",
     "hyphenate-style-name": "^1.0.4",
     "react": "^17.0.2",

--- a/packages/css-engine/src/core/css-engine.test.ts
+++ b/packages/css-engine/src/core/css-engine.test.ts
@@ -1,4 +1,5 @@
 import { describe, beforeEach, test, expect } from "@jest/globals";
+import type { Assets, ImageAsset } from "@webstudio-is/asset-uploader";
 import { CssEngine } from "./css-engine";
 
 const style0 = {
@@ -346,6 +347,51 @@ describe("CssEngine", () => {
     expect(engine.cssText).toMatchInlineSnapshot(`
       "@media all {
         .c { color: black }
+      }"
+    `);
+  });
+
+  test("delete style from rule", () => {
+    const assets: Assets = new Map([
+      [
+        "1234",
+        {
+          type: "image",
+          path: "foo.png",
+          id: "1234567890",
+          projectId: "",
+          format: "",
+          size: 1212,
+          name: "img",
+          description: "",
+          location: "REMOTE",
+          createdAt: "",
+          meta: { width: 1, height: 2 },
+        },
+      ],
+    ]);
+    const rule = engine.addStyleRule(
+      ".c",
+      {
+        style: {
+          backgroundImage: {
+            type: "image",
+            value: {
+              type: "asset",
+              value: {
+                id: "1234",
+              } as ImageAsset,
+            },
+          },
+        },
+        breakpoint: "0",
+      },
+      (id) => assets.get(id)?.path
+    );
+    rule.styleMap.delete("display");
+    expect(engine.cssText).toMatchInlineSnapshot(`
+      "@media all {
+        .c { background-image: url(foo.png) /* id=1234 */ }
       }"
     `);
   });

--- a/packages/css-engine/src/core/css-engine.test.ts
+++ b/packages/css-engine/src/core/css-engine.test.ts
@@ -351,7 +351,7 @@ describe("CssEngine", () => {
     `);
   });
 
-  test("delete style from rule", () => {
+  test("render images with injected asset path", () => {
     const assets: Assets = new Map([
       [
         "1234",

--- a/packages/css-engine/src/core/css-engine.ts
+++ b/packages/css-engine/src/core/css-engine.ts
@@ -10,6 +10,7 @@ import {
 import { compareMedia } from "./compare-media";
 import { StyleElement } from "./style-element";
 import { StyleSheet } from "./style-sheet";
+import type { GetAssetPath } from "./to-value";
 
 const defaultMediaRuleId = "__default-media-rule__";
 
@@ -36,10 +37,14 @@ export class CssEngine {
     }
     return mediaRule;
   }
-  addStyleRule(selectorText: string, rule: CssRule) {
+  addStyleRule(
+    selectorText: string,
+    rule: CssRule,
+    getAssetPath?: GetAssetPath
+  ) {
     const mediaRule = this.addMediaRule(rule.breakpoint || defaultMediaRuleId);
     this.#isDirty = true;
-    const styleRule = new StyleRule(selectorText, rule.style);
+    const styleRule = new StyleRule(selectorText, rule.style, getAssetPath);
     styleRule.onChange = this.#onChangeRule;
     if (mediaRule === undefined) {
       // Should be impossible to reach.

--- a/packages/css-engine/src/core/rules.ts
+++ b/packages/css-engine/src/core/rules.ts
@@ -1,12 +1,16 @@
 import type { Style, StyleProperty, StyleValue } from "@webstudio-is/css-data";
-import { toValue } from "./to-value";
+import { type GetAssetPath, toValue } from "./to-value";
 import { toProperty } from "./to-property";
 
 class StylePropertyMap {
   #styleMap: Map<StyleProperty, StyleValue | undefined> = new Map();
   #isDirty = false;
   #string = "";
+  #getAssetPath?: GetAssetPath;
   onChange?: () => void;
+  constructor(options?: { getAssetPath?: GetAssetPath }) {
+    this.#getAssetPath = options?.getAssetPath;
+  }
   set(property: StyleProperty, value?: StyleValue) {
     this.#styleMap.set(property, value);
     this.#isDirty = true;
@@ -37,7 +41,11 @@ class StylePropertyMap {
       if (value === undefined) {
         continue;
       }
-      block.push(`${toProperty(property)}: ${toValue(value)}`);
+      block.push(
+        `${toProperty(property)}: ${toValue(value, {
+          getAssetPath: this.#getAssetPath,
+        })}`
+      );
     }
     this.#string = block.join("; ");
     this.#isDirty = false;
@@ -49,8 +57,8 @@ export class StyleRule {
   styleMap;
   selectorText;
   onChange?: () => void;
-  constructor(selectorText: string, style: Style) {
-    this.styleMap = new StylePropertyMap();
+  constructor(selectorText: string, style: Style, getAssetPath?: GetAssetPath) {
+    this.styleMap = new StylePropertyMap({ getAssetPath });
     this.selectorText = selectorText;
     let property: StyleProperty;
     for (property in style) {

--- a/packages/css-engine/src/core/to-value.test.ts
+++ b/packages/css-engine/src/core/to-value.test.ts
@@ -1,5 +1,26 @@
 import { describe, test, expect } from "@jest/globals";
+import type { Assets } from "@webstudio-is/asset-uploader";
 import { toValue } from "./to-value";
+
+const assets: Assets = new Map([
+  [
+    "1234567890",
+    {
+      type: "image",
+      path: "foo.png",
+
+      id: "1234567890",
+      projectId: "",
+      format: "",
+      size: 1212,
+      name: "img",
+      description: "",
+      location: "REMOTE",
+      createdAt: "",
+      meta: { width: 1, height: 2 },
+    },
+  ],
+]);
 
 describe("Convert WS CSS Values to native CSS strings", () => {
   test("keyword", () => {
@@ -66,37 +87,42 @@ describe("Convert WS CSS Values to native CSS strings", () => {
   });
 
   test("array", () => {
-    const value = toValue({
-      type: "layers",
-      value: [
-        {
-          type: "keyword",
-          value: "auto",
-        },
-        { type: "unit", value: 10, unit: "px" },
-        { type: "unparsed", value: "calc(10px)" },
-        {
-          type: "image",
-          value: {
-            type: "asset",
+    const value = toValue(
+      {
+        type: "layers",
+        value: [
+          {
+            type: "keyword",
+            value: "auto",
+          },
+          { type: "unit", value: 10, unit: "px" },
+          { type: "unparsed", value: "calc(10px)" },
+          {
+            type: "image",
             value: {
-              type: "image",
-              path: "foo.png",
+              type: "asset",
+              value: {
+                type: "image",
+                path: "foo.png",
 
-              id: "1234567890",
-              projectId: "",
-              format: "",
-              size: 1212,
-              name: "img",
-              description: "",
-              location: "REMOTE",
-              createdAt: "",
-              meta: { width: 1, height: 2 },
+                id: "1234567890",
+                projectId: "",
+                format: "",
+                size: 1212,
+                name: "img",
+                description: "",
+                location: "REMOTE",
+                createdAt: "",
+                meta: { width: 1, height: 2 },
+              },
             },
           },
-        },
-      ],
-    });
+        ],
+      },
+      {
+        getAssetPath: (id) => assets.get(id)?.path,
+      }
+    );
 
     expect(value).toBe("auto,10px,calc(10px),url(foo.png) /* id=1234567890 */");
   });

--- a/packages/react-sdk/src/css/css.ts
+++ b/packages/react-sdk/src/css/css.ts
@@ -47,10 +47,14 @@ export const generateCssText = (data: Data) => {
 
   const styleRules = getStyleRules(styles, styleSourceSelections);
   for (const { breakpointId, instanceId, style } of styleRules) {
-    engine.addStyleRule(`[${idAttribute}="${instanceId}"]`, {
-      breakpoint: breakpointId,
-      style,
-    });
+    engine.addStyleRule(
+      `[${idAttribute}="${instanceId}"]`,
+      {
+        breakpoint: breakpointId,
+        style,
+      },
+      (assetId) => assets.get(assetId)?.path
+    );
   }
 
   return engine.cssText;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,6 +500,9 @@ importers:
 
   packages/css-engine:
     dependencies:
+      '@webstudio-is/asset-uploader':
+        specifier: workspace:^
+        version: link:../asset-uploader
       '@webstudio-is/fonts':
         specifier: workspace:^
         version: link:../fonts


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1179

Styles currently get urls like this

https://assets.webstudio.is/e55bd4Lu_400x400_8X-Q89JB6QQIxu8912gCK.jpg

While image component get optimized one like this

https://image-transform.wstd.io/cdn-cgi/image/width=384, quality=80, format=auto/https://assets.webstudio.is/e55bd4Lu_400x400_8X-Q89JB6QQIxu8912gCK.jpg

We need a way to provide different url than hardcoded in asset. Here I added getAssetPath support for css engine to inject right path by asset id.

This will also unlock us from decoupling styles and assets on server side.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
