### PR TITLE
Fix cascade indicators on scrub move

### DIFF
--- a/apps/builder/app/builder/features/breakpoints/breakpoints-selector.tsx
+++ b/apps/builder/app/builder/features/breakpoints/breakpoints-selector.tsx
@@ -4,7 +4,7 @@ import {
   ToolbarToggleGroup,
   ToolbarToggleItem,
 } from "@webstudio-is/design-system";
-import { useRef } from "react";
+import { useCallback, useRef } from "react";
 import { CascadeIndicator } from "./cascade-indicator";
 import { BpStarOffIcon, BpStarOnIcon } from "@webstudio-is/icons";
 import { useSetInitialCanvasWidth } from ".";
@@ -18,11 +18,14 @@ import { groupBreakpoints } from "~/shared/breakpoints";
 export const BreakpointsSelector = () => {
   const breakpoints = useStore(breakpointsStore);
   const selectedBreakpoint = useStore(selectedBreakpointStore);
-  const ref = useRef(null);
+  const refs = useRef(new Map<string, HTMLButtonElement>());
   const setInitialCanvasWidth = useSetInitialCanvasWidth();
+  const getButtonById = useCallback((id: string) => refs.current.get(id), []);
+
   if (selectedBreakpoint === undefined) {
     return null;
   }
+
   return (
     <Toolbar>
       <ToolbarToggleGroup
@@ -42,7 +45,13 @@ export const BreakpointsSelector = () => {
             return (
               <ToolbarToggleItem
                 variant="subtle"
-                ref={breakpoint.id === selectedBreakpoint.id ? ref : undefined}
+                ref={(node) => {
+                  if (node) {
+                    refs.current.set(breakpoint.id, node);
+                    return;
+                  }
+                  refs.current.delete(breakpoint.id);
+                }}
                 value={breakpoint.id}
                 key={breakpoint.id}
               >
@@ -57,7 +66,7 @@ export const BreakpointsSelector = () => {
             );
           }
         )}
-        <CascadeIndicator buttonRef={ref} />
+        <CascadeIndicator getButtonById={getButtonById} />
       </ToolbarToggleGroup>
     </Toolbar>
   );

--- a/apps/builder/app/builder/features/breakpoints/cascade-indicator.tsx
+++ b/apps/builder/app/builder/features/breakpoints/cascade-indicator.tsx
@@ -1,6 +1,6 @@
 import { useStore } from "@nanostores/react";
 import { css, theme } from "@webstudio-is/design-system";
-import { useEffect, useState, type RefObject } from "react";
+import { useEffect, useState } from "react";
 import { selectedBreakpointStore } from "~/shared/nano-states";
 import type { Breakpoint } from "@webstudio-is/project-build";
 import { breakpointsStore } from "~/shared/nano-states";
@@ -69,10 +69,10 @@ const calcIndicatorStyle = ({
 };
 
 const useSizes = ({
-  buttonRef,
+  getButtonById,
   selectedBreakpoint,
 }: {
-  buttonRef: RefObject<HTMLButtonElement | null>;
+  getButtonById: (id: string) => HTMLButtonElement | undefined;
   selectedBreakpoint?: Breakpoint;
 }) => {
   const [buttonLeft, setButtonLeft] = useState<number>();
@@ -81,14 +81,22 @@ const useSizes = ({
   const breakpoints = useStore(breakpointsStore);
 
   useEffect(() => {
-    if (buttonRef.current) {
-      setButtonLeft(buttonRef.current.offsetLeft);
-      setButtonWidth(buttonRef.current.offsetWidth);
-      setContainerWidth(buttonRef.current.parentElement?.offsetWidth);
+    if (selectedBreakpoint === undefined) {
+      return;
     }
+
+    const button = getButtonById(selectedBreakpoint?.id);
+
+    if (button === undefined) {
+      return;
+    }
+
+    setButtonLeft(button.offsetLeft);
+    setButtonWidth(button.offsetWidth);
+    setContainerWidth(button.parentElement?.offsetWidth);
   }, [
     selectedBreakpoint,
-    buttonRef,
+    getButtonById,
     // needed to update sizes when breakpoints are changed
     breakpoints,
   ]);
@@ -107,12 +115,12 @@ const useSizes = ({
 // Left one is shown for min breakpoints, right one for max breakpoints.
 // When you have base breakpoint selected which has neither min nor max width, both indicators are shown.
 export const CascadeIndicator = ({
-  buttonRef,
+  getButtonById,
 }: {
-  buttonRef: RefObject<HTMLButtonElement | null>;
+  getButtonById: (id: string) => HTMLButtonElement | undefined;
 }) => {
   const selectedBreakpoint = useStore(selectedBreakpointStore);
-  const sizes = useSizes({ buttonRef, selectedBreakpoint });
+  const sizes = useSizes({ getButtonById, selectedBreakpoint });
   if (selectedBreakpoint === undefined || sizes === undefined) {
     return null;
   }

--- a/apps/builder/app/builder/features/style-panel/style-panel.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-panel.tsx
@@ -29,12 +29,14 @@ const useMatchMedia = () => {
       if (breakpoint === undefined) {
         return;
       }
+
       if (canvasWidth === undefined) {
         return;
       }
 
       if (matchMedia(breakpoint, canvasWidth) === false) {
         setMatched(true);
+        return;
       }
 
       setMatched(false);


### PR DESCRIPTION
## Description

Map used based on
https://react.dev/learn/manipulating-the-dom-with-refs#how-to-manage-a-list-of-refs-using-a-ref-callback


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
