### PR TITLE
Switch canvas and published rendering to normalized instances

### DIFF
--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -2,7 +2,7 @@ import { useMemo, Fragment, useEffect } from "react";
 import { useStore } from "@nanostores/react";
 import { computed } from "nanostores";
 import type { Params } from "@webstudio-is/react-sdk";
-import type { Instance, Page } from "@webstudio-is/project-build";
+import type { Instances, Page } from "@webstudio-is/project-build";
 import {
   createElementsTree,
   registerComponents,
@@ -24,7 +24,6 @@ import {
   propsIndexStore,
   assetsStore,
   pagesStore,
-  useRootInstance,
   instancesStore,
   useIsPreviewMode,
   selectedPageStore,
@@ -44,21 +43,28 @@ const propsByInstanceIdStore = computed(
   (propsIndex) => propsIndex.propsByInstanceId
 );
 
-const temporaryRootInstance: Instance = {
-  type: "instance",
-  id: "temporaryRootInstance",
-  component: "Body",
-  children: [],
-};
+const temporaryRootInstanceId = "temporaryRootInstance";
+const temporaryInstances: Instances = new Map([
+  [
+    temporaryRootInstanceId,
+    {
+      type: "instance",
+      id: temporaryRootInstanceId,
+      component: "Body",
+      children: [],
+    },
+  ],
+]);
 
 const useElementsTree = (getComponent: GetComponent) => {
-  const [rootInstance] = useRootInstance();
+  const instances = useStore(instancesStore);
+  const page = useStore(selectedPageStore);
+  const rootInstanceId = page?.rootInstanceId;
 
   if (typeof window === "undefined") {
     // @todo remove after https://github.com/webstudio-is/webstudio-builder/issues/1313 now its needed to be sure that no leaks exists
     // eslint-disable-next-line no-console
     console.log({
-      rootInstance,
       assetsStore: assetsStore.get().size,
       pagesStore: pagesStore.get()?.pages.length ?? 0,
       instancesStore: instancesStore.get().size,
@@ -81,16 +87,17 @@ const useElementsTree = (getComponent: GetComponent) => {
   return useMemo(() => {
     return createElementsTree({
       sandbox: true,
+      instances: instances.size === 0 ? temporaryInstances : instances,
       // fallback to temporary root instance to render scripts
       // and receive real data from builder
-      instance: rootInstance ?? temporaryRootInstance,
+      rootInstanceId: rootInstanceId ?? temporaryRootInstanceId,
       propsByInstanceIdStore,
       assetsStore,
       pagesStore: pagesMapStore,
       Component: WebstudioComponentDev,
       getComponent,
     });
-  }, [rootInstance, getComponent, pagesMapStore]);
+  }, [rootInstanceId, getComponent, pagesMapStore]);
 };
 
 const DesignMode = () => {

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -97,7 +97,7 @@ const useElementsTree = (getComponent: GetComponent) => {
       Component: WebstudioComponentDev,
       getComponent,
     });
-  }, [rootInstanceId, getComponent, pagesMapStore]);
+  }, [instances, rootInstanceId, getComponent, pagesMapStore]);
 };
 
 const DesignMode = () => {

--- a/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
+++ b/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
@@ -1,6 +1,11 @@
 import { useEffect } from "react";
 import { useStore } from "@nanostores/react";
-import type { Instance, Prop, StyleDecl } from "@webstudio-is/project-build";
+import type {
+  Instance,
+  InstancesItem,
+  Prop,
+  StyleDecl,
+} from "@webstudio-is/project-build";
 import { getBrowserStyle, idAttribute } from "@webstudio-is/react-sdk";
 import { subscribe } from "~/shared/pubsub";
 import { subscribeWindowResize } from "~/shared/dom-hooks";
@@ -71,7 +76,7 @@ export const SelectedInstanceConnector = ({
   instanceProps,
 }: {
   instanceElementRef: { current: undefined | HTMLElement };
-  instance: Instance;
+  instance: InstancesItem;
   instanceStyles: StyleDecl[];
   instanceProps: undefined | Prop[];
 }) => {

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -8,6 +8,7 @@ import {
   type Prop,
   findTreeInstanceIds,
   Instances,
+  type InstancesItem,
 } from "@webstudio-is/project-build";
 import {
   renderWebstudioComponentChildren,
@@ -87,7 +88,7 @@ const getInstanceSelector = (
 };
 
 type WebstudioComponentDevProps = {
-  instance: Instance;
+  instance: InstancesItem;
   instanceSelector: InstanceSelector;
   children: Array<JSX.Element | string>;
   getComponent: GetComponent;

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -25,11 +25,7 @@ import { shallowComputed } from "../store-utils";
 import { type InstanceSelector } from "../tree-utils";
 import type { htmlTags as HtmlTags } from "html-tags";
 import { breakpointsStore } from "./breakpoints";
-import {
-  instancesStore,
-  rootInstanceContainer,
-  selectedInstanceSelectorStore,
-} from "./instances";
+import { instancesStore, selectedInstanceSelectorStore } from "./instances";
 import { selectedPageStore } from "./pages";
 import type { UnitSizes } from "~/builder/features/style-panel/shared/css-value-input/convert-units";
 
@@ -47,11 +43,6 @@ export const rootInstanceStore = computed(
     return instances.get(selectedPage.rootInstanceId);
   }
 );
-
-export const useRootInstance = () => {
-  const value = useStore(rootInstanceContainer);
-  return [value] as const;
-};
 
 export const propsStore = atom<Props>(new Map());
 export const propsIndexStore = computed(propsStore, (props) => {

--- a/packages/react-sdk/src/tree/root.ts
+++ b/packages/react-sdk/src/tree/root.ts
@@ -1,12 +1,6 @@
 import type { ComponentProps } from "react";
 import { atom } from "nanostores";
-import type {
-  Build,
-  Instance,
-  Instances,
-  InstancesItem,
-  Page,
-} from "@webstudio-is/project-build";
+import type { Build, Page } from "@webstudio-is/project-build";
 import type { Asset } from "@webstudio-is/asset-uploader";
 import { createElementsTree } from "./create-elements-tree";
 import { WebstudioComponent } from "./webstudio-component";
@@ -35,36 +29,6 @@ type RootProps = {
   getComponent: GetComponent;
 };
 
-const denormalizeTree = (
-  instances: Instances,
-  rootInstanceId: Instance["id"]
-) => {
-  const convertTree = (instance: InstancesItem) => {
-    const legacyInstance: Instance = {
-      type: "instance",
-      id: instance.id,
-      component: instance.component,
-      children: [],
-    };
-    for (const child of instance.children) {
-      if (child.type === "id") {
-        const childInstance = instances.get(child.value);
-        if (childInstance) {
-          legacyInstance.children.push(convertTree(childInstance));
-        }
-      } else {
-        legacyInstance.children.push(child);
-      }
-    }
-    return legacyInstance;
-  };
-  const rootInstance = instances.get(rootInstanceId);
-  if (rootInstance === undefined) {
-    return undefined;
-  }
-  return convertTree(rootInstance);
-};
-
 export const InstanceRoot = ({
   data,
   Component,
@@ -72,17 +36,10 @@ export const InstanceRoot = ({
   getComponent,
 }: RootProps): JSX.Element | null => {
   setParams(data.params ?? null);
-
   registerComponents(customComponents);
-  const instance = denormalizeTree(
-    new Map(data.build.instances),
-    data.page.rootInstanceId
-  );
-  if (instance === undefined) {
-    return null;
-  }
   return createElementsTree({
-    instance,
+    instances: new Map(data.build.instances),
+    rootInstanceId: data.page.rootInstanceId,
     propsByInstanceIdStore: atom(
       getPropsByInstanceId(new Map(data.build.props))
     ),

--- a/packages/react-sdk/src/tree/webstudio-component.tsx
+++ b/packages/react-sdk/src/tree/webstudio-component.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from "react";
-import type { Instance } from "@webstudio-is/project-build";
+import type { Instance, InstancesItem } from "@webstudio-is/project-build";
 import type { GetComponent } from "../components/components-utils";
 import { useInstanceProps } from "../props";
 
@@ -27,7 +27,7 @@ export const renderWebstudioComponentChildren = (
 };
 
 type WebstudioComponentProps = {
-  instance: Instance;
+  instance: InstancesItem;
   instanceSelector: Instance["id"][];
   children: Array<JSX.Element | string>;
   getComponent: GetComponent;


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/696

Here we finally can switch to normalized instances for rendering tree
and get rid from denormalization for published sites.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @rpominov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
