### PR TITLE
Fix blockquote properties

### DIFF
--- a/packages/react-sdk/src/components/blockquote.ws.tsx
+++ b/packages/react-sdk/src/components/blockquote.ws.tsx
@@ -79,5 +79,4 @@ export const meta: WsComponentMeta = {
 
 export const propsMeta: WsComponentPropsMeta = {
   props,
-  initialProps: ["tag"],
 };


### PR DESCRIPTION
## Description

We had a mismatch between a component and meta
Closes https://github.com/webstudio-is/webstudio-builder/issues/1418

## Steps for reproduction

1. add blockquote
2. open properties

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
