### PR TITLE
Add public path to local image loader

### DIFF
--- a/apps/builder/.env.example
+++ b/apps/builder/.env.example
@@ -10,6 +10,7 @@ MAX_ASSETS_PER_PROJECT=50
 
 # relative to the public directory
 FILE_UPLOAD_PATH="uploads"
+ASSET_PUBLIC_PATH=/s/uploads/
 
 # Optional max upload size in Mb
 # MAX_UPLOAD_SIZE=10

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-thumbnail.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-thumbnail.tsx
@@ -98,7 +98,9 @@ export const LayerThumbnail = (props: { layerStyle: StyleInfo }) => {
       ? loaders.cloudflareImageLoader({
           resizeOrigin: env.RESIZE_ORIGIN,
         })
-      : loaders.localImageLoader();
+      : loaders.localImageLoader({
+          publicPath: env.ASSET_PUBLIC_PATH,
+        });
 
     return (
       <StyledWebstudioImage

--- a/apps/builder/app/builder/shared/image-manager/image.tsx
+++ b/apps/builder/app/builder/shared/image-manager/image.tsx
@@ -55,7 +55,9 @@ export const Image = ({ assetContainer, alt, width }: ImageProps) => {
       });
     }
 
-    return loaders.localImageLoader();
+    return loaders.localImageLoader({
+      publicPath: env.ASSET_PUBLIC_PATH,
+    });
   }, [remoteLocation]);
 
   return (

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -10,6 +10,7 @@ import {
   idAttribute,
   addGlobalRules,
   createImageValueTransformer,
+  getParams,
 } from "@webstudio-is/react-sdk";
 import type { StyleDecl } from "@webstudio-is/project-build";
 import {
@@ -198,7 +199,9 @@ const addRule = (id: string, cssRule: CssRule, assets: Assets) => {
       ...cssRule,
       style: toVarStyleWithFallback(id, cssRule.style),
     },
-    createImageValueTransformer(assets)
+    createImageValueTransformer(assets, {
+      publicPath: getParams().publicPath,
+    })
   );
   wrappedRulesMap.set(key, rule);
   return rule;

--- a/apps/builder/app/env/env.public.server.ts
+++ b/apps/builder/app/env/env.public.server.ts
@@ -18,6 +18,8 @@ const env = {
   BUILD_REQUIRE_SUBDOMAIN: process.env.BUILD_REQUIRE_SUBDOMAIN === "true",
   // Must be set for Vercel deployments
   RESIZE_ORIGIN: process.env.RESIZE_ORIGIN,
+  // must be set for local setup
+  ASSET_PUBLIC_PATH: process.env.ASSET_PUBLIC_PATH,
 } as const;
 
 export default env;

--- a/apps/builder/app/routes/$.tsx
+++ b/apps/builder/app/routes/$.tsx
@@ -19,6 +19,9 @@ export const loader = async ({ request }: LoaderArgs) => {
   if (env.RESIZE_ORIGIN != null) {
     params.resizeOrigin = env.RESIZE_ORIGIN;
   }
+  if (env.ASSET_PUBLIC_PATH != null) {
+    params.publicPath = env.ASSET_PUBLIC_PATH;
+  }
 
   return { params };
 };

--- a/apps/builder/app/routes/s.css.ts
+++ b/apps/builder/app/routes/s.css.ts
@@ -39,12 +39,17 @@ export const loader = async ({ request }: ActionArgs) => {
       throw json("Page not found", { status: 404 });
     }
 
-    const cssText = generateCssText({
-      assets: canvasData.assets,
-      breakpoints: canvasData.build?.breakpoints,
-      styles: canvasData.build?.styles,
-      styleSourceSelections: canvasData.build?.styleSourceSelections,
-    });
+    const cssText = generateCssText(
+      {
+        assets: canvasData.assets,
+        breakpoints: canvasData.build?.breakpoints,
+        styles: canvasData.build?.styles,
+        styleSourceSelections: canvasData.build?.styleSourceSelections,
+      },
+      {
+        publicPath: env.ASSET_PUBLIC_PATH,
+      }
+    );
 
     const engine = createCssEngine({ name: "ssr" });
     for (const style of helperStyles) {

--- a/packages/asset-uploader/src/utils/get-asset-path.test.ts
+++ b/packages/asset-uploader/src/utils/get-asset-path.test.ts
@@ -38,30 +38,6 @@ describe("getAssetPath", () => {
     process.env = OLD_ENV;
   });
 
-  describe("local", () => {
-    test("returns local path with no custom path", async () => {
-      const { getAssetPath } = await import("./get-asset-path");
-      expect(
-        getAssetPath({
-          ...commonAsset,
-          name: "test.png",
-          location: Location.FS,
-        })
-      ).toBe("/s/uploads/test.png");
-    });
-
-    test("return local path with custom path", async () => {
-      process.env.FILE_UPLOAD_PATH = "assets";
-      const { getAssetPath } = await import("./get-asset-path");
-      expect(
-        getAssetPath({
-          ...commonAsset,
-          name: "test.png",
-          location: Location.FS,
-        })
-      ).toBe("/assets/test.png");
-    });
-  });
   describe("s3", () => {
     test("returns s3 url", async () => {
       process.env.S3_ENDPOINT = "https://fr1.s3.com";

--- a/packages/asset-uploader/src/utils/get-asset-path.ts
+++ b/packages/asset-uploader/src/utils/get-asset-path.ts
@@ -1,20 +1,11 @@
 import { type Asset as DbAsset, Location } from "@webstudio-is/prisma-client";
-import { FsEnv, S3Env } from "../schema";
-import path from "path";
+import { S3Env } from "../schema";
 
 const s3Envs = S3Env.safeParse(process.env);
-const fsEnv = FsEnv.parse(process.env);
 
 export const getAssetPath = (asset: DbAsset) => {
   if (asset.location === Location.FS) {
-    const splitPath = fsEnv.FILE_UPLOAD_PATH.split("public");
-    const url = new URL(
-      path.join("/", splitPath[splitPath.length - 1], asset.name),
-      // Hostname here is not important
-      "http://localhost"
-    );
-
-    return url.pathname;
+    return asset.name;
   }
 
   if (asset.location === Location.REMOTE && s3Envs.success) {

--- a/packages/image/src/image-dev.stories.tsx
+++ b/packages/image/src/image-dev.stories.tsx
@@ -30,7 +30,7 @@ const imageSrc = USE_CLOUDFLARE_IMAGE_TRANSFORM
 
 const imageLoader = USE_CLOUDFLARE_IMAGE_TRANSFORM
   ? loaders.cloudflareImageLoader({ resizeOrigin: "https://webstudio.is" })
-  : loaders.localImageLoader();
+  : loaders.localImageLoader({});
 
 const ImageBase: ComponentStory<
   React.ForwardRefExoticComponent<

--- a/packages/image/src/image-dev.stories.tsx
+++ b/packages/image/src/image-dev.stories.tsx
@@ -30,7 +30,7 @@ const imageSrc = USE_CLOUDFLARE_IMAGE_TRANSFORM
 
 const imageLoader = USE_CLOUDFLARE_IMAGE_TRANSFORM
   ? loaders.cloudflareImageLoader({ resizeOrigin: "https://webstudio.is" })
-  : loaders.localImageLoader({});
+  : loaders.localImageLoader({ publicPath: "" });
 
 const ImageBase: ComponentStory<
   React.ForwardRefExoticComponent<

--- a/packages/image/src/image-loaders.ts
+++ b/packages/image/src/image-loaders.ts
@@ -33,15 +33,20 @@ export const cloudflareImageLoader: (
     }
   };
 
+type LocalImageLoaderOptions = {
+  publicPath?: string;
+};
+
 /**
  * Fake pseudo loader for local testing purposes
  **/
-export const localImageLoader: () => ImageLoader =
-  () =>
+export const localImageLoader =
+  (options: LocalImageLoaderOptions): ImageLoader =>
   ({ width, src, quality }) => {
+    const { publicPath = "/" } = options;
     // Just emulate like we really resize the image
     const params = new URLSearchParams();
     params.set("width", `${width}`);
     params.set("quality", `${quality}`);
-    return `${src}?${params.toString()}`;
+    return `${publicPath}${src}?${params.toString()}`;
   };

--- a/packages/react-sdk/src/app/custom-components/image.tsx
+++ b/packages/react-sdk/src/app/custom-components/image.tsx
@@ -25,7 +25,7 @@ export const Image = forwardRef<ElementRef<typeof defaultTag>, Props>(
       if (asset.location === "REMOTE") {
         return loaders.cloudflareImageLoader(params);
       }
-      return loaders.localImageLoader();
+      return loaders.localImageLoader(params);
     }, [asset, params]);
 
     let src = props.src;

--- a/packages/react-sdk/src/app/params.ts
+++ b/packages/react-sdk/src/app/params.ts
@@ -1,5 +1,6 @@
 export type Params = {
   resizeOrigin?: string;
+  publicPath?: string;
 };
 
 let params: Params | null = {};

--- a/packages/react-sdk/src/css/css.ts
+++ b/packages/react-sdk/src/css/css.ts
@@ -14,26 +14,36 @@ type Data = {
   styleSourceSelections?: Build["styleSourceSelections"];
 };
 
+type CssOptions = {
+  publicPath?: string;
+};
+
 export const createImageValueTransformer =
-  (assets: Assets): TransformValue =>
+  (assets: Assets, options: CssOptions): TransformValue =>
   (styleValue) => {
     if (styleValue.type === "image" && styleValue.value.type === "asset") {
       const asset = assets.get(styleValue.value.value);
       if (asset === undefined) {
         return { type: "keyword", value: "none" };
       }
+
+      // @todo reuse image loaders and generate image-set
+      const { publicPath = "/" } = options;
+      let url =
+        asset.location === "REMOTE" ? asset.path : `${publicPath}${asset.name}`;
+
       return {
         type: "image",
         value: {
           type: "url",
-          url: asset.path,
+          url,
         },
         hidden: styleValue.hidden,
       };
     }
   };
 
-export const generateCssText = (data: Data) => {
+export const generateCssText = (data: Data, options: CssOptions) => {
   const assets = new Map<Asset["id"], Asset>(
     data.assets.map((asset) => [asset.id, asset])
   );
@@ -72,7 +82,7 @@ export const generateCssText = (data: Data) => {
         breakpoint: breakpointId,
         style,
       },
-      createImageValueTransformer(assets)
+      createImageValueTransformer(assets, options)
     );
   }
 

--- a/packages/react-sdk/src/css/css.ts
+++ b/packages/react-sdk/src/css/css.ts
@@ -29,7 +29,7 @@ export const createImageValueTransformer =
 
       // @todo reuse image loaders and generate image-set
       const { publicPath = "/" } = options;
-      let url =
+      const url =
         asset.location === "REMOTE" ? asset.path : `${publicPath}${asset.name}`;
 
       return {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1179

Added ASSET_PUBLIC_PATH env for local development
and publicPath option in local image loader.

Now fs asset client provides name as path without modification on server side.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
