### PR TITLE
Render label in breadcrumbs when possible

### DIFF
--- a/apps/builder/app/builder/features/footer/breadcrumbs.tsx
+++ b/apps/builder/app/builder/features/footer/breadcrumbs.tsx
@@ -4,7 +4,7 @@ import {
   theme,
   DeprecatedButton,
   Flex,
-  DeprecatedText2,
+  Text,
 } from "@webstudio-is/design-system";
 import {
   instancesStore,
@@ -46,7 +46,7 @@ export const Breadcrumbs = () => {
     <Flex align="center" css={{ height: "100%" }}>
       {selectedInstanceSelector === undefined ? (
         <Breadcrumb>
-          <DeprecatedText2>No instance selected</DeprecatedText2>
+          <Text>No instance selected</Text>
         </Breadcrumb>
       ) : (
         selectedInstanceSelector
@@ -71,7 +71,7 @@ export const Breadcrumbs = () => {
                   textEditingInstanceSelectorStore.set(undefined);
                 }}
               >
-                {instance.component}
+                {instance.label || instance.component}
               </Breadcrumb>
             );
           })


### PR DESCRIPTION
## Description

Render label in breadcrumbs when possible

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
