### PR TITLE
Speedup add remove nodes

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
@@ -160,6 +160,7 @@ export const useDraggable = ({
       // fallback to root as drop target
       selectedInstanceSelectorStore.get() ?? [selectedPage.rootInstanceId]
     );
+
     insertNewComponentInstance(component, dropTarget);
   };
 

--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -49,7 +49,10 @@ export const NavigatorTree = () => {
 
   const handleSelect = useCallback((instanceSelector: InstanceSelector) => {
     // @todo for unknown reason handleSelect is called during "delete" hot key
-    if (!shallowEqual(selectedInstanceSelectorStore.get(), instanceSelector)) {
+    if (
+      shallowEqual(selectedInstanceSelectorStore.get(), instanceSelector) ===
+      false
+    ) {
       selectedInstanceSelectorStore.set(instanceSelector);
       textEditingInstanceSelectorStore.set(undefined);
     }

--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -48,7 +48,9 @@ export const NavigatorTree = () => {
   );
 
   const handleSelect = useCallback((instanceSelector: InstanceSelector) => {
-    // @todo for unknown reason handleSelect is called during "delete" hot key
+    // TreeNode is refocused during "delete" hot key here https://github.com/webstudio-is/webstudio-builder/blob/5935d7818fba3739e4f16fe710ea468bf9d0ac78/packages/design-system/src/components/tree/tree.tsx#L435
+    // and then focus cause handleSelect to be called with the same instanceSelector
+    // This avoids additional rerender on node delete
     if (
       shallowEqual(selectedInstanceSelectorStore.get(), instanceSelector) ===
       false

--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -12,6 +12,7 @@ import {
 import type { InstanceSelector } from "~/shared/tree-utils";
 import { reparentInstance } from "~/shared/instance-utils";
 import { InstanceTree } from "./tree";
+import { shallowEqual } from "shallow-equal";
 
 export const NavigatorTree = () => {
   const selectedInstanceSelector = useStore(selectedInstanceSelectorStore);
@@ -47,8 +48,11 @@ export const NavigatorTree = () => {
   );
 
   const handleSelect = useCallback((instanceSelector: InstanceSelector) => {
-    selectedInstanceSelectorStore.set(instanceSelector);
-    textEditingInstanceSelectorStore.set(undefined);
+    // @todo for unknown reason handleSelect is called during "delete" hot key
+    if (!shallowEqual(selectedInstanceSelectorStore.get(), instanceSelector)) {
+      selectedInstanceSelectorStore.set(instanceSelector);
+      textEditingInstanceSelectorStore.set(undefined);
+    }
   }, []);
 
   if (rootInstance === undefined) {

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -18,117 +18,127 @@ import {
   getAncestorInstanceSelector,
 } from "./tree-utils";
 import { removeByMutable } from "./array-utils";
+import { unstable_batchedUpdates as batchedUpdates } from "react-dom";
 
 export const insertNewComponentInstance = (
   component: string,
   dropTarget: DroppableTarget
 ) => {
-  const instance = createComponentInstance(component);
-  store.createTransaction([instancesStore], (instances) => {
-    insertInstancesMutable(instances, [instance], [instance.id], dropTarget);
+  batchedUpdates(() => {
+    const instance = createComponentInstance(component);
+    store.createTransaction([instancesStore], (instances) => {
+      insertInstancesMutable(instances, [instance], [instance.id], dropTarget);
+    });
+
+    selectedInstanceSelectorStore.set([
+      instance.id,
+      ...dropTarget.parentSelector,
+    ]);
   });
-  selectedInstanceSelectorStore.set([
-    instance.id,
-    ...dropTarget.parentSelector,
-  ]);
 };
 
 export const reparentInstance = (
   targetInstanceSelector: InstanceSelector,
   dropTarget: DroppableTarget
 ) => {
-  store.createTransaction([instancesStore], (instances) => {
-    reparentInstanceMutable(instances, targetInstanceSelector, dropTarget);
+  batchedUpdates(() => {
+    store.createTransaction([instancesStore], (instances) => {
+      reparentInstanceMutable(instances, targetInstanceSelector, dropTarget);
+    });
+    selectedInstanceSelectorStore.set(targetInstanceSelector);
   });
-  selectedInstanceSelectorStore.set(targetInstanceSelector);
 };
 
 export const deleteInstance = (instanceSelector: InstanceSelector) => {
-  store.createTransaction(
-    [
-      instancesStore,
-      propsStore,
-      styleSourceSelectionsStore,
-      styleSourcesStore,
-      stylesStore,
-    ],
-    (instances, props, styleSourceSelections, styleSources, styles) => {
-      let targetInstanceId = instanceSelector[0];
-      const parentInstanceId = instanceSelector[1];
-      const grandparentInstanceId = instanceSelector[2];
-      let parentInstance =
-        parentInstanceId === undefined
-          ? undefined
-          : instances.get(parentInstanceId);
+  batchedUpdates(() => {
+    store.createTransaction(
+      [
+        instancesStore,
+        propsStore,
+        styleSourceSelectionsStore,
+        styleSourcesStore,
+        stylesStore,
+      ],
+      (instances, props, styleSourceSelections, styleSources, styles) => {
+        let targetInstanceId = instanceSelector[0];
+        const parentInstanceId = instanceSelector[1];
+        const grandparentInstanceId = instanceSelector[2];
+        let parentInstance =
+          parentInstanceId === undefined
+            ? undefined
+            : instances.get(parentInstanceId);
 
-      // delete parent fragment too if its last child is going to be deleted
-      // use case for slots: slot became empty and remove display: contents
-      // to be displayed properly on canvas
-      if (
-        parentInstance?.component === "Fragment" &&
-        parentInstance.children.length === 1 &&
-        grandparentInstanceId !== undefined
-      ) {
-        targetInstanceId = parentInstance.id;
-        parentInstance = instances.get(grandparentInstanceId);
-      }
+        // delete parent fragment too if its last child is going to be deleted
+        // use case for slots: slot became empty and remove display: contents
+        // to be displayed properly on canvas
+        if (
+          parentInstance?.component === "Fragment" &&
+          parentInstance.children.length === 1 &&
+          grandparentInstanceId !== undefined
+        ) {
+          targetInstanceId = parentInstance.id;
+          parentInstance = instances.get(grandparentInstanceId);
+        }
 
-      const subtreeIds = findTreeInstanceIdsExcludingSlotDescendants(
-        instances,
-        targetInstanceId
-      );
-      const subtreeLocalStyleSourceIds = findSubtreeLocalStyleSources(
-        subtreeIds,
-        styleSources,
-        styleSourceSelections
-      );
-
-      // may not exist when delete root
-      if (parentInstance) {
-        removeByMutable(
-          parentInstance.children,
-          (child) => child.type === "id" && child.value === targetInstanceId
+        const subtreeIds = findTreeInstanceIdsExcludingSlotDescendants(
+          instances,
+          targetInstanceId
         );
-      }
+        const subtreeLocalStyleSourceIds = findSubtreeLocalStyleSources(
+          subtreeIds,
+          styleSources,
+          styleSourceSelections
+        );
 
-      for (const instanceId of subtreeIds) {
-        instances.delete(instanceId);
-      }
-      // delete props and styles of deleted instance and its descendants
-      for (const prop of props.values()) {
-        if (subtreeIds.has(prop.instanceId)) {
-          props.delete(prop.id);
+        // may not exist when delete root
+        if (parentInstance) {
+          removeByMutable(
+            parentInstance.children,
+            (child) => child.type === "id" && child.value === targetInstanceId
+          );
+        }
+
+        for (const instanceId of subtreeIds) {
+          instances.delete(instanceId);
+        }
+        // delete props and styles of deleted instance and its descendants
+        for (const prop of props.values()) {
+          if (subtreeIds.has(prop.instanceId)) {
+            props.delete(prop.id);
+          }
+        }
+        for (const instanceId of subtreeIds) {
+          styleSourceSelections.delete(instanceId);
+        }
+        for (const styleSourceId of subtreeLocalStyleSourceIds) {
+          styleSources.delete(styleSourceId);
+        }
+        for (const [styleDeclKey, styleDecl] of styles) {
+          if (subtreeLocalStyleSourceIds.has(styleDecl.styleSourceId)) {
+            styles.delete(styleDeclKey);
+          }
+        }
+
+        if (parentInstance) {
+          selectedInstanceSelectorStore.set(
+            getAncestorInstanceSelector(instanceSelector, parentInstance.id)
+          );
         }
       }
-      for (const instanceId of subtreeIds) {
-        styleSourceSelections.delete(instanceId);
-      }
-      for (const styleSourceId of subtreeLocalStyleSourceIds) {
-        styleSources.delete(styleSourceId);
-      }
-      for (const [styleDeclKey, styleDecl] of styles) {
-        if (subtreeLocalStyleSourceIds.has(styleDecl.styleSourceId)) {
-          styles.delete(styleDeclKey);
-        }
-      }
-
-      if (parentInstance) {
-        selectedInstanceSelectorStore.set(
-          getAncestorInstanceSelector(instanceSelector, parentInstance.id)
-        );
-      }
-    }
-  );
+    );
+  });
 };
 
 export const deleteSelectedInstance = () => {
-  const selectedInstanceSelector = selectedInstanceSelectorStore.get();
-  // @todo tell user they can't delete root
-  if (
-    selectedInstanceSelector === undefined ||
-    selectedInstanceSelector.length === 1
-  ) {
-    return;
-  }
-  deleteInstance(selectedInstanceSelector);
+  batchedUpdates(() => {
+    const selectedInstanceSelector = selectedInstanceSelectorStore.get();
+    // @todo tell user they can't delete root
+    if (
+      selectedInstanceSelector === undefined ||
+      selectedInstanceSelector.length === 1
+    ) {
+      return;
+    }
+    deleteInstance(selectedInstanceSelector);
+  });
 };


### PR DESCRIPTION
## Description

Reduces amount of renders from 6 to 2 on addding/deleting instances

Reduction to 1 render is impossible in our current architecture as following situation happens.

On add node, we set selectedInstanceSelectorStore from the builder, what cause 

In the canvas "SelectedInstanceConnector" sets computed styles etc and sync back. Both are causing double rendering.

Can be avoided in the future allowing to set store from the builder in a canvas.


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
