### PR TITLE
Allow to map individual style values when stringify to css

### DIFF
--- a/apps/builder/app/builder/features/style-panel/controls/font-weight/font-weight-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/font-weight/font-weight-control.tsx
@@ -77,7 +77,15 @@ export const FontWeightControl = ({
   const fontFamily = currentStyle.fontFamily?.value;
 
   const availableFontWeights = useAvailableFontWeights(
-    toValue(fontFamily, { withFallback: false })
+    toValue(fontFamily, (styleValue) => {
+      // override default fallback with rendering only first font family
+      if (styleValue.type === "fontFamily") {
+        return {
+          type: "fontFamily",
+          value: [styleValue.value[0]],
+        };
+      }
+    })
   );
   const { labels, selectedLabel } = useLabels(
     availableFontWeights,

--- a/packages/css-engine/src/core/to-value.test.ts
+++ b/packages/css-engine/src/core/to-value.test.ts
@@ -54,13 +54,20 @@ describe("Convert WS CSS Values to native CSS strings", () => {
     expect(value).toBe("Courier New, monospace");
   });
 
-  test("withFallback=false", () => {
+  test("Transform font family value to override default fallback", () => {
     const value = toValue(
       {
         type: "fontFamily",
         value: ["Courier New"],
       },
-      { withFallback: false }
+      (styleValue) => {
+        if (styleValue.type === "fontFamily") {
+          return {
+            type: "fontFamily",
+            value: [styleValue.value[0]],
+          };
+        }
+      }
     );
     expect(value).toBe("Courier New");
   });


### PR DESCRIPTION
Related to https://github.com/webstudio-is/webstudio-builder/pull/1403

Here I removed app specific case from css-engine toValue by providing transformValue function which is called on every individual style value inside nested structure (like var or layers).

With this function we can resolve assets and remove complex resolving logic from server.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
