### PR TITLE
Concurency mode for React 18

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -29,7 +29,6 @@ import {
   useRef,
 } from "react";
 import { useUnitSelect } from "./unit-select";
-import { unstable_batchedUpdates as unstableBatchedUpdates } from "react-dom";
 import { parseIntermediateOrInvalidValue } from "./parse-intermediate-or-invalid-value";
 import { toValue } from "@webstudio-is/css-engine";
 import { useDebouncedCallback } from "use-debounce";
@@ -115,12 +114,11 @@ const useScrub = ({
       onValueChange(event) {
         // Will work without but depends on order of setState updates
         // at text-control, now fixed in both places (order of updates is right, and batched here)
-        unstableBatchedUpdates(() => {
-          onChangeCompleteRef.current({
-            type,
-            unit,
-            value: event.value,
-          });
+
+        onChangeCompleteRef.current({
+          type,
+          unit,
+          value: event.value,
         });
 
         // Returning focus that we've moved above

--- a/apps/builder/app/entry.client.tsx
+++ b/apps/builder/app/entry.client.tsx
@@ -1,10 +1,8 @@
-import { hydrate } from "react-dom";
-import { RemixBrowser } from "@remix-run/react";
-import { initSentry } from "./shared/sentry";
-
-import { useLocation, useMatches } from "@remix-run/react";
+import { RemixBrowser, useLocation, useMatches } from "@remix-run/react";
+import { startTransition, StrictMode, useEffect } from "react";
+import { hydrateRoot } from "react-dom/client";
 import { BrowserTracing, remixRouterInstrumentation } from "@sentry/remix";
-import { useEffect } from "react";
+import { initSentry } from "./shared/sentry";
 import env from "./shared/env";
 
 initSentry({
@@ -35,4 +33,11 @@ try {
   console.warn("Failed to set localStorage.debug due to Error:", error);
 }
 
-hydrate(<RemixBrowser />, document);
+startTransition(() => {
+  hydrateRoot(
+    document,
+    <StrictMode>
+      <RemixBrowser />
+    </StrictMode>
+  );
+});

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -20,132 +20,123 @@ import {
   getAncestorInstanceSelector,
 } from "./tree-utils";
 import { removeByMutable } from "./array-utils";
-import { unstable_batchedUpdates as batchedUpdates } from "react-dom";
 
 export const insertNewComponentInstance = (
   component: string,
   dropTarget: DroppableTarget
 ) => {
-  batchedUpdates(() => {
-    const instance = createComponentInstance(component);
-    store.createTransaction([instancesStore], (instances) => {
-      insertInstancesMutable(instances, [instance], [instance.id], dropTarget);
-    });
-
-    selectedInstanceSelectorStore.set([
-      instance.id,
-      ...dropTarget.parentSelector,
-    ]);
-    selectedStyleSourceSelectorStore.set(undefined);
+  const instance = createComponentInstance(component);
+  store.createTransaction([instancesStore], (instances) => {
+    insertInstancesMutable(instances, [instance], [instance.id], dropTarget);
   });
+
+  selectedInstanceSelectorStore.set([
+    instance.id,
+    ...dropTarget.parentSelector,
+  ]);
+  selectedStyleSourceSelectorStore.set(undefined);
 };
 
 export const reparentInstance = (
   targetInstanceSelector: InstanceSelector,
   dropTarget: DroppableTarget
 ) => {
-  batchedUpdates(() => {
-    store.createTransaction([instancesStore], (instances) => {
-      reparentInstanceMutable(instances, targetInstanceSelector, dropTarget);
-    });
-    selectedInstanceSelectorStore.set(targetInstanceSelector);
-    selectedStyleSourceSelectorStore.set(undefined);
+  store.createTransaction([instancesStore], (instances) => {
+    reparentInstanceMutable(instances, targetInstanceSelector, dropTarget);
   });
+  selectedInstanceSelectorStore.set(targetInstanceSelector);
+  selectedStyleSourceSelectorStore.set(undefined);
 };
 
 export const deleteInstance = (instanceSelector: InstanceSelector) => {
-  batchedUpdates(() => {
-    store.createTransaction(
-      [
-        instancesStore,
-        propsStore,
-        styleSourceSelectionsStore,
-        styleSourcesStore,
-        stylesStore,
-      ],
-      (instances, props, styleSourceSelections, styleSources, styles) => {
-        let targetInstanceId = instanceSelector[0];
-        const parentInstanceId = instanceSelector[1];
-        const grandparentInstanceId = instanceSelector[2];
-        let parentInstance =
-          parentInstanceId === undefined
-            ? undefined
-            : instances.get(parentInstanceId);
+  store.createTransaction(
+    [
+      instancesStore,
+      propsStore,
+      styleSourceSelectionsStore,
+      styleSourcesStore,
+      stylesStore,
+    ],
+    (instances, props, styleSourceSelections, styleSources, styles) => {
+      let targetInstanceId = instanceSelector[0];
+      const parentInstanceId = instanceSelector[1];
+      const grandparentInstanceId = instanceSelector[2];
+      let parentInstance =
+        parentInstanceId === undefined
+          ? undefined
+          : instances.get(parentInstanceId);
 
-        // delete parent fragment too if its last child is going to be deleted
-        // use case for slots: slot became empty and remove display: contents
-        // to be displayed properly on canvas
-        if (
-          parentInstance?.component === "Fragment" &&
-          parentInstance.children.length === 1 &&
-          grandparentInstanceId !== undefined
-        ) {
-          targetInstanceId = parentInstance.id;
-          parentInstance = instances.get(grandparentInstanceId);
-        }
+      // delete parent fragment too if its last child is going to be deleted
+      // use case for slots: slot became empty and remove display: contents
+      // to be displayed properly on canvas
+      if (
+        parentInstance?.component === "Fragment" &&
+        parentInstance.children.length === 1 &&
+        grandparentInstanceId !== undefined
+      ) {
+        targetInstanceId = parentInstance.id;
+        parentInstance = instances.get(grandparentInstanceId);
+      }
 
-        const subtreeIds = findTreeInstanceIdsExcludingSlotDescendants(
-          instances,
-          targetInstanceId
+      const subtreeIds = findTreeInstanceIdsExcludingSlotDescendants(
+        instances,
+        targetInstanceId
+      );
+      const subtreeLocalStyleSourceIds = findSubtreeLocalStyleSources(
+        subtreeIds,
+        styleSources,
+        styleSourceSelections
+      );
+
+      // may not exist when delete root
+      if (parentInstance) {
+        removeByMutable(
+          parentInstance.children,
+          (child) => child.type === "id" && child.value === targetInstanceId
         );
-        const subtreeLocalStyleSourceIds = findSubtreeLocalStyleSources(
-          subtreeIds,
-          styleSources,
-          styleSourceSelections
-        );
+      }
 
-        // may not exist when delete root
-        if (parentInstance) {
-          removeByMutable(
-            parentInstance.children,
-            (child) => child.type === "id" && child.value === targetInstanceId
-          );
-        }
-
-        for (const instanceId of subtreeIds) {
-          instances.delete(instanceId);
-        }
-        // delete props and styles of deleted instance and its descendants
-        for (const prop of props.values()) {
-          if (subtreeIds.has(prop.instanceId)) {
-            props.delete(prop.id);
-          }
-        }
-        for (const instanceId of subtreeIds) {
-          styleSourceSelections.delete(instanceId);
-        }
-        for (const styleSourceId of subtreeLocalStyleSourceIds) {
-          styleSources.delete(styleSourceId);
-        }
-        for (const [styleDeclKey, styleDecl] of styles) {
-          if (subtreeLocalStyleSourceIds.has(styleDecl.styleSourceId)) {
-            styles.delete(styleDeclKey);
-          }
-        }
-
-        if (parentInstance) {
-          selectedInstanceSelectorStore.set(
-            getAncestorInstanceSelector(instanceSelector, parentInstance.id)
-          );
-          selectedStyleSourceSelectorStore.set(undefined);
+      for (const instanceId of subtreeIds) {
+        instances.delete(instanceId);
+      }
+      // delete props and styles of deleted instance and its descendants
+      for (const prop of props.values()) {
+        if (subtreeIds.has(prop.instanceId)) {
+          props.delete(prop.id);
         }
       }
-    );
-  });
+      for (const instanceId of subtreeIds) {
+        styleSourceSelections.delete(instanceId);
+      }
+      for (const styleSourceId of subtreeLocalStyleSourceIds) {
+        styleSources.delete(styleSourceId);
+      }
+      for (const [styleDeclKey, styleDecl] of styles) {
+        if (subtreeLocalStyleSourceIds.has(styleDecl.styleSourceId)) {
+          styles.delete(styleDeclKey);
+        }
+      }
+
+      if (parentInstance) {
+        selectedInstanceSelectorStore.set(
+          getAncestorInstanceSelector(instanceSelector, parentInstance.id)
+        );
+        selectedStyleSourceSelectorStore.set(undefined);
+      }
+    }
+  );
 };
 
 export const deleteSelectedInstance = () => {
-  batchedUpdates(() => {
-    const selectedInstanceSelector = selectedInstanceSelectorStore.get();
-    // @todo tell user they can't delete root
-    if (
-      selectedInstanceSelector === undefined ||
-      selectedInstanceSelector.length === 1
-    ) {
-      return;
-    }
-    deleteInstance(selectedInstanceSelector);
-  });
+  const selectedInstanceSelector = selectedInstanceSelectorStore.get();
+  // @todo tell user they can't delete root
+  if (
+    selectedInstanceSelector === undefined ||
+    selectedInstanceSelector.length === 1
+  ) {
+    return;
+  }
+  deleteInstance(selectedInstanceSelector);
 };
 
 export const escapeSelection = () => {

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -221,10 +221,6 @@ const handshakeAndSyncStores = (
   } as const;
 
   publish(handshakeAction);
-  // Use setInterval as with SSR iframe can send handshake before builder is initialized and vice versa
-  const intervalHandle = setInterval(() => {
-    publish(handshakeAction);
-  }, 100);
 
   const destinationStoreReady = subscribe("handshake", (payload) => {
     if (source === payload.source) {
@@ -237,8 +233,6 @@ const handshakeAndSyncStores = (
 
     // We need to publish it here last time
     publish(handshakeAction);
-
-    clearInterval(intervalHandle);
 
     for (const action of actions) {
       publish(action);
@@ -255,7 +249,6 @@ const handshakeAndSyncStores = (
   return () => {
     destinationStoreReady();
     unsubscribe();
-    clearInterval(intervalHandle);
   };
 };
 

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -36,7 +36,8 @@ type SyncEventSource = "canvas" | "builder";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
-    canvasStoreReady: void;
+    handshake: { source: SyncEventSource };
+
     sendStoreData: {
       // distinct source to avoid infinite loop
       source: SyncEventSource;
@@ -112,6 +113,7 @@ const syncStoresChanges = (name: SyncEventSource, publish: Publish) => {
       if (source === "remote") {
         return;
       }
+
       publish({
         type: "sendStoreChanges",
         payload: {
@@ -168,6 +170,7 @@ const syncStoresState = (name: SyncEventSource, publish: Publish) => {
           return;
         }
         latestData.set(namespace, value);
+
         publish({
           type: "sendStoreData",
           payload: {
@@ -192,25 +195,89 @@ const syncStoresState = (name: SyncEventSource, publish: Publish) => {
   };
 };
 
+const handshakeAndSyncStores = (
+  source: SyncEventSource,
+  publish: Publish,
+  sync: (publish: Publish) => () => void
+) => {
+  const actions: Parameters<typeof publish>[0][] = [];
+  let destinationReady = false;
+
+  // Until builder is ready store action in local cache
+  const publishAction: typeof publish = (action) => {
+    if (destinationReady) {
+      return publish(action);
+    }
+    actions.push(action);
+  };
+
+  const unsubscribe = sync(publishAction);
+
+  const handshakeAction = {
+    type: "handshake",
+    payload: {
+      source,
+    },
+  } as const;
+
+  publish(handshakeAction);
+  // Use setInterval as with SSR iframe can send handshake before builder is initialized and vice versa
+  const intervalHandle = setInterval(() => {
+    publish(handshakeAction);
+  }, 100);
+
+  const destinationStoreReady = subscribe("handshake", (payload) => {
+    if (source === payload.source) {
+      return;
+    }
+
+    if (destinationReady) {
+      return;
+    }
+
+    // We need to publish it here last time
+    publish(handshakeAction);
+
+    clearInterval(intervalHandle);
+
+    for (const action of actions) {
+      publish(action);
+    }
+
+    // cleanup
+    actions.length = 0;
+
+    destinationReady = true;
+
+    destinationStoreReady();
+  });
+
+  return () => {
+    destinationStoreReady();
+    unsubscribe();
+    clearInterval(intervalHandle);
+  };
+};
+
 export const useCanvasStore = (publish: Publish) => {
   useEffect(() => {
-    const unsubscribeStoresState = syncStoresState("canvas", publish);
-    const unsubscribeStoresChanges = syncStoresChanges("canvas", publish);
-
-    publish({
-      type: "canvasStoreReady",
+    return handshakeAndSyncStores("canvas", publish, (publish) => {
+      const unsubscribeStoresState = syncStoresState("canvas", publish);
+      const unsubscribeStoresChanges = syncStoresChanges("canvas", publish);
+      return () => {
+        unsubscribeStoresState();
+        unsubscribeStoresChanges();
+      };
     });
-
-    return () => {
-      unsubscribeStoresState();
-      unsubscribeStoresChanges();
-    };
   }, [publish]);
 };
 
 export const useBuilderStore = (publish: Publish) => {
   useEffect(() => {
-    const unsubscribeCanvasStoreReady = subscribe("canvasStoreReady", () => {
+    return handshakeAndSyncStores("builder", publish, (publish) => {
+      const unsubscribeStoresState = syncStoresState("builder", publish);
+      const unsubscribeStoresChanges = syncStoresChanges("builder", publish);
+
       // immerhin data is sent only initially so not part of syncStoresState
       // expect data to be populated by the time effect is called
       const data = [];
@@ -233,15 +300,11 @@ export const useBuilderStore = (publish: Publish) => {
           data,
         },
       });
+
+      return () => {
+        unsubscribeStoresState();
+        unsubscribeStoresChanges();
+      };
     });
-
-    const unsubscribeStoresState = syncStoresState("builder", publish);
-    const unsubscribeStoresChanges = syncStoresChanges("builder", publish);
-
-    return () => {
-      unsubscribeCanvasStoreReady();
-      unsubscribeStoresState();
-      unsubscribeStoresChanges();
-    };
   }, [publish]);
 };

--- a/packages/react-sdk/src/pubsub/raf-queue.ts
+++ b/packages/react-sdk/src/pubsub/raf-queue.ts
@@ -1,18 +1,12 @@
-import { unstable_batchedUpdates as batchedUpdates } from "react-dom";
-
 type Task = () => void;
 
 let handle: ReturnType<typeof requestAnimationFrame> | undefined;
 let updateQueue: Task[] = [];
 
 const processUpdates = (updates: Task[]) => {
-  // Prior to React v18, updates not called within React event handlers would not be batched
-  // To ensure all updates are batched into a single React update, we wrap them in a batchedUpdates callback
-  batchedUpdates(() => {
-    for (const update of updates) {
-      update();
-    }
-  });
+  for (const update of updates) {
+    update();
+  }
 };
 
 export const batchUpdate = (update: () => void) => {


### PR DESCRIPTION
## Description

Made handshake between canvas and builder.
Now publish actions are delayed in local array until handshake message from destination is received

Switched on hydrateRoot to enable concurrent mode

unstable_batchedUpdates are removed

## Steps for reproduction



## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
