### PR TITLE
UX improvement for Inputs that have both keywords and units

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/convert-units.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/convert-units.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from "@jest/globals";
+import { convertUnits } from "./convert-units";
+
+const unitSizes = {
+  ch: 8,
+  vw: 3.2,
+  vh: 4.8,
+  em: 14,
+  rem: 16,
+  px: 1,
+};
+
+describe("Evaluate math", () => {
+  test("convert same units", () => {
+    expect(convertUnits(unitSizes)(100, "px", "px")).toEqual(100);
+    expect(convertUnits(unitSizes)(100, "deg", "deg")).toEqual(100);
+  });
+
+  test("do nothing if can't convert", () => {
+    expect(convertUnits(unitSizes)(100, "deg", "rad")).toEqual(100);
+  });
+
+  test("convert size units", () => {
+    expect(convertUnits(unitSizes)(224, "px", "em")).toEqual(16);
+    expect(convertUnits(unitSizes)(16, "em", "px")).toEqual(224);
+
+    expect(convertUnits(unitSizes)(16, "em", "rem")).toEqual(14);
+    expect(convertUnits(unitSizes)(14, "rem", "em")).toEqual(16);
+
+    expect(convertUnits(unitSizes)(320, "px", "vw")).toEqual(100);
+    expect(convertUnits(unitSizes)(480, "px", "vh")).toEqual(100);
+
+    expect(convertUnits(unitSizes)(100, "vw", "rem")).toEqual(20);
+  });
+});

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/convert-units.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/convert-units.ts
@@ -1,5 +1,4 @@
 import type { Unit } from "@webstudio-is/css-data";
-// import { selectedInstanceUnitSizesStore } from "~/shared/nano-states";
 
 const convertibleUnits = ["px", "ch", "vw", "vh", "em", "rem"] as const;
 

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/convert-units.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/convert-units.ts
@@ -1,0 +1,29 @@
+import type { Unit } from "@webstudio-is/css-data";
+// import { selectedInstanceUnitSizesStore } from "~/shared/nano-states";
+
+const convertibleUnits = ["px", "ch", "vw", "vh", "em", "rem"] as const;
+
+type ConvertibleUnit = (typeof convertibleUnits)[number];
+
+export type UnitSizes = Record<ConvertibleUnit, number>;
+
+const isConvertibleUnit = (unit: Unit): unit is ConvertibleUnit =>
+  convertibleUnits.includes(unit as ConvertibleUnit);
+
+export const convertUnits =
+  (unitSizes: UnitSizes) =>
+  (value: number, from: Unit, to: Unit): number => {
+    if (from === to) {
+      return value;
+    }
+
+    if (!isConvertibleUnit(from)) {
+      return value;
+    }
+
+    if (!isConvertibleUnit(to)) {
+      return value;
+    }
+
+    return (value * unitSizes[from]) / unitSizes[to];
+  };

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/convert-units.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/convert-units.ts
@@ -16,13 +16,8 @@ export const convertUnits =
       return value;
     }
 
-    if (!isConvertibleUnit(from)) {
-      return value;
+    if (isConvertibleUnit(from) && isConvertibleUnit(to)) {
+      return (value * unitSizes[from]) / unitSizes[to];
     }
-
-    if (!isConvertibleUnit(to)) {
-      return value;
-    }
-
-    return (value * unitSizes[from]) / unitSizes[to];
+    return value;
   };

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -35,6 +35,11 @@ import { useDebouncedCallback } from "use-debounce";
 import type { StyleSource } from "../style-info";
 import { toPascalCase } from "../keyword-utils";
 import { isValid } from "../parse-css-value";
+import {
+  selectedInstanceBrowserStyleStore,
+  selectedInstanceUnitSizesStore,
+} from "~/shared/nano-states";
+import { convertUnits } from "./convert-units";
 
 // We increment by 10 when shift is pressed, by 0.1 when alt/option is pressed and by 1 by default.
 const calcNumberChange = (
@@ -381,13 +386,72 @@ export const CssValueInput = ({
         ? value.unit
         : undefined,
     onChange: (unit) => {
-      if (value.type === "unit" || value.type === "intermediate") {
+      // Value edited by user, value looks like a number, then Unit has changed, no need in any conversions.
+      if (
+        value.type === "intermediate" &&
+        Number.isNaN(Number.parseFloat(value.value)) === false
+      ) {
         onChangeComplete({ ...value, unit }, "unit-select");
         return;
       }
 
+      const unitSizes = selectedInstanceUnitSizesStore.get();
+
+      // Value not edited by the user, we need to convert it to the new unit
+      if (value.type === "unit") {
+        const convertedValue = convertUnits(unitSizes)(
+          value.value,
+          value.unit,
+          unit
+        );
+
+        onChangeComplete(
+          {
+            type: "unit",
+            value: Number.parseFloat(convertedValue.toFixed(2)),
+            unit,
+          },
+          "unit-select"
+        );
+        return;
+      }
+
+      if (value.type === "keyword" || value.type === "intermediate") {
+        // try to convert browser style, otherwise set to 0
+        const browserStyle = selectedInstanceBrowserStyleStore.get();
+        const browserPropertyValue = browserStyle?.[property];
+        const propertyValue =
+          browserPropertyValue?.type === "unit"
+            ? browserPropertyValue.value
+            : 0;
+        const propertyUnit =
+          browserPropertyValue?.type === "unit"
+            ? browserPropertyValue.unit
+            : "number";
+
+        const convertedValue = convertUnits(unitSizes)(
+          propertyValue,
+          propertyUnit,
+          unit
+        );
+
+        onChangeComplete(
+          {
+            type: "unit",
+            value: Number.parseFloat(convertedValue.toFixed(2)),
+            unit,
+          },
+          "unit-select"
+        );
+        return;
+      }
+
       onChangeComplete(
-        { type: "intermediate", value: toValue(value), unit },
+        {
+          type: "intermediate",
+          value: toValue(value),
+          unit,
+        },
         "unit-select"
       );
     },
@@ -480,10 +544,13 @@ export const CssValueInput = ({
       <ChevronDownIcon />
     </NestedSelectButton>
   );
+
+  const isUnitValue = unitSelectElement !== null;
+
   const hasItems = items.length !== 0;
-  const isUnitValue = "unit" in value;
   const isKeywordValue = value.type === "keyword" && hasItems;
   const suffixRef = useRef<HTMLDivElement | null>(null);
+
   const suffix = (
     <Box ref={suffixRef}>
       {isUnitValue

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -386,7 +386,8 @@ export const CssValueInput = ({
         ? value.unit
         : undefined,
     onChange: (unit) => {
-      // Value edited by user, value looks like a number, then Unit has changed, no need in any conversions.
+      // value looks like a number and just edited (type === "intermediate")
+      // no additional conversions are necessary
       if (
         value.type === "intermediate" &&
         Number.isNaN(Number.parseFloat(value.value)) === false
@@ -416,8 +417,8 @@ export const CssValueInput = ({
         return;
       }
 
+      // value is a keyword or non numeric, try get browser style value and convert it
       if (value.type === "keyword" || value.type === "intermediate") {
-        // try to convert browser style, otherwise set to 0
         const browserStyle = selectedInstanceBrowserStyleStore.get();
         const browserPropertyValue = browserStyle?.[property];
         const propertyValue =

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/unit-select.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/unit-select.tsx
@@ -70,12 +70,13 @@ export const useUnitSelect = ({
 
   const select = (
     <UnitSelect
-      value={value ?? options[0].id}
+      value={value}
       options={options}
       open={isOpen}
       onCloseAutoFocus={onCloseAutoFocus}
       onOpenChange={setIsOpen}
       onChange={onChange}
+      labelFallback={options[0].label}
     />
   );
 
@@ -84,11 +85,12 @@ export const useUnitSelect = ({
 
 type UnitSelectProps = {
   options: Array<UnitOption>;
-  value: string;
+  value?: string | undefined;
   onChange: (value: Unit) => void;
   onOpenChange: (open: boolean) => void;
   onCloseAutoFocus: (event: Event) => void;
   open: boolean;
+  labelFallback: string;
 };
 
 const UnitSelect = ({
@@ -98,6 +100,7 @@ const UnitSelect = ({
   onOpenChange,
   onCloseAutoFocus,
   open,
+  labelFallback,
 }: UnitSelectProps) => {
   const matchedOption = options.find((item) => item.id === value);
   return (
@@ -111,7 +114,9 @@ const UnitSelect = ({
         <NestedSelectButton tabIndex={-1}>
           <SelectPrimitive.Value>
             {matchedOption?.label ??
-              (value === "number" ? nestedSelectButtonUnitless : value)}
+              (value === "number"
+                ? nestedSelectButtonUnitless
+                : value ?? labelFallback)}
           </SelectPrimitive.Value>
         </NestedSelectButton>
       </SelectPrimitive.SelectTrigger>

--- a/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
+++ b/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
@@ -8,6 +8,7 @@ import {
   rootInstanceContainer,
   selectedInstanceBrowserStyleStore,
   selectedInstanceIntanceToTagStore,
+  selectedInstanceUnitSizesStore,
 } from "~/shared/nano-states";
 import htmlTags, { type htmlTags as HtmlTags } from "html-tags";
 import { getAllElementsBoundingBox } from "~/shared/dom-utils";
@@ -26,6 +27,39 @@ const setOutline = (instanceId: Instance["id"], element: HTMLElement) => {
 
 const hideOutline = () => {
   selectedInstanceOutlineStore.set(undefined);
+};
+
+const calculateUnitSizes = (element: HTMLElement) => {
+  // https://stackoverflow.com/questions/1248081/how-to-get-the-browser-viewport-dimensions/8876069#8876069
+  const vw =
+    Math.max(document.documentElement.clientWidth, window.innerWidth) / 100;
+  const vh =
+    Math.max(document.documentElement.clientHeight, window.innerHeight) / 100;
+
+  const em = Number.parseFloat(getComputedStyle(element).fontSize);
+
+  const rem = Number.parseFloat(
+    getComputedStyle(document.documentElement).fontSize
+  );
+
+  const node = document.createElement("div");
+  node.style.width = "1ch";
+  node.style.position = "absolute";
+
+  element.appendChild(node);
+
+  const ch = Number.parseFloat(getComputedStyle(node).width);
+
+  element.removeChild(node);
+
+  return {
+    ch,
+    vw,
+    vh,
+    em,
+    rem,
+    px: 1,
+  };
 };
 
 export const SelectedInstanceConnector = ({
@@ -111,6 +145,9 @@ export const SelectedInstanceConnector = ({
     }
 
     selectedInstanceIntanceToTagStore.set(instanceToTag);
+
+    const unitSizes = calculateUnitSizes(element);
+    selectedInstanceUnitSizesStore.set(unitSizes);
 
     return () => {
       hideOutline();

--- a/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
+++ b/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
@@ -30,26 +30,27 @@ const hideOutline = () => {
 };
 
 const calculateUnitSizes = (element: HTMLElement) => {
-  // https://stackoverflow.com/questions/1248081/how-to-get-the-browser-viewport-dimensions/8876069#8876069
+  // Based on this https://stackoverflow.com/questions/1248081/how-to-get-the-browser-viewport-dimensions/8876069#8876069
+  // this is crossbrowser way to get viewport sizes vw vh in px
   const vw =
     Math.max(document.documentElement.clientWidth, window.innerWidth) / 100;
   const vh =
     Math.max(document.documentElement.clientHeight, window.innerHeight) / 100;
 
+  // em is equal to current computed style for font size
   const em = Number.parseFloat(getComputedStyle(element).fontSize);
 
+  // rem is equal to root computed style for font size
   const rem = Number.parseFloat(
     getComputedStyle(document.documentElement).fontSize
   );
 
+  // we create a node with 1ch width, measure it and remove it
   const node = document.createElement("div");
   node.style.width = "1ch";
   node.style.position = "absolute";
-
   element.appendChild(node);
-
   const ch = Number.parseFloat(getComputedStyle(node).width);
-
   element.removeChild(node);
 
   return {

--- a/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
+++ b/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
@@ -14,6 +14,7 @@ import htmlTags, { type htmlTags as HtmlTags } from "html-tags";
 import { getAllElementsBoundingBox } from "~/shared/dom-utils";
 import { subscribeScrollState } from "~/canvas/shared/scroll-state";
 import { selectedInstanceOutlineStore } from "~/shared/nano-states";
+import type { UnitSizes } from "~/builder/features/style-panel/shared/css-value-input/convert-units";
 
 const isHtmlTag = (tag: string): tag is HtmlTags =>
   htmlTags.includes(tag as HtmlTags);
@@ -29,7 +30,7 @@ const hideOutline = () => {
   selectedInstanceOutlineStore.set(undefined);
 };
 
-const calculateUnitSizes = (element: HTMLElement) => {
+const calculateUnitSizes = (element: HTMLElement): UnitSizes => {
   // Based on this https://stackoverflow.com/questions/1248081/how-to-get-the-browser-viewport-dimensions/8876069#8876069
   // this is crossbrowser way to get viewport sizes vw vh in px
   const vw =
@@ -37,15 +38,15 @@ const calculateUnitSizes = (element: HTMLElement) => {
   const vh =
     Math.max(document.documentElement.clientHeight, window.innerHeight) / 100;
 
-  // em is equal to current computed style for font size
+  // em in px is equal to current computed style for font size
   const em = Number.parseFloat(getComputedStyle(element).fontSize);
 
-  // rem is equal to root computed style for font size
+  // rem in px is equal to root computed style for font size
   const rem = Number.parseFloat(
     getComputedStyle(document.documentElement).fontSize
   );
 
-  // we create a node with 1ch width, measure it and remove it
+  // we create a node with 1ch width, measure it in px and remove it
   const node = document.createElement("div");
   node.style.width = "1ch";
   node.style.position = "absolute";
@@ -54,12 +55,12 @@ const calculateUnitSizes = (element: HTMLElement) => {
   element.removeChild(node);
 
   return {
-    ch,
-    vw,
-    vh,
-    em,
-    rem,
-    px: 1,
+    ch, // 1ch in pixels
+    vw, // 1vw in pixels
+    vh, // 1vh in pixels
+    em, // 1em in pixels
+    rem, // 1rem in pixels
+    px: 1, // always 1, simplifies conversions and types, i.e valueTo = valueFrom * unitSizes[from] / unitSizes[to]
   };
 };
 

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -31,6 +31,7 @@ import {
   selectedInstanceSelectorStore,
 } from "./instances";
 import { selectedPageStore } from "./pages";
+import type { UnitSizes } from "~/builder/features/style-panel/shared/css-value-input/convert-units";
 
 const useValue = <T>(atom: WritableAtom<T>) => {
   const value = useStore(atom);
@@ -211,6 +212,16 @@ export const useSetAssets = (assets: [Asset["id"], Asset][]) => {
 };
 
 export const selectedInstanceBrowserStyleStore = atom<undefined | Style>();
+
+// Init with some defaults to avoid undefined
+export const selectedInstanceUnitSizesStore = atom<UnitSizes>({
+  ch: 8,
+  vw: 3.2,
+  vh: 4.8,
+  em: 16,
+  rem: 16,
+  px: 1,
+});
 
 /**
  * instanceId => tagName store for selected instance and its ancestors

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -15,6 +15,7 @@ import {
   selectedPageIdStore,
   selectedInstanceSelectorStore,
   selectedInstanceBrowserStyleStore,
+  selectedInstanceUnitSizesStore,
   selectedInstanceIntanceToTagStore,
   hoveredInstanceSelectorStore,
   isPreviewModeStore,
@@ -70,6 +71,10 @@ export const registerContainers = () => {
   clientStores.set(
     "selectedInstanceIntanceToTagStore",
     selectedInstanceIntanceToTagStore
+  );
+  clientStores.set(
+    "selectedInstanceUnitSizesStore",
+    selectedInstanceUnitSizesStore
   );
 
   clientStores.set("hoveredInstanceSelector", hoveredInstanceSelectorStore);

--- a/packages/design-system/src/components/input-field.tsx
+++ b/packages/design-system/src/components/input-field.tsx
@@ -193,8 +193,8 @@ export const InputField = forwardRef(
     // Our input field can contain multiple focused elements,
     // so we need to use useFocusWithin to track focus within the container.
     const { focusWithinProps } = useFocusWithin({
-      onFocusWithin: (e) => onFocus?.(e),
-      onBlurWithin: (e) => onBlur?.(e),
+      onFocusWithin: onFocus,
+      onBlurWithin: onBlur,
     });
 
     return (

--- a/packages/design-system/src/components/input-field.tsx
+++ b/packages/design-system/src/components/input-field.tsx
@@ -8,11 +8,13 @@ import {
   type ReactNode,
   type ComponentProps,
   type Ref,
+  type FocusEvent,
 } from "react";
 import { textVariants } from "./text";
 import { css, theme, type CSS } from "../stitches.config";
 import { ArrowFocus } from "./primitives/arrow-focus";
 import { mergeRefs } from "@react-aria/utils";
+import { useFocusWithin } from "@react-aria/interactions";
 
 // we only support types that behave more or less like a regular text input
 export const inputFieldTypes = [
@@ -147,7 +149,7 @@ type InputProps = {
   type?: (typeof inputFieldTypes)[number];
   color?: (typeof inputFieldColors)[number];
   css?: CSS;
-} & Omit<ComponentProps<"input">, "prefix">;
+} & Omit<ComponentProps<"input">, "prefix" | "onFocus" | "onBlur">;
 
 const Input = forwardRef(
   (
@@ -175,24 +177,38 @@ export const InputField = forwardRef(
       suffix,
       containerRef,
       inputRef,
+      onFocus,
+      onBlur,
       ...props
     }: InputProps & {
       prefix?: ReactNode;
       suffix?: ReactNode;
       containerRef?: Ref<HTMLDivElement>;
       inputRef?: Ref<HTMLInputElement>;
+      onFocus?: (e: FocusEvent) => void;
+      onBlur?: (e: FocusEvent) => void;
     },
     ref: Ref<HTMLDivElement>
-  ) => (
-    <Container
-      css={css}
-      className={className}
-      prefix={prefix}
-      suffix={suffix}
-      ref={mergeRefs(ref, containerRef ?? null)}
-    >
-      <Input {...props} ref={inputRef} />
-    </Container>
-  )
+  ) => {
+    // Our input field can contain multiple focused elements,
+    // so we need to use useFocusWithin to track focus within the container.
+    const { focusWithinProps } = useFocusWithin({
+      onFocusWithin: (e) => onFocus?.(e),
+      onBlurWithin: (e) => onBlur?.(e),
+    });
+
+    return (
+      <Container
+        css={css}
+        className={className}
+        prefix={prefix}
+        suffix={suffix}
+        {...focusWithinProps}
+        ref={mergeRefs(ref, containerRef ?? null)}
+      >
+        <Input {...props} ref={inputRef} />
+      </Container>
+    );
+  }
 );
 InputField.displayName = "InputField";


### PR DESCRIPTION
## Description

closes #956

+ In case if user not edited the value but immediately clicked to unit select we are trying to convert em px etc values

## Steps for reproduction

1. Edit `width` value, enter 10
go to unit select set `em` - see 10em as final result

2. Click on unit select of the width, change em to px see 10em converted to 140px or like (depends on em size)

3. Enter `Auto` in width, click Enter. 
Click on UnitSelect select EM, see browser style is used to set em width.

4. Enter Auto in width, switch on Unit select, set px, see browser style is used.

5. See that now unit selector is visible always. With some exclusions like aspectRatio as it has keywords and numeric values.




## Code Review

- [x] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
