### PR TITLE
Drop assets resolving from project-build

### DIFF
--- a/apps/builder/app/builder/features/style-panel/controls/image/image-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/image/image-control.tsx
@@ -1,13 +1,16 @@
+import { useStore } from "@nanostores/react";
 import { Button } from "@webstudio-is/design-system";
-import type { ControlProps } from "../../style-sections";
+import { assetsStore } from "~/shared/nano-states";
 import { FloatingPanel } from "~/builder/shared/floating-panel";
 import { ImageManager } from "~/builder/shared/image-manager";
+import type { ControlProps } from "../../style-sections";
 
 export const ImageControl = ({
   property,
   currentStyle,
   setProperty,
 }: ControlProps) => {
+  const assets = useStore(assetsStore);
   const styleValue = currentStyle[property]?.value;
 
   if (styleValue === undefined) {
@@ -16,9 +19,9 @@ export const ImageControl = ({
 
   const setValue = setProperty(property);
 
-  const valueAsset =
+  const asset =
     styleValue.type === "image" && styleValue.value.type === "asset"
-      ? styleValue.value
+      ? assets.get(styleValue.value.value)
       : undefined;
 
   return (
@@ -29,14 +32,14 @@ export const ImageControl = ({
           onChange={(asset) => {
             setValue({
               type: "image",
-              value: { type: "asset", value: asset },
+              value: { type: "asset", value: asset.id },
             });
           }}
         />
       }
     >
       <Button color="neutral" css={{ maxWidth: "100%", justifySelf: "right" }}>
-        {valueAsset?.value.name ?? "Choose image..."}
+        {asset?.name ?? "Choose image..."}
       </Button>
     </FloatingPanel>
   );

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-thumbnail.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-thumbnail.tsx
@@ -1,5 +1,8 @@
+import { useStore } from "@nanostores/react";
+import type { Assets } from "@webstudio-is/asset-uploader";
 import { Image as WebstudioImage, loaders } from "@webstudio-is/image";
 import { styled, theme } from "@webstudio-is/design-system";
+import { assetsStore } from "~/shared/nano-states";
 import type { StyleInfo } from "../../shared/style-info";
 import brokenImage from "~/shared/images/broken-image-placeholder.svg";
 import env from "~/shared/env";
@@ -54,13 +57,16 @@ const gradientNames = [
   "repeating-radial-gradient",
 ];
 
-export const getLayerName = (layerStyle: StyleInfo) => {
+export const getLayerName = (layerStyle: StyleInfo, assets: Assets) => {
   const backgroundImageStyle = layerStyle.backgroundImage?.value;
   if (
     backgroundImageStyle?.type === "image" &&
     backgroundImageStyle.value.type === "asset"
   ) {
-    return backgroundImageStyle.value.value.name;
+    const asset = assets.get(backgroundImageStyle.value.value);
+    if (asset) {
+      return asset.name;
+    }
   }
 
   if (backgroundImageStyle?.type === "unparsed") {
@@ -75,13 +81,17 @@ export const getLayerName = (layerStyle: StyleInfo) => {
 };
 
 export const LayerThumbnail = (props: { layerStyle: StyleInfo }) => {
+  const assets = useStore(assetsStore);
   const backgroundImageStyle = props.layerStyle.backgroundImage?.value;
 
   if (
     backgroundImageStyle?.type === "image" &&
     backgroundImageStyle.value.type === "asset"
   ) {
-    const asset = backgroundImageStyle.value.value;
+    const asset = assets.get(backgroundImageStyle.value.value);
+    if (asset === undefined) {
+      return null;
+    }
     const remoteLocation = asset.location === "REMOTE";
 
     const loader = remoteLocation
@@ -97,7 +107,7 @@ export const LayerThumbnail = (props: { layerStyle: StyleInfo }) => {
         src={asset.path}
         width={theme.spacing[10]}
         optimize={true}
-        alt={getLayerName(props.layerStyle)}
+        alt={getLayerName(props.layerStyle, assets)}
       />
     );
   }

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
@@ -1,3 +1,4 @@
+import { useStore } from "@nanostores/react";
 import type { RenderCategoryProps } from "../../style-sections";
 import { styleConfigByName } from "../../shared/configs";
 import { FloatingPanel } from "~/builder/shared/floating-panel";
@@ -21,6 +22,7 @@ import {
   SubtractIcon,
   PlusIcon,
 } from "@webstudio-is/icons";
+import { assetsStore } from "~/shared/nano-states";
 import { PropertyName } from "../../shared/property-name";
 import type { StyleInfo } from "../../shared/style-info";
 import { ColorControl } from "../../controls/color/color-control";
@@ -63,6 +65,8 @@ const Layer = (props: {
   deleteLayer: () => void;
   setBackgroundColor: (color: RgbValue) => void;
 }) => {
+  const assets = useStore(assetsStore);
+
   const backgrounImageStyle = props.layerStyle.backgroundImage?.value;
   const isHidden =
     backgrounImageStyle?.type === "image" ||
@@ -104,7 +108,7 @@ const Layer = (props: {
         tabIndex={props.tabIndex}
         label={
           <Label truncate onReset={props.deleteLayer}>
-            {getLayerName(props.layerStyle)}
+            {getLayerName(props.layerStyle, assets)}
           </Label>
         }
         thumbnail={<LayerThumbnail layerStyle={props.layerStyle} />}

--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -16,7 +16,6 @@
   },
   "devDependencies": {
     "@types/css-tree": "^2.0.0",
-    "@webstudio-is/asset-uploader": "workspace:^",
     "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "camelcase": "^6.3.0",

--- a/packages/css-data/src/schema.ts
+++ b/packages/css-data/src/schema.ts
@@ -1,7 +1,6 @@
 import { units } from "./__generated__/units";
 import type { properties } from "./__generated__/properties";
 import { z } from "zod";
-import { ImageAsset } from "@webstudio-is/asset-uploader";
 
 type Properties = typeof properties & {
   [custom: CustomProperty]: {
@@ -75,7 +74,7 @@ export type RgbValue = z.infer<typeof RgbValue>;
 export const ImageValue = z.object({
   type: z.literal("image"),
   value: z.union([
-    z.object({ type: z.literal("asset"), value: ImageAsset }),
+    z.object({ type: z.literal("asset"), value: z.string() }),
     // url is not stored in db and only used by css-engine transformValue
     // to prepare image value for rendering
     z.object({ type: z.literal("url"), url: z.string() }),

--- a/packages/css-data/src/schema.ts
+++ b/packages/css-data/src/schema.ts
@@ -144,23 +144,15 @@ export const validStaticValueTypes = [
   "tuple",
 ] as const;
 
-/**
- * Shared zod types with DB types.
- * ImageValue in DB has a different type
- */
-const SharedStaticStyleValue = z.union([
+const ValidStaticStyleValue = z.union([
+  ImageValue,
+  LayersValue,
   UnitValue,
   KeywordValue,
   FontFamilyValue,
   RgbValue,
   UnparsedValue,
   TupleValue,
-]);
-
-const ValidStaticStyleValue = z.union([
-  ImageValue,
-  LayersValue,
-  SharedStaticStyleValue,
 ]);
 
 export type ValidStaticStyleValue = z.infer<typeof ValidStaticStyleValue>;
@@ -172,18 +164,8 @@ const VarValue = z.object({
 });
 export type VarValue = z.infer<typeof VarValue>;
 
-const StyleValue = z.union([
+export const StyleValue = z.union([
   ValidStaticStyleValue,
-  InvalidValue,
-  UnsetValue,
-  VarValue,
-]);
-
-/**
- * Shared types with DB types
- */
-export const SharedStyleValue = z.union([
-  SharedStaticStyleValue,
   InvalidValue,
   UnsetValue,
   VarValue,

--- a/packages/css-engine/src/core/css-engine.test.ts
+++ b/packages/css-engine/src/core/css-engine.test.ts
@@ -1,6 +1,6 @@
 import { describe, beforeEach, test, expect } from "@jest/globals";
+import type { Assets } from "@webstudio-is/asset-uploader";
 import { CssEngine } from "./css-engine";
-import type { Assets, ImageAsset } from "@webstudio-is/asset-uploader";
 
 const style0 = {
   display: { type: "keyword", value: "block" },
@@ -378,9 +378,7 @@ describe("CssEngine", () => {
             type: "image",
             value: {
               type: "asset",
-              value: {
-                id: "1234",
-              } as ImageAsset,
+              value: "1234",
             },
           },
         },
@@ -388,7 +386,7 @@ describe("CssEngine", () => {
       },
       (styleValue) => {
         if (styleValue.type === "image" && styleValue.value.type === "asset") {
-          const asset = assets.get(styleValue.value.value.id);
+          const asset = assets.get(styleValue.value.value);
           if (asset === undefined) {
             return { type: "keyword", value: "none" };
           }

--- a/packages/css-engine/src/core/to-value.test.ts
+++ b/packages/css-engine/src/core/to-value.test.ts
@@ -108,27 +108,14 @@ describe("Convert WS CSS Values to native CSS strings", () => {
             type: "image",
             value: {
               type: "asset",
-              value: {
-                type: "image",
-                path: "foo.png",
-
-                id: "1234567890",
-                projectId: "",
-                format: "",
-                size: 1212,
-                name: "img",
-                description: "",
-                location: "REMOTE",
-                createdAt: "",
-                meta: { width: 1, height: 2 },
-              },
+              value: "1234567890",
             },
           },
         ],
       },
       (styleValue) => {
         if (styleValue.type === "image" && styleValue.value.type === "asset") {
-          const asset = assets.get(styleValue.value.value.id);
+          const asset = assets.get(styleValue.value.value);
           if (asset === undefined) {
             return {
               type: "keyword",

--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -34,7 +34,6 @@
     "dts": "tsc --emitDeclarationOnly --declaration --declarationDir lib/types"
   },
   "dependencies": {
-    "@webstudio-is/asset-uploader": "workspace:^",
     "@webstudio-is/css-data": "workspace:^",
     "@webstudio-is/prisma-client": "workspace:^",
     "@webstudio-is/trpc-interface": "workspace:^",

--- a/packages/project-build/src/db/build.ts
+++ b/packages/project-build/src/db/build.ts
@@ -32,7 +32,7 @@ const parseBuild = async (build: DbBuild): Promise<Build> => {
     createdAt: build.createdAt.toISOString(),
     pages,
     breakpoints: Array.from(parseBreakpoints(build.breakpoints)),
-    styles: Array.from(await parseStyles(build.projectId, build.styles)),
+    styles: Array.from(parseStyles(build.styles)),
     styleSources: Array.from(parseStyleSources(build.styleSources)),
     styleSourceSelections: Array.from(
       parseStyleSourceSelections(build.styleSourceSelections)

--- a/packages/project-build/src/db/styles.ts
+++ b/packages/project-build/src/db/styles.ts
@@ -1,208 +1,20 @@
-import warnOnce from "warn-once";
 import { type Patch, applyPatches } from "immer";
 import { type Project, prisma } from "@webstudio-is/prisma-client";
-import type { Asset } from "@webstudio-is/asset-uploader";
-import { formatAsset } from "@webstudio-is/asset-uploader/server";
 import {
   authorizeProject,
   type AppContext,
 } from "@webstudio-is/trpc-interface/server";
 import type { Build } from "../types";
-import {
-  type StoredStyleDecl,
-  type StyleDecl,
-  getStyleDeclKey,
-  StoredStyles,
-  Styles,
-} from "../schema/styles";
+import { Styles, StylesList, getStyleDeclKey } from "../schema/styles";
 
-const parseValue = (
-  styleValue: StoredStyleDecl["value"],
-  assetsMap: Map<string, Asset>
-): StyleDecl["value"] => {
-  if (styleValue.type === "layers") {
-    return {
-      type: "layers" as const,
-      value: styleValue.value.map((style) => {
-        if (style.type === "image") {
-          const item = style.value;
-          const asset = assetsMap.get(item.value);
-          if (asset === undefined) {
-            warnOnce(true, `Asset with assetId "${item.value}" not found`);
-
-            return {
-              type: "invalid" as const,
-              value: JSON.stringify(styleValue.value),
-            };
-          }
-
-          if (asset.type !== "image") {
-            warnOnce(true, `Asset with assetId "${item.value}" not an image`);
-            return {
-              type: "invalid" as const,
-              value: JSON.stringify(styleValue.value),
-            };
-          }
-
-          return {
-            type: "image" as const,
-            value: {
-              type: "asset" as const,
-              value: asset,
-            },
-          };
-        }
-        return style;
-      }),
-    };
-  }
-
-  if (styleValue.type === "image") {
-    const item = styleValue.value;
-    const asset = assetsMap.get(item.value);
-
-    if (asset === undefined) {
-      warnOnce(true, `Asset with assetId "${item.value}" not found`);
-
-      return {
-        type: "invalid" as const,
-        value: JSON.stringify(styleValue.value),
-      };
-    }
-
-    if (asset.type !== "image") {
-      warnOnce(true, `Asset with assetId "${item.value}" not an image`);
-      return {
-        type: "invalid" as const,
-        value: JSON.stringify(styleValue.value),
-      };
-    }
-
-    return {
-      type: "image" as const,
-      value: {
-        type: "asset" as const,
-        value: asset,
-      },
-    };
-  }
-  return styleValue;
+export const parseStyles = (stylesString: string): Styles => {
+  const stylesList = StylesList.parse(JSON.parse(stylesString));
+  return new Map(stylesList.map((item) => [getStyleDeclKey(item), item]));
 };
 
-export const parseStyles = async (
-  projectId: Asset["projectId"],
-  stylesString: string
-) => {
-  const storedStyles = StoredStyles.parse(JSON.parse(stylesString));
-
-  const assetIds: string[] = [];
-  for (const { value: styleValue } of storedStyles) {
-    if (styleValue.type === "image") {
-      const item = styleValue.value;
-      if (item.type === "asset") {
-        assetIds.push(item.value);
-      }
-    }
-
-    if (styleValue.type === "layers") {
-      for (const layer of styleValue.value) {
-        if (layer.type === "image") {
-          const item = layer.value;
-          if (item.type === "asset") {
-            assetIds.push(item.value);
-          }
-        }
-      }
-    }
-  }
-
-  // Load all assets
-  const assets = await prisma.asset.findMany({
-    where: {
-      id: { in: assetIds },
-      projectId,
-    },
-  });
-  const assetsMap = new Map<string, Asset>();
-  for (const asset of assets) {
-    assetsMap.set(asset.id, formatAsset(asset));
-  }
-
-  const styles: Styles = new Map();
-  for (const storedStyleDecl of storedStyles) {
-    const styleDecl = {
-      styleSourceId: storedStyleDecl.styleSourceId,
-      breakpointId: storedStyleDecl.breakpointId,
-      state: storedStyleDecl.state,
-      property: storedStyleDecl.property,
-      value: parseValue(storedStyleDecl.value, assetsMap),
-    };
-    styles.set(getStyleDeclKey(styleDecl), styleDecl);
-  }
-
-  return styles;
-};
-
-/**
- * prepare value to store in db
- */
-const serializeValue = (
-  styleValue: StyleDecl["value"]
-): StoredStyleDecl["value"] => {
-  if (styleValue.type === "image") {
-    if (styleValue.value.type === "url") {
-      return { type: "keyword", value: "none" };
-    }
-    const asset = styleValue.value;
-    return {
-      type: "image" as const,
-      value: {
-        type: asset.type,
-        // only asset id is stored in db
-        value: asset.value.id,
-      },
-    };
-  }
-  if (styleValue.type === "layers") {
-    return {
-      type: "layers" as const,
-      value: styleValue.value.map((item) => {
-        if (item.type === "image") {
-          if (item.value.type === "url") {
-            return { type: "keyword" as const, value: "none" };
-          }
-          const asset = item.value;
-          return {
-            type: "image" as const,
-            value: {
-              type: asset.type,
-              // only asset id is stored in db
-              value: asset.value.id,
-            },
-          };
-        }
-        return item;
-      }),
-    };
-  }
-
-  return styleValue;
-};
-
-export const serializeStyles = (styles: Styles) => {
-  const storedStyles: StoredStyles = Array.from(
-    styles.values(),
-    (styleDecl) => {
-      return {
-        breakpointId: styleDecl.breakpointId,
-        styleSourceId: styleDecl.styleSourceId,
-        state: styleDecl.state,
-        property: styleDecl.property,
-        value: serializeValue(styleDecl.value),
-      };
-    }
-  );
-  return JSON.stringify(storedStyles);
+export const serializeStyles = (stylesMap: Styles) => {
+  const stylesList: StylesList = Array.from(stylesMap.values());
+  return JSON.stringify(stylesList);
 };
 
 export const patchStyles = async (
@@ -228,7 +40,7 @@ export const patchStyles = async (
     return;
   }
 
-  const styles = await parseStyles(build.projectId, build.styles);
+  const styles = parseStyles(build.styles);
 
   const patchedStyles = Styles.parse(applyPatches(styles, patches));
 

--- a/packages/project-build/src/schema/styles.ts
+++ b/packages/project-build/src/schema/styles.ts
@@ -1,10 +1,5 @@
 import { z } from "zod";
-import {
-  type StyleProperty,
-  SharedStyleValue,
-  ImageValue,
-  LayersValue,
-} from "@webstudio-is/css-data";
+import { type StyleProperty, StyleValue } from "@webstudio-is/css-data";
 
 export const StyleDecl = z.object({
   styleSourceId: z.string(),
@@ -12,7 +7,7 @@ export const StyleDecl = z.object({
   state: z.optional(z.string()),
   // @todo can't figure out how to make property to be enum
   property: z.string() as z.ZodType<StyleProperty>,
-  value: z.union([ImageValue, LayersValue, SharedStyleValue]),
+  value: StyleValue,
 });
 
 export type StyleDecl = z.infer<typeof StyleDecl>;

--- a/packages/project-build/src/schema/styles.ts
+++ b/packages/project-build/src/schema/styles.ts
@@ -4,49 +4,7 @@ import {
   SharedStyleValue,
   ImageValue,
   LayersValue,
-  UnitValue,
-  KeywordValue,
-  UnparsedValue,
-  InvalidValue,
-  TupleValue,
 } from "@webstudio-is/css-data";
-
-const StoredImageValue = z.object({
-  type: z.literal("image"),
-  value: z.object({ type: z.literal("asset"), value: z.string() }),
-
-  // For the builder we want to be able to hide images
-  hidden: z.boolean().optional(),
-});
-
-const StoredLayersValue = z.object({
-  type: z.literal("layers"),
-  value: z.array(
-    z.union([
-      UnitValue,
-      KeywordValue,
-      UnparsedValue,
-      StoredImageValue,
-      TupleValue,
-      InvalidValue,
-    ])
-  ),
-});
-
-export const StoredStyleDecl = z.object({
-  styleSourceId: z.string(),
-  breakpointId: z.string(),
-  state: z.optional(z.string()),
-  // @todo can't figure out how to make property to be enum
-  property: z.string() as z.ZodType<StyleProperty>,
-  value: z.union([StoredImageValue, StoredLayersValue, SharedStyleValue]),
-});
-
-export type StoredStyleDecl = z.infer<typeof StoredStyleDecl>;
-
-export const StoredStyles = z.array(StoredStyleDecl);
-
-export type StoredStyles = z.infer<typeof StoredStyles>;
 
 export const StyleDecl = z.object({
   styleSourceId: z.string(),
@@ -68,6 +26,10 @@ export const getStyleDeclKey = (
     styleDecl.property
   }:${styleDecl.state ?? ""}`;
 };
+
+export const StylesList = z.array(StyleDecl);
+
+export type StylesList = z.infer<typeof StylesList>;
 
 export const Styles = z.map(z.string() as z.ZodType<StyleDeclKey>, StyleDecl);
 

--- a/packages/react-sdk/src/css/css.ts
+++ b/packages/react-sdk/src/css/css.ts
@@ -28,6 +28,7 @@ export const createImageValueTransformer =
           type: "url",
           url: asset.path,
         },
+        hidden: styleValue.hidden,
       };
     }
   };

--- a/packages/react-sdk/src/css/css.ts
+++ b/packages/react-sdk/src/css/css.ts
@@ -18,7 +18,7 @@ export const createImageValueTransformer =
   (assets: Assets): TransformValue =>
   (styleValue) => {
     if (styleValue.type === "image" && styleValue.value.type === "asset") {
-      const asset = assets.get(styleValue.value.value.id);
+      const asset = assets.get(styleValue.value.value);
       if (asset === undefined) {
         return { type: "keyword", value: "none" };
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,9 +470,6 @@ importers:
       '@types/css-tree':
         specifier: ^2.0.0
         version: 2.0.0
-      '@webstudio-is/asset-uploader':
-        specifier: workspace:^
-        version: link:../asset-uploader
       '@webstudio-is/scripts':
         specifier: workspace:^
         version: link:../scripts
@@ -1107,9 +1104,6 @@ importers:
 
   packages/project-build:
     dependencies:
-      '@webstudio-is/asset-uploader':
-        specifier: workspace:^
-        version: link:../asset-uploader
       '@webstudio-is/css-data':
         specifier: workspace:^
         version: link:../css-data


### PR DESCRIPTION
This big chunk of legacy is no longer necessary.
We resolve style assets on client so css engine can accept db types now.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview

- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
