### PR TITLE
Fix font assets resolving

### DIFF
--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -125,7 +125,12 @@ export const GlobalStyles = () => {
 
   useIsomorphicLayoutEffect(() => {
     fontsAndDefaultsCssEngine.clear();
-    addGlobalRules(fontsAndDefaultsCssEngine, { assets });
+    const params = getParams();
+    addGlobalRules(fontsAndDefaultsCssEngine, {
+      assets,
+      publicPath: params.publicPath,
+      cdnUrl: params.cdnUrl,
+    });
     fontsAndDefaultsCssEngine.render();
   }, [assets]);
 

--- a/packages/fonts/src/get-font-faces.test.ts
+++ b/packages/fonts/src/get-font-faces.test.ts
@@ -11,7 +11,8 @@ describe("getFontFaces()", () => {
           style: "normal",
           weight: 400,
         },
-        path: "/fonts/roboto.woff",
+        location: "FS",
+        name: "roboto.woff",
       },
       {
         format: "ttf",
@@ -20,10 +21,11 @@ describe("getFontFaces()", () => {
           style: "normal",
           weight: 400,
         },
-        path: "/fonts/roboto.ttf",
+        location: "FS",
+        name: "roboto.ttf",
       },
     ];
-    expect(getFontFaces(assets)).toMatchSnapshot();
+    expect(getFontFaces(assets, { publicPath: "/fonts/" })).toMatchSnapshot();
   });
 
   test("different style", () => {
@@ -35,7 +37,8 @@ describe("getFontFaces()", () => {
           style: "normal",
           weight: 400,
         },
-        path: "/fonts/roboto.ttf",
+        location: "FS",
+        name: "roboto.ttf",
       },
       {
         format: "ttf",
@@ -44,10 +47,11 @@ describe("getFontFaces()", () => {
           style: "italic",
           weight: 400,
         },
-        path: "/fonts/roboto-italic.ttf",
+        location: "FS",
+        name: "roboto-italic.ttf",
       },
     ];
-    expect(getFontFaces(assets)).toMatchSnapshot();
+    expect(getFontFaces(assets, { publicPath: "/fonts/" })).toMatchSnapshot();
   });
 
   test("different weight", () => {
@@ -59,7 +63,8 @@ describe("getFontFaces()", () => {
           style: "normal",
           weight: 400,
         },
-        path: "/fonts/roboto.ttf",
+        location: "FS",
+        name: "roboto.ttf",
       },
       {
         format: "ttf",
@@ -68,10 +73,11 @@ describe("getFontFaces()", () => {
           style: "normal",
           weight: 500,
         },
-        path: "/fonts/roboto-bold.ttf",
+        location: "FS",
+        name: "roboto-bold.ttf",
       },
     ];
-    expect(getFontFaces(assets)).toMatchSnapshot();
+    expect(getFontFaces(assets, { publicPath: "/fonts/" })).toMatchSnapshot();
   });
 
   test("variable font", () => {
@@ -96,9 +102,10 @@ describe("getFontFaces()", () => {
             YTFI: { name: "YTFI", min: 560, default: 738, max: 788 },
           },
         },
-        path: "/fonts/inter.ttf",
+        location: "FS",
+        name: "inter.ttf",
       },
     ];
-    expect(getFontFaces(assets)).toMatchSnapshot();
+    expect(getFontFaces(assets, { publicPath: "/fonts/" })).toMatchSnapshot();
   });
 });

--- a/packages/react-sdk/src/css/css.ts
+++ b/packages/react-sdk/src/css/css.ts
@@ -56,7 +56,11 @@ export const generateCssText = (data: Data, options: CssOptions) => {
 
   const engine = createCssEngine({ name: "ssr" });
 
-  addGlobalRules(engine, { assets });
+  addGlobalRules(engine, {
+    assets,
+    publicPath: options.publicPath,
+    cdnUrl: options.cdnUrl,
+  });
 
   for (const breakpoint of breakpoints.values()) {
     engine.addMediaRule(breakpoint.id, breakpoint);

--- a/packages/react-sdk/src/css/global-rules.ts
+++ b/packages/react-sdk/src/css/global-rules.ts
@@ -1,28 +1,31 @@
 import type { CssEngine } from "@webstudio-is/css-engine";
 import type { Assets, FontAsset } from "@webstudio-is/asset-uploader";
-import {
-  type FontFormat,
-  FONT_FORMATS,
-  getFontFaces,
-} from "@webstudio-is/fonts";
+import { getFontFaces } from "@webstudio-is/fonts";
 
 export const addGlobalRules = (
   engine: CssEngine,
-  { assets }: { assets: Assets }
+  {
+    assets,
+    publicPath,
+    cdnUrl,
+  }: { assets: Assets; publicPath?: string; cdnUrl?: string }
 ) => {
   // @todo we need to figure out all global resets while keeping
   // the engine aware of all of them.
   // Ideally, the user is somehow aware and in control of the reset
   engine.addPlaintextRule("html {margin: 0; height: 100%}");
 
-  const fontAssets: Array<FontAsset> = [];
+  const fontAssets: FontAsset[] = [];
   for (const asset of assets.values()) {
-    if (asset && FONT_FORMATS.has(asset.format as FontFormat)) {
-      fontAssets.push(asset as FontAsset);
+    if (asset?.type === "font") {
+      fontAssets.push(asset);
     }
   }
 
-  const fontFaces = getFontFaces(fontAssets);
+  const fontFaces = getFontFaces(fontAssets, {
+    publicPath,
+    cdnUrl,
+  });
   for (const fontFace of fontFaces) {
     engine.addFontFaceRule(fontFace);
   }


### PR DESCRIPTION
Fonts are resolved separately. Here provided same publicPath and cdnUrl options to font face resolver.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
