### PR TITLE
Define component states in meta

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
-import store from "immerhin";
+import { useStore } from "@nanostores/react";
 import { nanoid } from "nanoid";
+import { computed } from "nanostores";
+import store from "immerhin";
 import { theme, Text } from "@webstudio-is/design-system";
 import {
   type Instance,
@@ -8,12 +10,13 @@ import {
   type StyleSourceSelections,
   getStyleDeclKey,
 } from "@webstudio-is/project-build";
+import { getComponentMeta } from "@webstudio-is/react-sdk";
 import { type ItemSource, StyleSourceInput } from "./style-source";
-import { useStore } from "@nanostores/react";
 import {
   availableStyleSourcesStore,
   selectedInstanceSelectorStore,
   selectedInstanceStatesByStyleSourceIdStore,
+  selectedInstanceStore,
   selectedInstanceStyleSourcesStore,
   selectedOrLastStyleSourceSelectorStore,
   selectedStyleSourceSelectorStore,
@@ -282,6 +285,16 @@ const renameStyleSource = (id: StyleSource["id"], label: string) => {
   });
 };
 
+const componentStatesStore = computed(
+  [selectedInstanceStore],
+  (selectedInstance) => {
+    if (selectedInstance === undefined) {
+      return;
+    }
+    return getComponentMeta(selectedInstance.component)?.states;
+  }
+);
+
 type StyleSourceInputItem = {
   id: string;
   label: string;
@@ -304,6 +317,7 @@ const convertToInputItem = (
 };
 
 export const StyleSourcesSection = () => {
+  const componentStates = useStore(componentStatesStore);
   const availableStyleSources = useStore(availableStyleSourcesStore);
   const selectedInstanceStyleSources = useStore(
     selectedInstanceStyleSourcesStore
@@ -338,6 +352,7 @@ export const StyleSourcesSection = () => {
         items={items}
         value={value}
         selectedItemSelector={selectedOrLastStyleSourceSelector}
+        componentStates={componentStates}
         onCreateItem={createStyleSource}
         onSelectAutocompleteItem={({ id }) => {
           addStyleSourceToInstace(id);

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
@@ -264,9 +264,9 @@ const renderMenuItems = (props: {
   onDelete?: (itemId: IntermediateItem["id"]) => void;
 }) => {
   const states = [
-    ...userActionStates.map((value) => ({
-      value,
-      label: humanizeString(value),
+    ...userActionStates.map((selector) => ({
+      selector,
+      label: humanizeString(selector),
     })),
     ...(props.componentStates ?? []),
   ];
@@ -318,26 +318,29 @@ const renderMenuItems = (props: {
         <>
           <DropdownMenuSeparator />
           <DropdownMenuLabel>States</DropdownMenuLabel>
-          {states.map(({ label, value }) => (
+          {states.map(({ label, selector }) => (
             <DropdownMenuItem
-              key={value}
+              key={selector}
               withIndicator={true}
               icon={
                 props.item.id === props.selectedItemSelector?.styleSourceId &&
-                value === props.selectedItemSelector.state ? (
+                selector === props.selectedItemSelector.state ? (
                   <CheckMarkIcon
                     color={
-                      props.item.states.includes(value)
+                      props.item.states.includes(selector)
                         ? rawTheme.colors.foregroundPrimary
                         : rawTheme.colors.foregroundIconMain
                     }
                   />
-                ) : props.item.states.includes(value) ? (
+                ) : props.item.states.includes(selector) ? (
                   <DotIcon color={rawTheme.colors.foregroundPrimary} />
                 ) : null
               }
               onSelect={() =>
-                props.onSelect?.({ styleSourceId: props.item.id, state: value })
+                props.onSelect?.({
+                  styleSourceId: props.item.id,
+                  state: selector,
+                })
               }
             >
               {label}

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
@@ -41,6 +41,7 @@ import {
   type ReactNode,
 } from "react";
 import { mergeRefs } from "@react-aria/utils";
+import type { ComponentState } from "@webstudio-is/react-sdk";
 import { type ItemSource, menuCssVars, StyleSource } from "./style-source";
 import { useSortable } from "./use-sortable";
 import { matchSorter } from "match-sorter";
@@ -186,7 +187,7 @@ type StyleSourceInputProps<Item extends IntermediateItem> = {
   value?: Array<Item>;
   selectedItemSelector: undefined | ItemSelector;
   editingItemId?: Item["id"];
-  componentStates?: string[];
+  componentStates?: ComponentState[];
   onSelectAutocompleteItem?: (item: Item) => void;
   onRemoveItem?: (id: Item["id"]) => void;
   onDeleteItem?: (id: Item["id"]) => void;
@@ -252,7 +253,7 @@ const userActionStates = [
 const renderMenuItems = (props: {
   selectedItemSelector: undefined | ItemSelector;
   item: IntermediateItem;
-  componentStates?: string[];
+  componentStates?: ComponentState[];
   onSelect?: (itemSelector: ItemSelector) => void;
   onEdit?: (itemId: IntermediateItem["id"]) => void;
   onDuplicate?: (itemId: IntermediateItem["id"]) => void;
@@ -262,7 +263,13 @@ const renderMenuItems = (props: {
   onRemove?: (itemId: IntermediateItem["id"]) => void;
   onDelete?: (itemId: IntermediateItem["id"]) => void;
 }) => {
-  const states = [...userActionStates, ...(props.componentStates ?? [])];
+  const states = [
+    ...userActionStates.map((value) => ({
+      value,
+      label: humanizeString(value),
+    })),
+    ...(props.componentStates ?? []),
+  ];
   return (
     <>
       {props.item.source !== "local" && (
@@ -306,33 +313,34 @@ const renderMenuItems = (props: {
           Delete
         </DropdownMenuItem>
       )}
+
       {isFeatureEnabled("styleSourceStates") && (
         <>
           <DropdownMenuSeparator />
           <DropdownMenuLabel>States</DropdownMenuLabel>
-          {states.map((state) => (
+          {states.map(({ label, value }) => (
             <DropdownMenuItem
-              key={state}
+              key={value}
               withIndicator={true}
               icon={
                 props.item.id === props.selectedItemSelector?.styleSourceId &&
-                state === props.selectedItemSelector.state ? (
+                value === props.selectedItemSelector.state ? (
                   <CheckMarkIcon
                     color={
-                      props.item.states.includes(state)
+                      props.item.states.includes(value)
                         ? rawTheme.colors.foregroundPrimary
                         : rawTheme.colors.foregroundIconMain
                     }
                   />
-                ) : props.item.states.includes(state) ? (
+                ) : props.item.states.includes(value) ? (
                   <DotIcon color={rawTheme.colors.foregroundPrimary} />
                 ) : null
               }
               onSelect={() =>
-                props.onSelect?.({ styleSourceId: props.item.id, state })
+                props.onSelect?.({ styleSourceId: props.item.id, state: value })
               }
             >
-              {humanizeString(state)}
+              {label}
             </DropdownMenuItem>
           ))}
         </>

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
@@ -186,6 +186,7 @@ type StyleSourceInputProps<Item extends IntermediateItem> = {
   value?: Array<Item>;
   selectedItemSelector: undefined | ItemSelector;
   editingItemId?: Item["id"];
+  componentStates?: string[];
   onSelectAutocompleteItem?: (item: Item) => void;
   onRemoveItem?: (id: Item["id"]) => void;
   onDeleteItem?: (id: Item["id"]) => void;
@@ -251,6 +252,7 @@ const userActionStates = [
 const renderMenuItems = (props: {
   selectedItemSelector: undefined | ItemSelector;
   item: IntermediateItem;
+  componentStates?: string[];
   onSelect?: (itemSelector: ItemSelector) => void;
   onEdit?: (itemId: IntermediateItem["id"]) => void;
   onDuplicate?: (itemId: IntermediateItem["id"]) => void;
@@ -259,26 +261,28 @@ const renderMenuItems = (props: {
   onEnable?: (itemId: IntermediateItem["id"]) => void;
   onRemove?: (itemId: IntermediateItem["id"]) => void;
   onDelete?: (itemId: IntermediateItem["id"]) => void;
-}) => (
-  <>
-    {props.item.source !== "local" && (
-      <DropdownMenuItem onSelect={() => props.onEdit?.(props.item.id)}>
-        Edit Name
-      </DropdownMenuItem>
-    )}
-    {props.item.source !== "local" && (
-      <DropdownMenuItem onSelect={() => props.onDuplicate?.(props.item.id)}>
-        Duplicate
-      </DropdownMenuItem>
-    )}
-    {props.item.source === "local" && (
-      <DropdownMenuItem
-        onSelect={() => props.onConvertToToken?.(props.item.id)}
-      >
-        Convert to token
-      </DropdownMenuItem>
-    )}
-    {/* @todo implement disabling
+}) => {
+  const states = [...userActionStates, ...(props.componentStates ?? [])];
+  return (
+    <>
+      {props.item.source !== "local" && (
+        <DropdownMenuItem onSelect={() => props.onEdit?.(props.item.id)}>
+          Edit Name
+        </DropdownMenuItem>
+      )}
+      {props.item.source !== "local" && (
+        <DropdownMenuItem onSelect={() => props.onDuplicate?.(props.item.id)}>
+          Duplicate
+        </DropdownMenuItem>
+      )}
+      {props.item.source === "local" && (
+        <DropdownMenuItem
+          onSelect={() => props.onConvertToToken?.(props.item.id)}
+        >
+          Convert to token
+        </DropdownMenuItem>
+      )}
+      {/* @todo implement disabling
     {props.disabled ? (
       <DropdownMenuItem onSelect={() => props.onEnable?.(props.itemId)}>
         Enable
@@ -289,52 +293,53 @@ const renderMenuItems = (props: {
       </DropdownMenuItem>
     )}
     */}
-    {props.item.source !== "local" && (
-      <DropdownMenuItem onSelect={() => props.onRemove?.(props.item.id)}>
-        Remove
-      </DropdownMenuItem>
-    )}
-    {props.item.source !== "local" && (
-      <DropdownMenuItem
-        destructive={true}
-        onSelect={() => props.onDelete?.(props.item.id)}
-      >
-        Delete
-      </DropdownMenuItem>
-    )}
-    {isFeatureEnabled("styleSourceStates") && (
-      <>
-        <DropdownMenuSeparator />
-        <DropdownMenuLabel>States</DropdownMenuLabel>
-        {userActionStates.map((state) => (
-          <DropdownMenuItem
-            key={state}
-            withIndicator={true}
-            icon={
-              props.item.id === props.selectedItemSelector?.styleSourceId &&
-              state === props.selectedItemSelector.state ? (
-                <CheckMarkIcon
-                  color={
-                    props.item.states.includes(state)
-                      ? rawTheme.colors.foregroundPrimary
-                      : rawTheme.colors.foregroundIconMain
-                  }
-                />
-              ) : props.item.states.includes(state) ? (
-                <DotIcon color={rawTheme.colors.foregroundPrimary} />
-              ) : null
-            }
-            onSelect={() =>
-              props.onSelect?.({ styleSourceId: props.item.id, state })
-            }
-          >
-            {humanizeString(state)}
-          </DropdownMenuItem>
-        ))}
-      </>
-    )}
-  </>
-);
+      {props.item.source !== "local" && (
+        <DropdownMenuItem onSelect={() => props.onRemove?.(props.item.id)}>
+          Remove
+        </DropdownMenuItem>
+      )}
+      {props.item.source !== "local" && (
+        <DropdownMenuItem
+          destructive={true}
+          onSelect={() => props.onDelete?.(props.item.id)}
+        >
+          Delete
+        </DropdownMenuItem>
+      )}
+      {isFeatureEnabled("styleSourceStates") && (
+        <>
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel>States</DropdownMenuLabel>
+          {states.map((state) => (
+            <DropdownMenuItem
+              key={state}
+              withIndicator={true}
+              icon={
+                props.item.id === props.selectedItemSelector?.styleSourceId &&
+                state === props.selectedItemSelector.state ? (
+                  <CheckMarkIcon
+                    color={
+                      props.item.states.includes(state)
+                        ? rawTheme.colors.foregroundPrimary
+                        : rawTheme.colors.foregroundIconMain
+                    }
+                  />
+                ) : props.item.states.includes(state) ? (
+                  <DotIcon color={rawTheme.colors.foregroundPrimary} />
+                ) : null
+              }
+              onSelect={() =>
+                props.onSelect?.({ styleSourceId: props.item.id, state })
+              }
+            >
+              {humanizeString(state)}
+            </DropdownMenuItem>
+          ))}
+        </>
+      )}
+    </>
+  );
+};
 
 export const StyleSourceInput = (
   props: StyleSourceInputProps<IntermediateItem>
@@ -403,6 +408,7 @@ export const StyleSourceInput = (
               renderMenuItems({
                 selectedItemSelector: props.selectedItemSelector,
                 item,
+                componentStates: props.componentStates,
                 onSelect: props.onSelectItem,
                 onDuplicate: props.onDuplicateItem,
                 onConvertToToken: props.onConvertToToken,

--- a/packages/react-sdk/src/components/component-meta.ts
+++ b/packages/react-sdk/src/components/component-meta.ts
@@ -23,6 +23,13 @@ export const componentCategories = [
   "forms",
 ] as const;
 
+export const ComponentState = z.object({
+  value: z.string(),
+  label: z.string(),
+});
+
+export type ComponentState = z.infer<typeof ComponentState>;
+
 const WsComponentMeta = z.object({
   category: z.enum(componentCategories).optional(),
   // container - can accept other components with dnd
@@ -40,7 +47,7 @@ const WsComponentMeta = z.object({
   label: z.string(),
   Icon: z.function(),
   presetStyle: z.optional(z.any()),
-  states: z.optional(z.array(z.string())),
+  states: z.optional(z.array(ComponentState)),
   children: z.optional(z.array(z.string())),
 });
 

--- a/packages/react-sdk/src/components/component-meta.ts
+++ b/packages/react-sdk/src/components/component-meta.ts
@@ -40,6 +40,7 @@ const WsComponentMeta = z.object({
   label: z.string(),
   Icon: z.function(),
   presetStyle: z.optional(z.any()),
+  states: z.optional(z.array(z.string())),
   children: z.optional(z.array(z.string())),
 });
 

--- a/packages/react-sdk/src/components/component-meta.ts
+++ b/packages/react-sdk/src/components/component-meta.ts
@@ -24,7 +24,7 @@ export const componentCategories = [
 ] as const;
 
 export const ComponentState = z.object({
-  value: z.string(),
+  selector: z.string(),
   label: z.string(),
 });
 

--- a/packages/react-sdk/src/components/link-block.ws.tsx
+++ b/packages/react-sdk/src/components/link-block.ws.tsx
@@ -1,7 +1,7 @@
 import { BoxLinkIcon } from "@webstudio-is/icons";
 import type { WsComponentMeta, WsComponentPropsMeta } from "./component-meta";
 import { props } from "./__generated__/link-block.props";
-import { propsMeta as linkPropsMeta } from "./link.ws";
+import { meta as linkMeta, propsMeta as linkPropsMeta } from "./link.ws";
 import type { defaultTag } from "./link-block";
 import type { Style } from "@webstudio-is/css-data";
 import { a } from "../css/normalize";
@@ -21,6 +21,7 @@ export const meta: WsComponentMeta = {
   type: "container",
   label: "Link Block",
   Icon: BoxLinkIcon,
+  states: linkMeta.states,
   presetStyle,
 };
 

--- a/packages/react-sdk/src/components/link.ws.tsx
+++ b/packages/react-sdk/src/components/link.ws.tsx
@@ -26,7 +26,7 @@ export const meta: WsComponentMeta = {
   label: "Link Text",
   Icon: LinkIcon,
   presetStyle,
-  states: ["[aria-current=page]"],
+  states: [{ value: "[aria-current=page]", label: "Current page" }],
   children: ["Link text you can edit"],
 };
 

--- a/packages/react-sdk/src/components/link.ws.tsx
+++ b/packages/react-sdk/src/components/link.ws.tsx
@@ -26,7 +26,7 @@ export const meta: WsComponentMeta = {
   label: "Link Text",
   Icon: LinkIcon,
   presetStyle,
-  states: [{ value: "[aria-current=page]", label: "Current page" }],
+  states: [{ selector: "[aria-current=page]", label: "Current page" }],
   children: ["Link text you can edit"],
 };
 

--- a/packages/react-sdk/src/components/link.ws.tsx
+++ b/packages/react-sdk/src/components/link.ws.tsx
@@ -26,6 +26,7 @@ export const meta: WsComponentMeta = {
   label: "Link Text",
   Icon: LinkIcon,
   presetStyle,
+  states: ["[aria-current=page]"],
   children: ["Link text you can edit"],
 };
 

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -13,5 +13,6 @@ export {
 export {
   type WsComponentPropsMeta,
   type WsComponentMeta,
+  type ComponentState,
   componentCategories,
 } from "./components/component-meta";


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/807

Here added ability to extend states in style source menu list with a list defined in component meta.

As an example added `[aria-current=page]` support to links. For now can be statically set with props panel.

Note: review with hidden whitespaces

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
