### PR TITLE
Pass all asset uploader envs from builder

### DIFF
--- a/apps/builder/app/env/env.server.ts
+++ b/apps/builder/app/env/env.server.ts
@@ -30,6 +30,22 @@ const env = {
 
   // Preview support
   BRANCH_NAME: process.env.BRANCH_NAME,
+
+  // Assets
+  MAX_UPLOAD_SIZE: process.env.MAX_UPLOAD_SIZE,
+  MAX_ASSETS_PER_PROJECT: process.env.MAX_ASSETS_PER_PROJECT,
+
+  // Local assets
+  FILE_UPLOAD_PATH: process.env.FILE_UPLOAD_PATH,
+
+  // Remove assets
+  S3_ENDPOINT: process.env.S3_ENDPOINT,
+  S3_REGION: process.env.S3_REGION,
+  S3_ACCESS_KEY_ID: process.env.S3_ACCESS_KEY_ID,
+  S3_SECRET_ACCESS_KEY: process.env.S3_SECRET_ACCESS_KEY,
+  S3_BUCKET: process.env.S3_BUCKET,
+  S3_ACL: process.env.S3_ACL,
+  ASSET_CDN_URL: process.env.ASSET_CDN_URL,
 };
 
 export type ServerEnv = typeof env;

--- a/apps/builder/app/env/env.server.ts
+++ b/apps/builder/app/env/env.server.ts
@@ -38,7 +38,7 @@ const env = {
   // Local assets
   FILE_UPLOAD_PATH: process.env.FILE_UPLOAD_PATH,
 
-  // Remove assets
+  // Remote assets
   S3_ENDPOINT: process.env.S3_ENDPOINT,
   S3_REGION: process.env.S3_REGION,
   S3_ACCESS_KEY_ID: process.env.S3_ACCESS_KEY_ID,

--- a/apps/builder/app/routes/rest.assets.$projectId.tsx
+++ b/apps/builder/app/routes/rest.assets.$projectId.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import type { ActionArgs, LoaderArgs } from "@remix-run/node";
 import { useActionData } from "@remix-run/react";
-import type { Asset } from "@webstudio-is/asset-uploader";
+import { MaxAssets, type Asset } from "@webstudio-is/asset-uploader";
 import {
   uploadAssets,
   loadByProject,
@@ -11,6 +11,7 @@ import type { ActionData } from "~/builder/shared/assets";
 import { sentryException } from "~/shared/sentry";
 import { createContext } from "~/shared/context.server";
 import { createAssetClient } from "~/shared/asset-client";
+import env from "~/env/env.server";
 
 export const loader = async ({
   params,
@@ -40,6 +41,7 @@ export const action = async (
         {
           request,
           projectId: params.projectId,
+          maxAssetsPerProject: MaxAssets.parse(env.MAX_ASSETS_PER_PROJECT),
         },
         context,
         createAssetClient()

--- a/apps/builder/app/shared/asset-client.ts
+++ b/apps/builder/app/shared/asset-client.ts
@@ -1,27 +1,28 @@
 import * as path from "path";
-import { S3Env, FsEnv } from "@webstudio-is/asset-uploader";
+import { MaxSize } from "@webstudio-is/asset-uploader";
 import {
   createFsClient,
   createS3Client,
 } from "@webstudio-is/asset-uploader/server";
+import env from "~/env/env.server";
 
 export const createAssetClient = () => {
+  const maxUploadSize = MaxSize.parse(env.MAX_UPLOAD_SIZE);
   if (process.env.NODE_ENV === "development") {
-    const env = FsEnv.parse(process.env);
+    const fileUploadPath = env.FILE_UPLOAD_PATH ?? "public/s/uploads";
     return createFsClient({
-      maxUploadSize: env.MAX_UPLOAD_SIZE,
-      fileDirectory: path.join(process.cwd(), env.FILE_UPLOAD_PATH),
+      maxUploadSize,
+      fileDirectory: path.join(process.cwd(), fileUploadPath),
     });
   } else {
-    const env = S3Env.parse(process.env);
     return createS3Client({
-      endpoint: env.S3_ENDPOINT,
-      region: env.S3_REGION,
-      accessKeyId: env.S3_ACCESS_KEY_ID,
-      secretAccessKey: env.S3_SECRET_ACCESS_KEY,
-      bucket: env.S3_BUCKET,
+      endpoint: env.S3_ENDPOINT as string,
+      region: env.S3_REGION as string,
+      accessKeyId: env.S3_ACCESS_KEY_ID as string,
+      secretAccessKey: env.S3_SECRET_ACCESS_KEY as string,
+      bucket: env.S3_BUCKET as string,
       acl: env.S3_ACL,
-      maxUploadSize: env.MAX_UPLOAD_SIZE,
+      maxUploadSize,
     });
   }
 };

--- a/packages/asset-uploader/src/constants.ts
+++ b/packages/asset-uploader/src/constants.ts
@@ -1,3 +1,2 @@
-export const DEFAULT_UPLOAD_PATH = "public/s/uploads";
 // By default using Vercel's limit https://vercel.com/docs/concepts/limits/overview#serverless-function-payload-size-limit
 export const MAX_UPLOAD_SIZE = "4.5";

--- a/packages/asset-uploader/src/db/create.ts
+++ b/packages/asset-uploader/src/db/create.ts
@@ -5,14 +5,12 @@ import {
   type Project,
   type Asset,
 } from "@webstudio-is/prisma-client";
-import { Env, type ImageMeta } from "../schema";
+import type { ImageMeta } from "../schema";
 import { formatAsset } from "../utils/format-asset";
 import {
   authorizeProject,
   type AppContext,
 } from "@webstudio-is/trpc-interface/server";
-
-const env = Env.parse(process.env);
 
 type BaseOptions = {
   id: string;
@@ -33,7 +31,10 @@ type Options =
 export const createAssetWithLimit = async (
   projectId: Project["id"],
   uploadAsset: () => Promise<Options>,
-  context: AppContext
+  context: AppContext,
+  options: {
+    maxAssetsPerProject: number;
+  }
 ) => {
   let updated: { id: string } | undefined;
 
@@ -67,7 +68,7 @@ export const createAssetWithLimit = async (
       },
     });
 
-    if (count >= env.MAX_ASSETS_PER_PROJECT) {
+    if (count >= options.maxAssetsPerProject) {
       /**
        * Here is right to write `Max ${MAX_ASSETS_PER_PROJECT}` but see the comment below,
        * it's probable that the user can exceed the limit a little bit.

--- a/packages/asset-uploader/src/schema.ts
+++ b/packages/asset-uploader/src/schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { FontFormat, FontMeta } from "@webstudio-is/fonts";
-import { DEFAULT_UPLOAD_PATH, MAX_UPLOAD_SIZE } from "./constants";
+import { MAX_UPLOAD_SIZE } from "./constants";
 import { toBytes } from "./utils/to-bytes";
 
 export const ImageMeta = z.object({
@@ -9,31 +9,13 @@ export const ImageMeta = z.object({
 });
 export type ImageMeta = z.infer<typeof ImageMeta>;
 
-const maxSize = z
+export const MaxSize = z
   .string()
+  .default(MAX_UPLOAD_SIZE)
   // user inputs the max value in mb and we transform it to bytes
-  .transform(toBytes)
-  .default(MAX_UPLOAD_SIZE);
+  .transform(toBytes);
 
-export const Env = z.object({
-  MAX_ASSETS_PER_PROJECT: z.string().default("50").transform(Number.parseFloat),
-});
-
-export const S3Env = z.object({
-  S3_ENDPOINT: z.string(),
-  S3_REGION: z.string(),
-  S3_ACCESS_KEY_ID: z.string(),
-  S3_SECRET_ACCESS_KEY: z.string(),
-  S3_BUCKET: z.string(),
-  S3_ACL: z.string().optional(),
-  ASSET_CDN_URL: z.string().optional(),
-  MAX_UPLOAD_SIZE: maxSize,
-});
-
-export const FsEnv = z.object({
-  MAX_UPLOAD_SIZE: maxSize,
-  FILE_UPLOAD_PATH: z.string().default(DEFAULT_UPLOAD_PATH),
-});
+export const MaxAssets = z.string().default("50").transform(Number.parseFloat);
 
 export const Location = z.union([z.literal("FS"), z.literal("REMOTE")]);
 export type Location = z.infer<typeof Location>;

--- a/packages/asset-uploader/src/upload.ts
+++ b/packages/asset-uploader/src/upload.ts
@@ -6,9 +6,11 @@ export const uploadAssets = async (
   {
     request,
     projectId,
+    maxAssetsPerProject,
   }: {
     request: Request;
     projectId: string;
+    maxAssetsPerProject: number;
   },
   context: AppContext,
   client: AssetClient
@@ -18,7 +20,10 @@ export const uploadAssets = async (
     () => {
       return client.uploadFile(request);
     },
-    context
+    context,
+    {
+      maxAssetsPerProject,
+    }
   );
 
   return [asset];


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1179

Here all envs which were accessed and parsed in asset uploader moved to builder. Now we have better control over assets in different environments.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
