### PR TITLE
Drop asset.path

### DIFF
--- a/apps/builder/app/builder/features/props-panel/props-panel.stories.tsx
+++ b/apps/builder/app/builder/features/props-panel/props-panel.stories.tsx
@@ -40,7 +40,6 @@ const imageAsset = (name = "cat", format = "jpeg"): Asset => ({
   projectId,
   type: "image",
   name: `${name}.${format}`,
-  path: `https://loremflickr.com/128/180/${name}`,
   format: format,
   location: "FS",
   size: 100000,

--- a/apps/builder/app/builder/features/style-panel/controls/font-weight/is-supported-font-weight.test.ts
+++ b/apps/builder/app/builder/features/style-panel/controls/font-weight/is-supported-font-weight.test.ts
@@ -13,7 +13,6 @@ const createServerAsset = (meta: FontAsset["meta"]): FontAsset => ({
   createdAt: "",
   description: "",
   meta,
-  path: "",
 });
 
 describe("isSupportedFontWeight", () => {

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-thumbnail.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-thumbnail.tsx
@@ -107,7 +107,7 @@ export const LayerThumbnail = (props: { layerStyle: StyleInfo }) => {
       <StyledWebstudioImage
         key={asset.id}
         loader={loader}
-        src={asset.path}
+        src={asset.name}
         width={theme.spacing[10]}
         optimize={true}
         alt={getLayerName(props.layerStyle, assets)}

--- a/apps/builder/app/builder/shared/assets/types.ts
+++ b/apps/builder/app/builder/shared/assets/types.ts
@@ -2,7 +2,7 @@ import type { Asset } from "@webstudio-is/asset-uploader";
 
 export type PreviewAsset = Pick<
   Asset,
-  "path" | "name" | "id" | "format" | "description" | "type"
+  "name" | "id" | "format" | "description" | "type"
 >;
 
 export type UploadedAssetContainer = {
@@ -12,6 +12,7 @@ export type UploadedAssetContainer = {
 
 export type UploadingAssetContainer = {
   status: "uploading";
+  objectURL: string;
   asset: Asset | PreviewAsset;
 };
 

--- a/apps/builder/app/builder/shared/assets/use-assets.tsx
+++ b/apps/builder/app/builder/shared/assets/use-assets.tsx
@@ -10,7 +10,7 @@ import {
 import { toast } from "@webstudio-is/design-system";
 import { sanitizeS3Key } from "@webstudio-is/asset-uploader";
 import { restAssetsPath } from "~/shared/router-utils";
-import type { AssetContainer } from "./types";
+import type { AssetContainer, PreviewAsset } from "./types";
 import { usePersistentFetcher } from "~/shared/fetcher";
 import type { ActionData } from "~/builder/shared/assets";
 import { normalizeErrors, toastUnknownFieldErrors } from "~/shared/form-utils";
@@ -78,25 +78,25 @@ const deleteUploadingFileData = (id: FileData["id"]) => {
 const assetContainersStore = computed(
   [assetsStore, uploadingFilesDataStore],
   (assets, uploadingFilesData) => {
-    const uploadingAssets = new Map();
+    const uploadingAssets = new Map<PreviewAsset["id"], AssetContainer>();
     for (const { id, type, file, objectURL } of uploadingFilesData) {
       uploadingAssets.set(id, {
-        id,
-        type,
-        format: file.type.split("/")[1],
-        path: objectURL,
-        name: file.name,
-        description: file.name,
+        status: "uploading",
+        objectURL: objectURL,
+        asset: {
+          id,
+          type,
+          format: file.type.split("/")[1],
+          name: file.name,
+          description: file.name,
+        },
       });
     }
     const assetContainers: Array<AssetContainer> = [];
     for (const [assetId, asset] of assets) {
       const uploadingAsset = uploadingAssets.get(assetId);
       if (uploadingAsset) {
-        assetContainers.push({
-          status: "uploading",
-          asset: uploadingAsset,
-        });
+        assetContainers.push(uploadingAsset);
         continue;
       }
       if (asset) {

--- a/apps/builder/app/builder/shared/image-manager/image.tsx
+++ b/apps/builder/app/builder/shared/image-manager/image.tsx
@@ -61,12 +61,17 @@ export const Image = ({ assetContainer, alt, width }: ImageProps) => {
     });
   }, [remoteLocation]);
 
+  const src =
+    assetContainer.status === "uploading"
+      ? assetContainer.objectURL
+      : asset.name;
+
   return (
     <StyledWebstudioImage
       key={asset.id}
       loader={loader}
       decoding={decoding}
-      src={asset.path}
+      src={src}
       width={width}
       optimize={optimize}
       alt={alt}

--- a/apps/builder/app/shared/asset-client.ts
+++ b/apps/builder/app/shared/asset-client.ts
@@ -8,21 +8,27 @@ import env from "~/env/env.server";
 
 export const createAssetClient = () => {
   const maxUploadSize = MaxSize.parse(env.MAX_UPLOAD_SIZE);
-  if (process.env.NODE_ENV === "development") {
+  if (
+    env.S3_ENDPOINT !== undefined &&
+    env.S3_REGION !== undefined &&
+    env.S3_ACCESS_KEY_ID !== undefined &&
+    env.S3_SECRET_ACCESS_KEY !== undefined &&
+    env.S3_BUCKET !== undefined
+  ) {
+    return createS3Client({
+      endpoint: env.S3_ENDPOINT,
+      region: env.S3_REGION,
+      accessKeyId: env.S3_ACCESS_KEY_ID,
+      secretAccessKey: env.S3_SECRET_ACCESS_KEY,
+      bucket: env.S3_BUCKET,
+      acl: env.S3_ACL,
+      maxUploadSize,
+    });
+  } else {
     const fileUploadPath = env.FILE_UPLOAD_PATH ?? "public/s/uploads";
     return createFsClient({
       maxUploadSize,
       fileDirectory: path.join(process.cwd(), fileUploadPath),
-    });
-  } else {
-    return createS3Client({
-      endpoint: env.S3_ENDPOINT as string,
-      region: env.S3_REGION as string,
-      accessKeyId: env.S3_ACCESS_KEY_ID as string,
-      secretAccessKey: env.S3_SECRET_ACCESS_KEY as string,
-      bucket: env.S3_BUCKET as string,
-      acl: env.S3_ACL,
-      maxUploadSize,
     });
   }
 };

--- a/packages/asset-uploader/src/schema.ts
+++ b/packages/asset-uploader/src/schema.ts
@@ -31,7 +31,6 @@ const BaseAsset = z.object({
   description: z.union([z.string(), z.null()]),
   location: Location,
   createdAt: z.string(),
-  path: z.string(),
 });
 
 export const FontAsset = BaseAsset.omit({ format: true }).extend({

--- a/packages/asset-uploader/src/utils/format-asset.ts
+++ b/packages/asset-uploader/src/utils/format-asset.ts
@@ -10,12 +10,10 @@ export const formatAsset = (asset: DbAsset): Asset => {
     return {
       id: asset.id,
       name: asset.name,
-      path: asset.name,
       description: asset.description,
       location: asset.location,
       projectId: asset.projectId,
       size: asset.size,
-
       type: "font",
       createdAt: asset.createdAt.toISOString(),
       format: asset.format as FontFormat,
@@ -26,7 +24,6 @@ export const formatAsset = (asset: DbAsset): Asset => {
   return {
     id: asset.id,
     name: asset.name,
-    path: asset.name,
     description: asset.description,
     location: asset.location,
     projectId: asset.projectId,

--- a/packages/css-engine/package.json
+++ b/packages/css-engine/package.json
@@ -17,6 +17,7 @@
     "storybook:build": "build-storybook"
   },
   "dependencies": {
+    "@webstudio-is/css-data": "workspace:^",
     "@webstudio-is/fonts": "workspace:^",
     "hyphenate-style-name": "^1.0.4",
     "react": "^17.0.2",
@@ -28,8 +29,6 @@
     "@types/hyphenate-style-name": "^1.0.0",
     "@types/react": "^17.0.24",
     "@types/react-dom": "^17.0.9",
-    "@webstudio-is/asset-uploader": "workspace:^",
-    "@webstudio-is/css-data": "workspace:^",
     "@webstudio-is/jest-config": "workspace:^",
     "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/storybook-config": "workspace:^",

--- a/packages/css-engine/src/core/css-engine.test.ts
+++ b/packages/css-engine/src/core/css-engine.test.ts
@@ -1,5 +1,4 @@
 import { describe, beforeEach, test, expect } from "@jest/globals";
-import type { Assets } from "@webstudio-is/asset-uploader";
 import { CssEngine } from "./css-engine";
 
 const style0 = {
@@ -352,23 +351,8 @@ describe("CssEngine", () => {
   });
 
   test("render images with injected asset url", () => {
-    const assets: Assets = new Map([
-      [
-        "1234",
-        {
-          type: "image",
-          path: "foo.png",
-          id: "1234567890",
-          projectId: "",
-          format: "",
-          size: 1212,
-          name: "img",
-          description: "",
-          location: "REMOTE",
-          createdAt: "",
-          meta: { width: 1, height: 2 },
-        },
-      ],
+    const assets = new Map<string, { path: string }>([
+      ["1234", { path: "foo.png" }],
     ]);
     const rule = engine.addStyleRule(
       ".c",

--- a/packages/css-engine/src/core/to-value.test.ts
+++ b/packages/css-engine/src/core/to-value.test.ts
@@ -1,5 +1,4 @@
 import { describe, test, expect } from "@jest/globals";
-import type { Assets } from "@webstudio-is/asset-uploader";
 import { toValue } from "./to-value";
 
 describe("Convert WS CSS Values to native CSS strings", () => {
@@ -74,24 +73,8 @@ describe("Convert WS CSS Values to native CSS strings", () => {
   });
 
   test("array", () => {
-    const assets: Assets = new Map([
-      [
-        "1234567890",
-        {
-          type: "image",
-          path: "foo.png",
-
-          id: "1234567890",
-          projectId: "",
-          format: "",
-          size: 1212,
-          name: "img",
-          description: "",
-          location: "REMOTE",
-          createdAt: "",
-          meta: { width: 1, height: 2 },
-        },
-      ],
+    const assets = new Map<string, { path: string }>([
+      ["1234567890", { path: "foo.png" }],
     ]);
 
     const value = toValue(

--- a/packages/react-sdk/src/app/custom-components/image.tsx
+++ b/packages/react-sdk/src/app/custom-components/image.tsx
@@ -28,11 +28,7 @@ export const Image = forwardRef<ElementRef<typeof defaultTag>, Props>(
       return loaders.localImageLoader(params);
     }, [asset, params]);
 
-    let src = props.src;
-
-    if (asset != null) {
-      src = asset.path;
-    }
+    const src = asset?.name ?? props.src;
 
     if (asset == null || loader == null) {
       return <SdkImage key={src} {...props} src={src} ref={ref} />;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -491,6 +491,9 @@ importers:
 
   packages/css-engine:
     dependencies:
+      '@webstudio-is/css-data':
+        specifier: workspace:^
+        version: link:../css-data
       '@webstudio-is/fonts':
         specifier: workspace:^
         version: link:../fonts
@@ -519,12 +522,6 @@ importers:
       '@types/react-dom':
         specifier: ^17.0.9
         version: 17.0.17
-      '@webstudio-is/asset-uploader':
-        specifier: workspace:^
-        version: link:../asset-uploader
-      '@webstudio-is/css-data':
-        specifier: workspace:^
-        version: link:../css-data
       '@webstudio-is/jest-config':
         specifier: workspace:^
         version: link:../jest-config


### PR DESCRIPTION
This is computed field which is after moving logic to loaders equal to asset.name so not really useful except for preview images.

Here object url for preview images is moved to container so there is no need in asset.path here too.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
