### PR TITLE
Transform image value to resolve url

### DIFF
--- a/apps/builder/app/builder/features/style-panel/controls/image/image-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/image/image-control.tsx
@@ -16,7 +16,10 @@ export const ImageControl = ({
 
   const setValue = setProperty(property);
 
-  const valueAsset = styleValue.type === "image" ? styleValue.value : undefined;
+  const valueAsset =
+    styleValue.type === "image" && styleValue.value.type === "asset"
+      ? styleValue.value
+      : undefined;
 
   return (
     <FloatingPanel

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-thumbnail.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-thumbnail.tsx
@@ -56,7 +56,10 @@ const gradientNames = [
 
 export const getLayerName = (layerStyle: StyleInfo) => {
   const backgroundImageStyle = layerStyle.backgroundImage?.value;
-  if (backgroundImageStyle?.type === "image") {
+  if (
+    backgroundImageStyle?.type === "image" &&
+    backgroundImageStyle.value.type === "asset"
+  ) {
     return backgroundImageStyle.value.value.name;
   }
 
@@ -74,7 +77,10 @@ export const getLayerName = (layerStyle: StyleInfo) => {
 export const LayerThumbnail = (props: { layerStyle: StyleInfo }) => {
   const backgroundImageStyle = props.layerStyle.backgroundImage?.value;
 
-  if (backgroundImageStyle?.type === "image") {
+  if (
+    backgroundImageStyle?.type === "image" &&
+    backgroundImageStyle.value.type === "asset"
+  ) {
     const asset = backgroundImageStyle.value.value;
     const remoteLocation = asset.location === "REMOTE";
 

--- a/packages/css-data/src/schema.ts
+++ b/packages/css-data/src/schema.ts
@@ -74,7 +74,12 @@ export type RgbValue = z.infer<typeof RgbValue>;
 
 export const ImageValue = z.object({
   type: z.literal("image"),
-  value: z.object({ type: z.literal("asset"), value: ImageAsset }),
+  value: z.union([
+    z.object({ type: z.literal("asset"), value: ImageAsset }),
+    // url is not stored in db and only used by css-engine transformValue
+    // to prepare image value for rendering
+    z.object({ type: z.literal("url"), url: z.string() }),
+  ]),
   // For the builder we want to be able to hide images
   hidden: z.boolean().optional(),
 });

--- a/packages/css-engine/package.json
+++ b/packages/css-engine/package.json
@@ -28,6 +28,7 @@
     "@types/hyphenate-style-name": "^1.0.0",
     "@types/react": "^17.0.24",
     "@types/react-dom": "^17.0.9",
+    "@webstudio-is/asset-uploader": "workspace:^",
     "@webstudio-is/css-data": "workspace:^",
     "@webstudio-is/jest-config": "workspace:^",
     "@webstudio-is/scripts": "workspace:^",

--- a/packages/css-engine/src/core/css-engine.ts
+++ b/packages/css-engine/src/core/css-engine.ts
@@ -10,6 +10,7 @@ import {
 import { compareMedia } from "./compare-media";
 import { StyleElement } from "./style-element";
 import { StyleSheet } from "./style-sheet";
+import type { TransformValue } from "./to-value";
 
 const defaultMediaRuleId = "__default-media-rule__";
 
@@ -36,10 +37,14 @@ export class CssEngine {
     }
     return mediaRule;
   }
-  addStyleRule(selectorText: string, rule: CssRule) {
+  addStyleRule(
+    selectorText: string,
+    rule: CssRule,
+    transformValue?: TransformValue
+  ) {
     const mediaRule = this.addMediaRule(rule.breakpoint || defaultMediaRuleId);
     this.#isDirty = true;
-    const styleRule = new StyleRule(selectorText, rule.style);
+    const styleRule = new StyleRule(selectorText, rule.style, transformValue);
     styleRule.onChange = this.#onChangeRule;
     if (mediaRule === undefined) {
       // Should be impossible to reach.

--- a/packages/css-engine/src/core/rules.ts
+++ b/packages/css-engine/src/core/rules.ts
@@ -1,12 +1,16 @@
 import type { Style, StyleProperty, StyleValue } from "@webstudio-is/css-data";
-import { toValue } from "./to-value";
+import { toValue, type TransformValue } from "./to-value";
 import { toProperty } from "./to-property";
 
 class StylePropertyMap {
   #styleMap: Map<StyleProperty, StyleValue | undefined> = new Map();
   #isDirty = false;
   #string = "";
+  #transformValue?: TransformValue;
   onChange?: () => void;
+  constructor(transformValue?: TransformValue) {
+    this.#transformValue = transformValue;
+  }
   set(property: StyleProperty, value?: StyleValue) {
     this.#styleMap.set(property, value);
     this.#isDirty = true;
@@ -37,7 +41,9 @@ class StylePropertyMap {
       if (value === undefined) {
         continue;
       }
-      block.push(`${toProperty(property)}: ${toValue(value)}`);
+      block.push(
+        `${toProperty(property)}: ${toValue(value, this.#transformValue)}`
+      );
     }
     this.#string = block.join("; ");
     this.#isDirty = false;
@@ -49,8 +55,12 @@ export class StyleRule {
   styleMap;
   selectorText;
   onChange?: () => void;
-  constructor(selectorText: string, style: Style) {
-    this.styleMap = new StylePropertyMap();
+  constructor(
+    selectorText: string,
+    style: Style,
+    transformValue?: TransformValue
+  ) {
+    this.styleMap = new StylePropertyMap(transformValue);
     this.selectorText = selectorText;
     let property: StyleProperty;
     for (property in style) {

--- a/packages/css-engine/src/core/to-value.ts
+++ b/packages/css-engine/src/core/to-value.ts
@@ -68,7 +68,7 @@ export const toValue = (
   }
 
   if (value.type === "image") {
-    if (value.hidden) {
+    if (value.hidden || value.value.type !== "url") {
       // We assume that property is background-image and use this to hide background layers
       // In the future we might want to have a more generic way to hide values
       // i.e. have knowledge about property-name, as none is property specific
@@ -76,7 +76,7 @@ export const toValue = (
     }
 
     // @todo image-set
-    return `url(${value.value.value.path}) /* id=${value.value.value.id} */`;
+    return `url(${value.value.url})`;
   }
 
   if (value.type === "unparsed") {

--- a/packages/project-build/src/db/styles.ts
+++ b/packages/project-build/src/db/styles.ts
@@ -150,6 +150,9 @@ const serializeValue = (
   styleValue: StyleDecl["value"]
 ): StoredStyleDecl["value"] => {
   if (styleValue.type === "image") {
+    if (styleValue.value.type === "url") {
+      return { type: "keyword", value: "none" };
+    }
     const asset = styleValue.value;
     return {
       type: "image" as const,
@@ -165,6 +168,9 @@ const serializeValue = (
       type: "layers" as const,
       value: styleValue.value.map((item) => {
         if (item.type === "image") {
+          if (item.value.type === "url") {
+            return { type: "keyword" as const, value: "none" };
+          }
           const asset = item.value;
           return {
             type: "image" as const,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -528,6 +528,9 @@ importers:
       '@types/react-dom':
         specifier: ^17.0.9
         version: 17.0.17
+      '@webstudio-is/asset-uploader':
+        specifier: workspace:^
+        version: link:../asset-uploader
       '@webstudio-is/css-data':
         specifier: workspace:^
         version: link:../css-data


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1179

Succeeded https://github.com/webstudio-is/webstudio-builder/pull/1403

Here added support for transformValue in css-engine StyleRule. So we can apply any transformation when render css.

In sdk added image transformation which accepts assets and provides image value with new url value.

Now we can get rid of resolving on server side and apply image loaders for images rendered in styles.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
