### PR TITLE
Pass asset base url for fonts and style images

### DIFF
--- a/apps/builder/.env.example
+++ b/apps/builder/.env.example
@@ -10,7 +10,7 @@ MAX_ASSETS_PER_PROJECT=50
 
 # relative to the public directory
 FILE_UPLOAD_PATH="uploads"
-ASSET_PUBLIC_PATH=/s/uploads/
+ASSET_BASE_URL=/s/uploads/
 
 # Optional max upload size in Mb
 # MAX_UPLOAD_SIZE=10

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-thumbnail.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-thumbnail.tsx
@@ -97,10 +97,10 @@ export const LayerThumbnail = (props: { layerStyle: StyleInfo }) => {
     const loader = remoteLocation
       ? loaders.cloudflareImageLoader({
           resizeOrigin: env.RESIZE_ORIGIN,
-          cdnUrl: env.ASSET_CDN_URL,
+          cdnUrl: env.ASSET_BASE_URL,
         })
       : loaders.localImageLoader({
-          publicPath: env.ASSET_PUBLIC_PATH,
+          publicPath: env.ASSET_BASE_URL,
         });
 
     return (

--- a/apps/builder/app/builder/shared/image-manager/image.tsx
+++ b/apps/builder/app/builder/shared/image-manager/image.tsx
@@ -52,12 +52,12 @@ export const Image = ({ assetContainer, alt, width }: ImageProps) => {
     if (remoteLocation) {
       return loaders.cloudflareImageLoader({
         resizeOrigin: env.RESIZE_ORIGIN,
-        cdnUrl: env.ASSET_CDN_URL,
+        cdnUrl: env.ASSET_BASE_URL,
       });
     }
 
     return loaders.localImageLoader({
-      publicPath: env.ASSET_PUBLIC_PATH,
+      publicPath: env.ASSET_BASE_URL,
     });
   }, [remoteLocation]);
 

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -128,8 +128,7 @@ export const GlobalStyles = () => {
     const params = getParams();
     addGlobalRules(fontsAndDefaultsCssEngine, {
       assets,
-      publicPath: params.publicPath,
-      cdnUrl: params.cdnUrl,
+      assetBaseUrl: params.assetBaseUrl,
     });
     fontsAndDefaultsCssEngine.render();
   }, [assets]);
@@ -206,8 +205,7 @@ const addRule = (id: string, cssRule: CssRule, assets: Assets) => {
       style: toVarStyleWithFallback(id, cssRule.style),
     },
     createImageValueTransformer(assets, {
-      publicPath: params.publicPath,
-      cdnUrl: params.cdnUrl,
+      assetBaseUrl: params.assetBaseUrl,
     })
   );
   wrappedRulesMap.set(key, rule);

--- a/apps/builder/app/env/env.public.server.ts
+++ b/apps/builder/app/env/env.public.server.ts
@@ -27,11 +27,16 @@ const env = {
   PUBLISHER_ENDPOINT: process.env.PUBLISHER_ENDPOINT || null,
   PUBLISHER_HOST: process.env.PUBLISHER_HOST || null,
   BUILD_REQUIRE_SUBDOMAIN: process.env.BUILD_REQUIRE_SUBDOMAIN === "true",
+
   // Must be set for Vercel deployments
   RESIZE_ORIGIN: process.env.RESIZE_ORIGIN,
-  ASSET_CDN_URL: process.env.ASSET_CDN_URL ?? getCdnUrlFromS3(),
-  // must be set for local setup
-  ASSET_PUBLIC_PATH: process.env.ASSET_PUBLIC_PATH,
+
+  ASSET_BASE_URL:
+    process.env.ASSET_BASE_URL ??
+    process.env.ASSET_CDN_URL ??
+    process.env.ASSET_PUBLIC_PATH ??
+    getCdnUrlFromS3() ??
+    "/",
 } as const;
 
 export default env;

--- a/apps/builder/app/routes/$.tsx
+++ b/apps/builder/app/routes/$.tsx
@@ -14,16 +14,12 @@ export const loader = async ({ request }: LoaderArgs) => {
     throw redirect(dashboardPath());
   }
 
-  const params: Params = {};
+  const params: Params = {
+    assetBaseUrl: env.ASSET_BASE_URL,
+  };
 
   if (env.RESIZE_ORIGIN != null) {
     params.resizeOrigin = env.RESIZE_ORIGIN;
-  }
-  if (env.ASSET_PUBLIC_PATH != null) {
-    params.publicPath = env.ASSET_PUBLIC_PATH;
-  }
-  if (env.ASSET_CDN_URL != null) {
-    params.cdnUrl = env.ASSET_CDN_URL;
   }
 
   return { params };

--- a/apps/builder/app/routes/s.css.ts
+++ b/apps/builder/app/routes/s.css.ts
@@ -47,8 +47,7 @@ export const loader = async ({ request }: ActionArgs) => {
         styleSourceSelections: canvasData.build?.styleSourceSelections,
       },
       {
-        publicPath: env.ASSET_PUBLIC_PATH,
-        cdnUrl: env.ASSET_CDN_URL,
+        assetBaseUrl: env.ASSET_BASE_URL,
       }
     );
 

--- a/packages/fonts/src/get-font-faces.test.ts
+++ b/packages/fonts/src/get-font-faces.test.ts
@@ -11,7 +11,6 @@ describe("getFontFaces()", () => {
           style: "normal",
           weight: 400,
         },
-        location: "FS",
         name: "roboto.woff",
       },
       {
@@ -21,11 +20,10 @@ describe("getFontFaces()", () => {
           style: "normal",
           weight: 400,
         },
-        location: "FS",
         name: "roboto.ttf",
       },
     ];
-    expect(getFontFaces(assets, { publicPath: "/fonts/" })).toMatchSnapshot();
+    expect(getFontFaces(assets, { assetBaseUrl: "/fonts/" })).toMatchSnapshot();
   });
 
   test("different style", () => {
@@ -37,7 +35,6 @@ describe("getFontFaces()", () => {
           style: "normal",
           weight: 400,
         },
-        location: "FS",
         name: "roboto.ttf",
       },
       {
@@ -47,11 +44,10 @@ describe("getFontFaces()", () => {
           style: "italic",
           weight: 400,
         },
-        location: "FS",
         name: "roboto-italic.ttf",
       },
     ];
-    expect(getFontFaces(assets, { publicPath: "/fonts/" })).toMatchSnapshot();
+    expect(getFontFaces(assets, { assetBaseUrl: "/fonts/" })).toMatchSnapshot();
   });
 
   test("different weight", () => {
@@ -63,7 +59,6 @@ describe("getFontFaces()", () => {
           style: "normal",
           weight: 400,
         },
-        location: "FS",
         name: "roboto.ttf",
       },
       {
@@ -73,11 +68,10 @@ describe("getFontFaces()", () => {
           style: "normal",
           weight: 500,
         },
-        location: "FS",
         name: "roboto-bold.ttf",
       },
     ];
-    expect(getFontFaces(assets, { publicPath: "/fonts/" })).toMatchSnapshot();
+    expect(getFontFaces(assets, { assetBaseUrl: "/fonts/" })).toMatchSnapshot();
   });
 
   test("variable font", () => {
@@ -102,10 +96,9 @@ describe("getFontFaces()", () => {
             YTFI: { name: "YTFI", min: 560, default: 738, max: 788 },
           },
         },
-        location: "FS",
         name: "inter.ttf",
       },
     ];
-    expect(getFontFaces(assets, { publicPath: "/fonts/" })).toMatchSnapshot();
+    expect(getFontFaces(assets, { assetBaseUrl: "/fonts/" })).toMatchSnapshot();
   });
 });

--- a/packages/fonts/src/get-font-faces.ts
+++ b/packages/fonts/src/get-font-faces.ts
@@ -5,7 +5,6 @@ export type PartialFontAsset = {
   format: FontFormat;
   meta: FontMeta;
   name: string;
-  location: "FS" | "REMOTE";
 };
 
 export type FontFace = {
@@ -52,17 +51,13 @@ const getKey = (asset: PartialFontAsset) => {
 export const getFontFaces = (
   assets: Array<PartialFontAsset>,
   options: {
-    publicPath?: string;
-    cdnUrl?: string;
+    assetBaseUrl: string;
   }
 ): Array<FontFace> => {
-  const { publicPath = "/", cdnUrl = "/" } = options;
+  const { assetBaseUrl } = options;
   const faces = new Map();
   for (const asset of assets) {
-    const url =
-      asset.location === "REMOTE"
-        ? `${cdnUrl}${asset.name}`
-        : `${publicPath}${asset.name}`;
+    const url = `${assetBaseUrl}${asset.name}`;
     const assetKey = getKey(asset);
     const face = faces.get(assetKey);
     const format = FONT_FORMATS.get(asset.format);

--- a/packages/react-sdk/src/app/custom-components/image.tsx
+++ b/packages/react-sdk/src/app/custom-components/image.tsx
@@ -25,7 +25,7 @@ export const Image = forwardRef<ElementRef<typeof defaultTag>, Props>(
       if (asset.location === "REMOTE") {
         return loaders.cloudflareImageLoader(params);
       }
-      return loaders.localImageLoader(params);
+      return loaders.localImageLoader({ publicPath: params.assetBaseUrl });
     }, [asset, params]);
 
     const src = asset?.name ?? props.src;

--- a/packages/react-sdk/src/app/custom-components/image.tsx
+++ b/packages/react-sdk/src/app/custom-components/image.tsx
@@ -23,7 +23,10 @@ export const Image = forwardRef<ElementRef<typeof defaultTag>, Props>(
         return null;
       }
       if (asset.location === "REMOTE") {
-        return loaders.cloudflareImageLoader(params);
+        return loaders.cloudflareImageLoader({
+          resizeOrigin: params.resizeOrigin,
+          cdnUrl: params.assetBaseUrl,
+        });
       }
       return loaders.localImageLoader({ publicPath: params.assetBaseUrl });
     }, [asset, params]);

--- a/packages/react-sdk/src/app/params.ts
+++ b/packages/react-sdk/src/app/params.ts
@@ -1,15 +1,16 @@
 export type Params = {
   resizeOrigin?: string;
-  cdnUrl?: string;
-  publicPath?: string;
+  assetBaseUrl: string;
 };
 
-let params: Params | null = {};
+let params: undefined | Params;
 
-const emptyParams: Params = {};
+const emptyParams: Params = {
+  assetBaseUrl: "/",
+};
 
 export const getParams = (): Params => params ?? emptyParams;
 
-export const setParams = (newParams: Params | null) => {
+export const setParams = (newParams: undefined | Params) => {
   params = newParams;
 };

--- a/packages/react-sdk/src/css/css.ts
+++ b/packages/react-sdk/src/css/css.ts
@@ -15,8 +15,7 @@ type Data = {
 };
 
 type CssOptions = {
-  publicPath?: string;
-  cdnUrl?: string;
+  assetBaseUrl: string;
 };
 
 export const createImageValueTransformer =
@@ -29,11 +28,8 @@ export const createImageValueTransformer =
       }
 
       // @todo reuse image loaders and generate image-set
-      const { publicPath = "/", cdnUrl = "/" } = options;
-      const url =
-        asset.location === "REMOTE"
-          ? `${cdnUrl}${asset.name}`
-          : `${publicPath}${asset.name}`;
+      const { assetBaseUrl } = options;
+      const url = `${assetBaseUrl}${asset.name}`;
 
       return {
         type: "image",
@@ -58,8 +54,7 @@ export const generateCssText = (data: Data, options: CssOptions) => {
 
   addGlobalRules(engine, {
     assets,
-    publicPath: options.publicPath,
-    cdnUrl: options.cdnUrl,
+    assetBaseUrl: options.assetBaseUrl,
   });
 
   for (const breakpoint of breakpoints.values()) {

--- a/packages/react-sdk/src/css/global-rules.ts
+++ b/packages/react-sdk/src/css/global-rules.ts
@@ -4,11 +4,7 @@ import { getFontFaces } from "@webstudio-is/fonts";
 
 export const addGlobalRules = (
   engine: CssEngine,
-  {
-    assets,
-    publicPath,
-    cdnUrl,
-  }: { assets: Assets; publicPath?: string; cdnUrl?: string }
+  { assets, assetBaseUrl }: { assets: Assets; assetBaseUrl: string }
 ) => {
   // @todo we need to figure out all global resets while keeping
   // the engine aware of all of them.
@@ -22,10 +18,7 @@ export const addGlobalRules = (
     }
   }
 
-  const fontFaces = getFontFaces(fontAssets, {
-    publicPath,
-    cdnUrl,
-  });
+  const fontFaces = getFontFaces(fontAssets, { assetBaseUrl });
   for (const fontFace of fontFaces) {
     engine.addFontFaceRule(fontFace);
   }

--- a/packages/react-sdk/src/tree/root.ts
+++ b/packages/react-sdk/src/tree/root.ts
@@ -35,7 +35,7 @@ export const InstanceRoot = ({
   customComponents = defaultCustomComponents,
   getComponent,
 }: RootProps): JSX.Element | null => {
-  setParams(data.params ?? null);
+  setParams(data.params);
   registerComponents(customComponents);
   return createElementsTree({
     instances: new Map(data.build.instances),


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1179

publicPath and cdnUrl are separate environment variables for different deployments. Though they do exactly same thing we can unify them as asset base url.

## Code Review

- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview
- [ ] hi @rpominov, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
