### PR TITLE
Fix error in dev mode

### DIFF
--- a/apps/builder/app/shared/theme/theme.ts
+++ b/apps/builder/app/shared/theme/theme.ts
@@ -3,6 +3,7 @@ import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import { darkTheme } from "@webstudio-is/design-system";
 import { restThemePath } from "~/shared/router-utils";
 import type { ColorScheme, ThemeSetting } from "./types";
+import { useEffect, useState } from "react";
 
 // User selected theme setting.
 let setting: ThemeSetting = isFeatureEnabled("dark") ? "system" : "light";
@@ -75,12 +76,28 @@ export const useThemeProps = () => {
   if (data.theme.system) {
     system = data.theme.system;
   }
-  const theme = getColorScheme();
-  return {
-    className: theme === "dark" ? darkTheme.className : undefined,
-    style: { colorScheme: theme },
-    "data-theme": theme,
-  };
+
+  const [themeProps, setThemeProps] = useState<{
+    className: string | undefined;
+    style: { colorScheme: ColorScheme };
+    "data-theme": ColorScheme;
+  }>({
+    className: undefined,
+    style: { colorScheme: "light" },
+    "data-theme": "light",
+  });
+
+  useEffect(() => {
+    const theme = getColorScheme();
+
+    setThemeProps(() => ({
+      className: theme === "dark" ? darkTheme.className : undefined,
+      style: { colorScheme: theme },
+      "data-theme": theme,
+    }));
+  }, []);
+
+  return themeProps;
 };
 
 /**

--- a/apps/builder/app/shared/theme/theme.ts
+++ b/apps/builder/app/shared/theme/theme.ts
@@ -3,7 +3,7 @@ import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import { darkTheme } from "@webstudio-is/design-system";
 import { restThemePath } from "~/shared/router-utils";
 import type { ColorScheme, ThemeSetting } from "./types";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 // User selected theme setting.
 let setting: ThemeSetting = isFeatureEnabled("dark") ? "system" : "light";
@@ -77,7 +77,7 @@ export const useThemeProps = () => {
     system = data.theme.system;
   }
 
-  const [themeProps, setThemeProps] = useState<{
+  const [themeProps] = useState<{
     className: string | undefined;
     style: { colorScheme: ColorScheme };
     "data-theme": ColorScheme;
@@ -87,6 +87,8 @@ export const useThemeProps = () => {
     "data-theme": "light",
   });
 
+  /*
+  // @todo uncomment when we will decide to use theme
   useEffect(() => {
     const theme = getColorScheme();
 
@@ -96,6 +98,7 @@ export const useThemeProps = () => {
       "data-theme": theme,
     }));
   }, []);
+  */
 
   return themeProps;
 };


### PR DESCRIPTION
## Description

Fixes Error in dev mode on every start or reload

```
react-dom.development.js:67 Warning: Prop `className` did not match. Server: "null" Client: "t-doScVt"
    at html
    at Root (http://localhost:3000/build/_shared/chunk-TNFZIIN2.js:36:22)
 ```

It works because of bug, now without bug it shows
https://github.com/webstudio-is/webstudio-builder/pull/1408

I would comment usetEffect for now



## Steps for reproduction

Run localy, see Error has gone

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
