### PR TITLE
Ability to link by #ID; Fixed a bug with links in RTE

### DIFF
--- a/apps/builder/app/builder/features/props-panel/controls/combined.tsx
+++ b/apps/builder/app/builder/features/props-panel/controls/combined.tsx
@@ -13,7 +13,7 @@ export const renderControl = ({
   meta,
   prop,
   ...rest
-}: ControlProps<string, string>) => {
+}: ControlProps<string, string> & { key?: string }) => {
   if (
     meta.control === "text" &&
     (prop === undefined || prop.type === "string")
@@ -77,6 +77,7 @@ export const renderControl = ({
     (prop === undefined ||
       prop.type === "string" ||
       prop.type === "page" ||
+      prop.type === "instance" ||
       prop.type === "asset")
   ) {
     return <UrlControl meta={meta} prop={prop} {...rest} />;
@@ -145,7 +146,7 @@ export const renderControl = ({
       );
     }
 
-    if (prop.type === "page") {
+    if (prop.type === "page" || prop.type === "instance") {
       return (
         <UrlControl
           meta={{

--- a/apps/builder/app/builder/features/props-panel/controls/combined.tsx
+++ b/apps/builder/app/builder/features/props-panel/controls/combined.tsx
@@ -77,7 +77,6 @@ export const renderControl = ({
     (prop === undefined ||
       prop.type === "string" ||
       prop.type === "page" ||
-      prop.type === "instance" ||
       prop.type === "asset")
   ) {
     return <UrlControl meta={meta} prop={prop} {...rest} />;
@@ -146,7 +145,7 @@ export const renderControl = ({
       );
     }
 
-    if (prop.type === "page" || prop.type === "instance") {
+    if (prop.type === "page") {
       return (
         <UrlControl
           meta={{

--- a/apps/builder/app/builder/features/props-panel/controls/url.tsx
+++ b/apps/builder/app/builder/features/props-panel/controls/url.tsx
@@ -1,4 +1,5 @@
 import { useStore } from "@nanostores/react";
+import { computed } from "nanostores";
 import {
   instancesStore,
   pagesStore,
@@ -33,7 +34,6 @@ import {
 } from "../shared";
 import type { Instance, Page } from "@webstudio-is/project-build";
 import { SelectAsset } from "./select-asset";
-import { computed, type ReadableAtom } from "nanostores";
 
 type UrlControlProps = ControlProps<
   "url",
@@ -222,6 +222,7 @@ const BaseAttachment = ({ prop, onChange, onSoftDelete }: BaseControlProps) => (
   </Row>
 );
 
+// store that contains IDs off all instances in the selected page
 const pageInstancesStore = computed(
   [selectedPageStore, instancesStore],
   (page, instances) => {
@@ -249,7 +250,7 @@ const pageInstancesStore = computed(
   }
 );
 
-let sectionsStore: ReadableAtom<Map<string, string>> = computed(
+let sectionsStore = computed(
   [pageInstancesStore, propsStore],
   (pageInstances, props) => {
     const sections = new Map<Instance["id"], string>();

--- a/apps/builder/app/builder/features/props-panel/controls/url.tsx
+++ b/apps/builder/app/builder/features/props-panel/controls/url.tsx
@@ -259,6 +259,7 @@ let sectionsStore: ReadableAtom<Map<string, string>> = computed(
       if (
         prop.type === "string" &&
         prop.name === "id" &&
+        prop.value.trim() !== "" &&
         pageInstances.has(prop.instanceId)
       ) {
         sections.set(prop.instanceId, prop.value);

--- a/apps/builder/app/builder/features/props-panel/controls/url.tsx
+++ b/apps/builder/app/builder/features/props-panel/controls/url.tsx
@@ -33,7 +33,7 @@ import {
 } from "../shared";
 import type { Instance, Page } from "@webstudio-is/project-build";
 import { SelectAsset } from "./select-asset";
-import { computed } from "nanostores";
+import { computed, type ReadableAtom } from "nanostores";
 
 type UrlControlProps = ControlProps<
   "url",
@@ -250,7 +250,7 @@ const pageInstancesStore = computed(
   }
 );
 
-const sectionsStore = computed(
+let sectionsStore: ReadableAtom<Map<string, string>> = computed(
   [pageInstancesStore, propsStore],
   (pageInstances, props) => {
     const sections = new Map<Instance["id"], string>();
@@ -268,6 +268,12 @@ const sectionsStore = computed(
     return sections;
   }
 );
+
+// too hard to mock all the stores that sectionsStore is derived from
+// so we have this for Storybook
+export const setMockUrlSectionsStore = (store: typeof sectionsStore) => {
+  sectionsStore = store;
+};
 
 const BaseSection = ({ prop, onChange, id, instanceId }: BaseControlProps) => {
   const sections = useStore(sectionsStore);

--- a/apps/builder/app/builder/features/props-panel/controls/url.tsx
+++ b/apps/builder/app/builder/features/props-panel/controls/url.tsx
@@ -231,7 +231,6 @@ const pageInstancesStore = computed(
       return result;
     }
 
-    // @todo: do we need to handle slots specially here?
     const addInstance = (id: string) => {
       const instance = instances.get(id);
       if (instance === undefined) {

--- a/apps/builder/app/builder/features/props-panel/controls/url.tsx
+++ b/apps/builder/app/builder/features/props-panel/controls/url.tsx
@@ -235,7 +235,7 @@ const pageInstancesStore = computed(
       : findTreeInstanceIds(instances, page.rootInstanceId)
 );
 
-let sectionsStore = computed(
+const sectionsStore = computed(
   [pageInstancesStore, propsStore],
   (pageInstances, props) => {
     const sections = new Map<Instance["id"], string>();
@@ -255,15 +255,8 @@ let sectionsStore = computed(
   }
 );
 
-// too hard to mock all the stores that sectionsStore is derived from
-// so we have this for Storybook
-export const setMockUrlSectionsStore = (store: typeof sectionsStore) => {
-  sectionsStore = store;
-};
-
 const BaseSection = ({ prop, onChange, id, instanceId }: BaseControlProps) => {
   const sections = useStore(sectionsStore);
-
   const options = Array.from(sections.keys()).filter((id) => id !== instanceId);
 
   const value =

--- a/apps/builder/app/builder/features/props-panel/controls/url.tsx
+++ b/apps/builder/app/builder/features/props-panel/controls/url.tsx
@@ -42,6 +42,7 @@ type UrlControlProps = ControlProps<
 
 type BaseControlProps = {
   id: string;
+  instanceId: string;
   prop: UrlControlProps["prop"];
   onChange: UrlControlProps["onChange"];
   onSoftDelete: UrlControlProps["onSoftDelete"];
@@ -268,18 +269,22 @@ const sectionsStore = computed(
   }
 );
 
-const BaseSection = ({ prop, onChange, id }: BaseControlProps) => {
+const BaseSection = ({ prop, onChange, id, instanceId }: BaseControlProps) => {
   const sections = useStore(sectionsStore);
-  const value = prop?.type === "instance" ? prop.value : undefined;
 
-  // @todo: filter out id of current instance
+  const options = Array.from(sections.keys()).filter((id) => id !== instanceId);
+
+  const value =
+    prop?.type === "instance" && options.includes(prop.value)
+      ? prop.value
+      : undefined;
 
   return (
     <Row>
       <Select
         id={id}
         value={value}
-        options={Array.from(sections.keys())}
+        options={options}
         getLabel={(instanceId) => sections.get(instanceId) ?? ""}
         onChange={(instanceId) =>
           onChange({ type: "instance", value: instanceId })
@@ -338,6 +343,7 @@ const propToMode = (prop?: UrlControlProps["prop"]): Mode => {
 };
 
 export const UrlControl = ({
+  instanceId,
   meta,
   prop,
   propName,
@@ -385,6 +391,7 @@ export const UrlControl = ({
 
       <BaseControl
         id={id}
+        instanceId={instanceId}
         prop={prop}
         onChange={onChange}
         onSoftDelete={onSoftDelete}

--- a/apps/builder/app/builder/features/props-panel/controls/url.tsx
+++ b/apps/builder/app/builder/features/props-panel/controls/url.tsx
@@ -32,7 +32,11 @@ import {
   useLocalValue,
   VerticalLayout,
 } from "../shared";
-import type { Instance, Page } from "@webstudio-is/project-build";
+import {
+  findTreeInstanceIds,
+  type Instance,
+  type Page,
+} from "@webstudio-is/project-build";
 import { SelectAsset } from "./select-asset";
 
 type UrlControlProps = ControlProps<
@@ -222,32 +226,13 @@ const BaseAttachment = ({ prop, onChange, onSoftDelete }: BaseControlProps) => (
   </Row>
 );
 
-// store that contains IDs off all instances in the selected page
+// separate store just to avoid unnecessary recomputations
 const pageInstancesStore = computed(
   [selectedPageStore, instancesStore],
-  (page, instances) => {
-    const result = new Set<string>();
-
-    if (page === undefined) {
-      return result;
-    }
-
-    const addInstance = (id: string) => {
-      const instance = instances.get(id);
-      if (instance === undefined) {
-        return;
-      }
-      result.add(id);
-      for (const child of instance.children) {
-        if (child.type === "id") {
-          addInstance(child.value);
-        }
-      }
-    };
-    addInstance(page.rootInstanceId);
-
-    return result;
-  }
+  (page, instances): Set<Instance["id"]> =>
+    page === undefined
+      ? new Set()
+      : findTreeInstanceIds(instances, page.rootInstanceId)
 );
 
 let sectionsStore = computed(

--- a/apps/builder/app/builder/features/props-panel/props-panel.stories.tsx
+++ b/apps/builder/app/builder/features/props-panel/props-panel.stories.tsx
@@ -11,8 +11,10 @@ import type {
 } from "@webstudio-is/react-sdk";
 import { textVariants } from "@webstudio-is/design-system";
 import type { Asset } from "@webstudio-is/asset-uploader";
+import { setMockUrlSectionsStore } from "./controls/url";
 // eslint-disable-next-line import/no-internal-modules
 import catPath from "./props-panel.stories.assets/cat.jpg";
+import { atom } from "nanostores";
 
 setMockEnv({ ASSET_BASE_URL: catPath.replace("cat.jpg", "") });
 
@@ -39,6 +41,13 @@ pagesStore.set({
     page("Contacts", "/contacts"),
   ],
 });
+
+const urlSections = new Map([
+  [unique(), "links"],
+  [unique(), "about"],
+]);
+
+setMockUrlSectionsStore(atom(urlSections));
 
 const imageAsset = (name = "cat", format = "jpg"): Asset => ({
   id: unique(),
@@ -169,6 +178,7 @@ const componentPropsMeta: WsComponentPropsMeta = {
     addedCheck: checkProp(),
     addedUrlUrl: urlProp("Added URL (URL)"),
     addedUrlPage: urlProp("Added URL (Page)"),
+    addedUrlSection: urlProp("Added URL (Section)"),
     addedUrlEmail: urlProp("Added URL (Email)"),
     addedUrlPhone: urlProp("Added URL (Phone)"),
     addedUrlAttachment: urlProp("Added URL (Attachment)"),
@@ -272,6 +282,13 @@ const startingProps: Prop[] = [
   {
     id: unique(),
     instanceId,
+    name: "addedUrlSection",
+    type: "instance",
+    value: Array.from(urlSections.keys())[0] ?? "",
+  },
+  {
+    id: unique(),
+    instanceId,
     name: "addedUrlEmail",
     type: "string",
     value: "mailto:hello@example.com?subject=Hello",
@@ -327,6 +344,7 @@ export const Story = () => {
     <div style={{ display: "flex", gap: 12 }}>
       <div style={{ width: 240, border: "dashed 3px #e3e3e3" }}>
         <PropsPanel
+          instanceId={instanceId}
           propsLogic={logic}
           component="Button"
           instanceLabel="My Button"

--- a/apps/builder/app/builder/features/props-panel/props-panel.stories.tsx
+++ b/apps/builder/app/builder/features/props-panel/props-panel.stories.tsx
@@ -92,6 +92,7 @@ const addLinkableSections = (
 };
 
 addLinkableSections(["contacts", "about"]);
+addLinkableSections(["company", "employees"], pagesStore.get()?.pages[0]);
 selectedPageIdStore.set(pagesStore.get()?.homePage.id);
 
 const imageAsset = (name = "cat", format = "jpg"): Asset => ({
@@ -328,8 +329,11 @@ const startingProps: Prop[] = [
     id: unique(),
     instanceId,
     name: "addedUrlSection",
-    type: "instance",
-    value: getSectionInstanceId("about"),
+    type: "page",
+    value: {
+      pageId: pagesStore.get()?.homePage.id ?? "",
+      instanceId: getSectionInstanceId("about"),
+    },
   },
   {
     id: unique(),

--- a/apps/builder/app/builder/features/props-panel/props-panel.tsx
+++ b/apps/builder/app/builder/features/props-panel/props-panel.tsx
@@ -130,6 +130,7 @@ const renderProperty = (
   deletable?: boolean
 ) =>
   renderControl({
+    key: propName,
     meta,
     prop,
     propName,

--- a/apps/builder/app/builder/features/props-panel/props-panel.tsx
+++ b/apps/builder/app/builder/features/props-panel/props-panel.tsx
@@ -8,13 +8,13 @@ import {
   ComboboxAnchor,
   ComboboxListbox,
   ComboboxListboxItem,
-  SmallIconButton,
   Separator,
   Flex,
   Text,
   type CSS,
   ScrollArea,
   InputField,
+  NestedSelectButton,
 } from "@webstudio-is/design-system";
 import { ChevronDownIcon } from "@webstudio-is/icons";
 import type { Publish } from "~/shared/pubsub";
@@ -97,9 +97,8 @@ const PropsCombobox = ({
             {...combobox.getInputProps()}
             placeholder="Property"
             suffix={
-              <SmallIconButton
+              <NestedSelectButton
                 {...combobox.getToggleButtonProps()}
-                css={{ display: "flex", justifyContent: "center" }}
                 icon={<ChevronDownIcon />}
               />
             }
@@ -239,7 +238,6 @@ export const PropsPanel = (props: PropsPanelProps) => {
           </Flex>
         )}
       </CollapsibleSectionWithAddButton>
-      <Separator />
     </ScrollArea>
   );
 };

--- a/apps/builder/app/builder/features/props-panel/props-panel.tsx
+++ b/apps/builder/app/builder/features/props-panel/props-panel.tsx
@@ -126,7 +126,8 @@ const PropsCombobox = ({
 
 const renderProperty = (
   { propsLogic: logic, setCssProperty, component }: PropsPanelProps,
-  { prop, propName, meta, deletable }: PropAndMeta & { deletable?: boolean }
+  { prop, propName, meta }: PropAndMeta,
+  deletable?: boolean
 ) =>
   renderControl({
     meta,
@@ -222,10 +223,7 @@ export const PropsPanel = (props: PropsPanelProps) => {
       >
         {hasAddedProps && (
           <Flex gap="2" direction="column">
-            {logic.addedProps.map(({ prop, propName, meta }) =>
-              renderProperty(props, { prop, propName, meta, deletable: true })
-            )}
-
+            {logic.addedProps.map((item) => renderProperty(props, item, true))}
             {addingProp && (
               <AddPropertyForm
                 availableProps={logic.remainingProps}

--- a/apps/builder/app/builder/features/props-panel/props-panel.tsx
+++ b/apps/builder/app/builder/features/props-panel/props-panel.tsx
@@ -125,12 +125,13 @@ const PropsCombobox = ({
 };
 
 const renderProperty = (
-  { propsLogic: logic, setCssProperty, component }: PropsPanelProps,
+  { propsLogic: logic, setCssProperty, component, instanceId }: PropsPanelProps,
   { prop, propName, meta }: PropAndMeta,
   deletable?: boolean
 ) =>
   renderControl({
     key: propName,
+    instanceId,
     meta,
     prop,
     propName,
@@ -177,6 +178,7 @@ type PropsPanelProps = {
   propsLogic: ReturnType<typeof usePropsLogic>;
   component: Instance["component"];
   instanceLabel: string;
+  instanceId: string;
   componentMeta: WsComponentMeta;
   setCssProperty: SetCssProperty;
 };
@@ -286,6 +288,7 @@ export const PropsPanelContainer = ({
     <PropsPanel
       propsLogic={logic}
       component={instance.component}
+      instanceId={instance.id}
       instanceLabel={instanceLabel}
       componentMeta={componentMeta}
       setCssProperty={setCssProperty}

--- a/apps/builder/app/builder/features/props-panel/shared.tsx
+++ b/apps/builder/app/builder/features/props-panel/shared.tsx
@@ -40,6 +40,7 @@ type PropByType<Type> = Type extends string
   : never;
 
 export type ControlProps<Control, PropType> = {
+  instanceId: string;
   meta: PropMetaByControl<Control>;
   // prop is optional because we don't have it when an intial prop is not set
   // and we don't want to show user something like a 0 for number when it's in fact not set to any value

--- a/apps/builder/app/builder/features/props-panel/use-props-logic.ts
+++ b/apps/builder/app/builder/features/props-panel/use-props-logic.ts
@@ -86,8 +86,8 @@ type UsePropsLogicInput = {
 };
 
 type UsePropsLogicOutput = {
-  /** Similar to Initial, but displayed as a seoparate group in UI etc.
-   * Currentrly only for the ID prop. */
+  /** Similar to Initial, but displayed as a separate group in UI etc.
+   * Currentrly used only for the ID prop. */
   systemProps: PropAndMeta[];
   /** Initial (not deletable) props */
   initialProps: PropAndMeta[];

--- a/apps/builder/app/builder/features/props-panel/use-props-logic.ts
+++ b/apps/builder/app/builder/features/props-panel/use-props-logic.ts
@@ -86,24 +86,19 @@ type UsePropsLogicInput = {
 };
 
 type UsePropsLogicOutput = {
-  /**
-   * Initial (not deletable) props
-   */
+  /** Similar to Initial, but displayed as a seoparate group in UI etc.
+   * Currentrly only for the ID prop. */
+  systemProps: PropAndMeta[];
+  /** Initial (not deletable) props */
   initialProps: PropAndMeta[];
-  /**
-   * Optional props that were added by user
-   */
+  /** Optional props that were added by user */
   addedProps: PropAndMeta[];
-  /**
-   * List of remaining props still available to add
-   */
+  /** List of remaining props still available to add */
   remainingProps: NameAndLabel[];
   handleAdd: (propName: string) => void;
   handleChange: (prop: PropOrName, value: PropValue) => void;
   handleDelete: (prop: PropOrName) => void;
-  /**
-   * Delete the prop, but keep it in the list of added props
-   */
+  /** Delete the prop, but keep it in the list of added props */
   handleSoftDelete: (prop: Prop) => void;
 };
 
@@ -113,9 +108,20 @@ const getAndDelete = <Value>(map: Map<string, Value>, key: string) => {
   return value;
 };
 
-/**
- * usePropsLogic expects that key={instanceId} is used on the ancestor component
- */
+const systemPropsMeta: { name: string; meta: PropMeta }[] = [
+  {
+    name: "id",
+    meta: {
+      required: false,
+      control: "text",
+      type: "string",
+      rows: 0,
+      label: "ID",
+    },
+  },
+];
+
+/** usePropsLogic expects that key={instanceId} is used on the ancestor component */
 export const usePropsLogic = ({
   props: savedProps,
   meta,
@@ -127,7 +133,16 @@ export const usePropsLogic = ({
   const unprocessedSaved = new Map(savedProps.map((prop) => [prop.name, prop]));
   const unprocessedKnown = new Map(Object.entries(meta.props));
 
-  const initialProps: PropAndMeta[] = (meta.initialProps ?? []).map((name) => {
+  const initialPropsNames = new Set(meta.initialProps ?? []);
+
+  const systemProps = systemPropsMeta.map(({ name, meta }) => {
+    const saved = getAndDelete(unprocessedSaved, name);
+    getAndDelete(unprocessedKnown, name);
+    initialPropsNames.delete(name);
+    return { prop: saved, propName: name, meta };
+  });
+
+  const initialProps: PropAndMeta[] = Array.from(initialPropsNames, (name) => {
     const saved = getAndDelete(unprocessedSaved, name);
     const known = getAndDelete(unprocessedKnown, name);
 
@@ -222,9 +237,11 @@ export const usePropsLogic = ({
   };
 
   return {
+    systemProps,
     initialProps,
     addedProps,
-    remainingProps: Array.from(unprocessedKnown.entries()).map(
+    remainingProps: Array.from(
+      unprocessedKnown.entries(),
       ([name, { label }]) => ({ name, label })
     ),
     handleAdd,

--- a/apps/builder/app/canvas/features/webstudio-component/link.ts
+++ b/apps/builder/app/canvas/features/webstudio-component/link.ts
@@ -33,7 +33,9 @@ export const handleLinkClick = (event: MouseEvent) => {
     return;
   }
 
-  const page = findPageByIdOrPath(pages, href);
+  const [withoutHash] = href.split("#");
+
+  const page = findPageByIdOrPath(pages, withoutHash);
 
   if (page) {
     publish({ type: "switchPage", payload: { pageId: page.id } });

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -118,11 +118,7 @@ export const WebstudioComponentDev = ({
       return result;
     }
     for (const item of instanceProps) {
-      if (
-        item.type !== "asset" &&
-        item.type !== "page" &&
-        item.type !== "instance"
-      ) {
+      if (item.type !== "asset" && item.type !== "page") {
         result[item.name] = item.value;
       }
     }

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -118,7 +118,11 @@ export const WebstudioComponentDev = ({
       return result;
     }
     for (const item of instanceProps) {
-      if (item.type !== "asset") {
+      if (
+        item.type !== "asset" &&
+        item.type !== "page" &&
+        item.type !== "instance"
+      ) {
         result[item.name] = item.value;
       }
     }

--- a/packages/design-system/src/components/select.tsx
+++ b/packages/design-system/src/components/select.tsx
@@ -27,7 +27,11 @@ export const SelectSeparator = styled(Primitive.Separator, separatorCss);
 
 export const SelectGroup = Primitive.Group;
 
-const StyledItem = styled(Primitive.Item, itemCss);
+const StyledItem = styled(Primitive.Item, itemCss, {
+  // we don't want to transform text using CSS in case of the Select,
+  // we want getLabel to handle it
+  textTransform: "none",
+});
 
 const StyledIndicator = styled(Primitive.ItemIndicator, itemIndicatorCss);
 

--- a/packages/project-build/src/schema/props.ts
+++ b/packages/project-build/src/schema/props.ts
@@ -37,6 +37,11 @@ export const Prop = z.union([
   }),
   z.object({
     ...baseProp,
+    type: z.literal("instance"),
+    value: z.string(), // instance id
+  }),
+  z.object({
+    ...baseProp,
     type: z.literal("string[]"),
     value: z.array(z.string()),
   }),

--- a/packages/project-build/src/schema/props.ts
+++ b/packages/project-build/src/schema/props.ts
@@ -33,12 +33,13 @@ export const Prop = z.union([
   z.object({
     ...baseProp,
     type: z.literal("page"),
-    value: z.string(), // page id
-  }),
-  z.object({
-    ...baseProp,
-    type: z.literal("instance"),
-    value: z.string(), // instance id
+    value: z.union([
+      z.string(), // page id
+      z.object({
+        pageId: z.string(),
+        instanceId: z.string(),
+      }),
+    ]),
   }),
   z.object({
     ...baseProp,

--- a/packages/react-sdk/src/app/custom-components/shared/remix-link.tsx
+++ b/packages/react-sdk/src/app/custom-components/shared/remix-link.tsx
@@ -12,7 +12,11 @@ export const wrapLinkComponent = (BaseLink: LinkComponent) => {
     const href = usePropUrl(getInstanceIdFromComponentProps(props), "href");
 
     if (href?.type === "page") {
-      return <RemixLink {...props} to={href.page.path} ref={ref} />;
+      let to = href.page.path;
+      if (href.idPropValue !== undefined) {
+        to += `#${href.idPropValue}`;
+      }
+      return <RemixLink {...props} to={to} ref={ref} />;
     }
 
     return <BaseLink {...props} ref={ref} />;

--- a/packages/react-sdk/src/app/custom-components/shared/remix-link.tsx
+++ b/packages/react-sdk/src/app/custom-components/shared/remix-link.tsx
@@ -13,8 +13,8 @@ export const wrapLinkComponent = (BaseLink: LinkComponent) => {
 
     if (href?.type === "page") {
       let to = href.page.path;
-      if (href.idPropValue !== undefined) {
-        to += `#${href.idPropValue}`;
+      if (href.hash !== undefined) {
+        to += `#${href.hash}`;
       }
       return <RemixLink {...props} to={to} ref={ref} />;
     }

--- a/packages/react-sdk/src/components/link.tsx
+++ b/packages/react-sdk/src/components/link.tsx
@@ -24,8 +24,8 @@ export const Link = forwardRef<HTMLAnchorElement, Props>((props, ref) => {
   switch (href?.type) {
     case "page":
       url = href.page.path;
-      if (href.idPropValue !== undefined) {
-        url += `#${href.idPropValue}`;
+      if (href.hash !== undefined) {
+        url += `#${href.hash}`;
       }
       break;
     case "asset":

--- a/packages/react-sdk/src/components/link.tsx
+++ b/packages/react-sdk/src/components/link.tsx
@@ -24,12 +24,12 @@ export const Link = forwardRef<HTMLAnchorElement, Props>((props, ref) => {
   switch (href?.type) {
     case "page":
       url = href.page.path;
+      if (href.idPropValue !== undefined) {
+        url += `#${href.idPropValue}`;
+      }
       break;
     case "asset":
       url = `${assetBaseUrl}${href.asset.name}`;
-      break;
-    case "instance":
-      url = `#${href.idProp ?? ""}`;
       break;
     case "string":
       url = href.url;

--- a/packages/react-sdk/src/components/link.tsx
+++ b/packages/react-sdk/src/components/link.tsx
@@ -19,13 +19,17 @@ export const Link = forwardRef<HTMLAnchorElement, Props>((props, ref) => {
 
   const { assetBaseUrl } = getParams();
 
-  let url: string | undefined;
+  let url = "#";
+
   switch (href?.type) {
     case "page":
       url = href.page.path;
       break;
     case "asset":
       url = `${assetBaseUrl}${href.asset.name}`;
+      break;
+    case "instance":
+      url = `#${href.idProp ?? ""}`;
       break;
     case "string":
       url = href.url;

--- a/packages/react-sdk/src/props.test.ts
+++ b/packages/react-sdk/src/props.test.ts
@@ -147,7 +147,7 @@ describe("resolveUrlProp", () => {
       type: "page",
       page: page1,
       instanceId: instnaceIdProp.instanceId,
-      idPropValue: instnaceIdProp.value,
+      hash: instnaceIdProp.value,
     });
   });
 

--- a/packages/react-sdk/src/props.test.ts
+++ b/packages/react-sdk/src/props.test.ts
@@ -56,6 +56,22 @@ describe("resolveUrlProp", () => {
     value: page1.id,
   };
 
+  const instnaceIdProp: Prop = {
+    type: "string",
+    id: unique(),
+    instanceId: unique(),
+    name: "id",
+    value: unique(),
+  };
+
+  const pageSectionProp: Prop = {
+    type: "page",
+    id: unique(),
+    instanceId,
+    name: unique(),
+    value: { pageId: page1.id, instanceId: instnaceIdProp.instanceId },
+  };
+
   const pageByPathProp: Prop = {
     type: "string",
     id: unique(),
@@ -72,30 +88,6 @@ describe("resolveUrlProp", () => {
     value: unique(),
   };
 
-  const instanceProp1: Prop = {
-    type: "instance",
-    id: unique(),
-    instanceId,
-    name: unique(),
-    value: unique(),
-  };
-
-  const instnaceIdProp: Prop = {
-    type: "string",
-    id: unique(),
-    instanceId: instanceProp1.value,
-    name: "id",
-    value: unique(),
-  };
-
-  const instanceProp2: Prop = {
-    type: "instance",
-    id: unique(),
-    instanceId,
-    name: unique(),
-    value: unique(),
-  };
-
   const props: PropsByInstanceId = new Map([
     [
       instanceId,
@@ -104,8 +96,7 @@ describe("resolveUrlProp", () => {
         pageByPathProp,
         arbitraryUrlProp,
         assetProp,
-        instanceProp1,
-        instanceProp2,
+        pageSectionProp,
       ],
     ],
     [instnaceIdProp.instanceId, [instnaceIdProp]],
@@ -151,18 +142,12 @@ describe("resolveUrlProp", () => {
     });
   });
 
-  test("instance by id", () => {
-    expect(resolveUrlProp(instanceId, instanceProp1.name, stores)).toEqual({
-      type: "instance",
+  test("section on a page", () => {
+    expect(resolveUrlProp(instanceId, pageSectionProp.name, stores)).toEqual({
+      type: "page",
+      page: page1,
       instanceId: instnaceIdProp.instanceId,
-      idProp: instnaceIdProp.value,
-    });
-  });
-
-  test("instance by id (no id prop)", () => {
-    expect(resolveUrlProp(instanceId, instanceProp2.name, stores)).toEqual({
-      type: "instance",
-      instanceId: instanceProp2.value,
+      idPropValue: instnaceIdProp.value,
     });
   });
 

--- a/packages/react-sdk/src/props.test.ts
+++ b/packages/react-sdk/src/props.test.ts
@@ -72,8 +72,43 @@ describe("resolveUrlProp", () => {
     value: unique(),
   };
 
+  const instanceProp1: Prop = {
+    type: "instance",
+    id: unique(),
+    instanceId,
+    name: unique(),
+    value: unique(),
+  };
+
+  const instnaceIdProp: Prop = {
+    type: "string",
+    id: unique(),
+    instanceId: instanceProp1.value,
+    name: "id",
+    value: unique(),
+  };
+
+  const instanceProp2: Prop = {
+    type: "instance",
+    id: unique(),
+    instanceId,
+    name: unique(),
+    value: unique(),
+  };
+
   const props: PropsByInstanceId = new Map([
-    [instanceId, [pageByIdProp, pageByPathProp, arbitraryUrlProp, assetProp]],
+    [
+      instanceId,
+      [
+        pageByIdProp,
+        pageByPathProp,
+        arbitraryUrlProp,
+        assetProp,
+        instanceProp1,
+        instanceProp2,
+      ],
+    ],
+    [instnaceIdProp.instanceId, [instnaceIdProp]],
   ]);
 
   const pages: Pages = new Map([
@@ -113,6 +148,21 @@ describe("resolveUrlProp", () => {
     expect(resolveUrlProp(instanceId, pageByPathProp.name, stores)).toEqual({
       type: "page",
       page: page2,
+    });
+  });
+
+  test("instance by id", () => {
+    expect(resolveUrlProp(instanceId, instanceProp1.name, stores)).toEqual({
+      type: "instance",
+      instanceId: instnaceIdProp.instanceId,
+      idProp: instnaceIdProp.value,
+    });
+  });
+
+  test("instance by id (no id prop)", () => {
+    expect(resolveUrlProp(instanceId, instanceProp2.name, stores)).toEqual({
+      type: "instance",
+      instanceId: instanceProp2.value,
     });
   });
 

--- a/packages/react-sdk/src/props.ts
+++ b/packages/react-sdk/src/props.ts
@@ -32,7 +32,11 @@ export const useInstanceProps = (instanceId: Instance["id"]) => {
   const instancePropsObject: Record<Prop["name"], Prop["value"]> = {};
   if (instanceProps) {
     for (const prop of instanceProps) {
-      if (prop.type !== "asset") {
+      if (
+        prop.type !== "asset" &&
+        prop.type !== "page" &&
+        prop.type !== "instance"
+      ) {
         instancePropsObject[prop.name] = prop.value;
       }
     }

--- a/packages/react-sdk/src/props.ts
+++ b/packages/react-sdk/src/props.ts
@@ -78,7 +78,7 @@ export const resolveUrlProp = (
       type: "page";
       page: Page;
       instanceId?: Instance["id"];
-      idPropValue?: string;
+      hash?: string;
     }
   | { type: "asset"; asset: Asset }
   | { type: "string"; url: string }
@@ -112,7 +112,7 @@ export const resolveUrlProp = (
         type: "page",
         page,
         instanceId,
-        idPropValue:
+        hash:
           idProp === undefined || idProp.type !== "string"
             ? undefined
             : idProp.value,

--- a/packages/react-sdk/src/props.ts
+++ b/packages/react-sdk/src/props.ts
@@ -81,6 +81,7 @@ export const resolveUrlProp = (
   | { type: "page"; page: Page }
   | { type: "asset"; asset: Asset }
   | { type: "string"; url: string }
+  | { type: "instance"; instanceId: Instance["id"]; idProp?: string }
   | undefined => {
   const instanceProps = props.get(instanceId);
   if (instanceProps === undefined) {
@@ -110,6 +111,18 @@ export const resolveUrlProp = (
       return asset && { type: "asset", asset };
     }
 
+    if (prop.type === "instance") {
+      const idProp = props.get(prop.value)?.find((prop) => prop.name === "id");
+      return {
+        type: "instance",
+        instanceId: prop.value,
+        idProp:
+          idProp === undefined || idProp.type !== "string"
+            ? undefined
+            : idProp.value,
+      };
+    }
+
     return;
   }
 };
@@ -119,7 +132,7 @@ export const resolveUrlProp = (
 export const usePropUrl = (instanceId: Instance["id"], name: string) => {
   const { propsByInstanceIdStore, pagesStore, assetsStore } =
     useContext(ReactSdkContext);
-  const pageStore = useMemo(
+  const store = useMemo(
     () =>
       computed(
         [propsByInstanceIdStore, pagesStore, assetsStore],
@@ -128,7 +141,7 @@ export const usePropUrl = (instanceId: Instance["id"], name: string) => {
       ),
     [propsByInstanceIdStore, pagesStore, assetsStore, instanceId, name]
   );
-  return useStore(pageStore);
+  return useStore(store);
 };
 
 export const getInstanceIdFromComponentProps = (


### PR DESCRIPTION
## Description

1. Made `href` always present (# is used when not set, similar to Webflow). Fixes #1380
2. Added "Section" option in URL Control. Closes #993 
3. Added "ID" prop that is visible in all components. Closes #991 
4. Closes #1475

## Steps for reproduction

1. Add ID prop to an instance
4. Add a link that references that instance by ID

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @TrySound, I need you to
  - have a look at how I deal with stores to get list of available IDs

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
