### PR TITLE
Fixed location of emitted declarations

### DIFF
--- a/packages/asset-uploader/package.json
+++ b/packages/asset-uploader/package.json
@@ -11,7 +11,7 @@
     "checks": "pnpm typecheck && pnpm lint && pnpm test",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc",
+    "dts": "tsc --declarationDir lib/types",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"
   },
   "dependencies": {

--- a/packages/authorization-token/package.json
+++ b/packages/authorization-token/package.json
@@ -11,7 +11,7 @@
     "checks": "pnpm typecheck && pnpm lint",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc",
+    "dts": "tsc --declarationDir lib/types",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"
   },
   "dependencies": {

--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -11,7 +11,7 @@
     "dev": "build-package --watch",
     "build": "build-package",
     "build:mdn-data": "tsx ./bin/mdn-data.ts ./src/__generated__ &&  prettier --write \"./src/__generated__/**/*.ts\"",
-    "dts": "tsc",
+    "dts": "tsc --declarationDir lib/types",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"
   },
   "devDependencies": {

--- a/packages/css-engine/package.json
+++ b/packages/css-engine/package.json
@@ -10,7 +10,7 @@
     "checks": "pnpm typecheck && pnpm lint && pnpm test",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc",
+    "dts": "tsc --declarationDir lib/types",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0",
     "storybook:run": "start-storybook -p 6006",

--- a/packages/css-vars/package.json
+++ b/packages/css-vars/package.json
@@ -10,7 +10,7 @@
     "checks": "pnpm typecheck && pnpm lint",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc",
+    "dts": "tsc --declarationDir lib/types",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"
   },
   "devDependencies": {

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -9,7 +9,7 @@
     "dev": "build-package --watch",
     "build": "build-package",
     "build-figma-tokens": "tsx ./bin/transform-figma-tokens.ts",
-    "dts": "tsc",
+    "dts": "tsc --declarationDir lib/types",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -10,7 +10,7 @@
     "checks": "pnpm typecheck && pnpm lint",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc",
+    "dts": "tsc --declarationDir lib/types",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"
   },
   "dependencies": {},

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -11,7 +11,7 @@
     "checks": "pnpm typecheck && pnpm lint && pnpm test",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc",
+    "dts": "tsc --declarationDir lib/types",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"
   },
   "dependencies": {

--- a/packages/generate-arg-types/package.json
+++ b/packages/generate-arg-types/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc",
+    "dts": "tsc --declarationDir lib/types",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "checks": "pnpm typecheck && pnpm lint",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc",
+    "dts": "tsc --declarationDir lib/types",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc",
+    "dts": "tsc --declarationDir lib/types",
     "generate": "rm -fr src/__generated__ && NODE_OPTIONS='--loader=tsx' svgo-jsx svgo-jsx.config.ts",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -12,7 +12,7 @@
     "dev": "build-package --watch",
     "build": "build-package",
     "build:args": "generate-arg-types './src/*.tsx !./src/**/*.stories.tsx !./src/**/*.ws.tsx' && prettier --write \"**/*.props.ts\"",
-    "dts": "tsc",
+    "dts": "tsc --declarationDir lib/types",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0",
     "storybook:run": "start-storybook -p 6006",
     "storybook:build": "build-storybook",

--- a/packages/prisma-client/package.json
+++ b/packages/prisma-client/package.json
@@ -11,7 +11,7 @@
     "checks": "pnpm typecheck && pnpm lint",
     "dev": "prisma generate --watch & build-package --watch --no-generated-as-entries",
     "build": "prisma format && prisma generate && build-package --no-generated-as-entries",
-    "dts": "tsc --emitDeclarationOnly --declaration --declarationDir lib",
+    "dts": "tsc --declarationDir lib",
     "migrations": "./migrations-cli/cli.ts"
   },
   "bin": {

--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -31,7 +31,7 @@
     "checks": "pnpm typecheck && pnpm lint && pnpm test",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc"
+    "dts": "tsc --declarationDir lib/types"
   },
   "dependencies": {
     "@webstudio-is/css-data": "workspace:^",

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -10,7 +10,7 @@
     "checks": "pnpm typecheck && pnpm lint",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc",
+    "dts": "tsc --declarationDir lib/types",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"
   },
   "dependencies": {

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -9,7 +9,7 @@
     "dev": "build-package --watch",
     "build": "build-package",
     "build:args": "generate-arg-types './src/components/*.tsx !./src/**/*.stories.tsx !./src/**/*.ws.tsx' && prettier --write \"**/*.props.ts\"",
-    "dts": "tsc",
+    "dts": "tsc --declarationDir lib/types",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0",

--- a/packages/trpc-interface/package.json
+++ b/packages/trpc-interface/package.json
@@ -11,7 +11,7 @@
     "checks": "pnpm typecheck && pnpm lint",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc",
+    "dts": "tsc --declarationDir lib/types",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"
   },
   "dependencies": {

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -19,7 +19,6 @@
     "noFallthroughCasesInSwitch": true,
     "verbatimModuleSyntax": true,
     "emitDeclarationOnly": true,
-    "declaration": true,
-    "declarationDir": "lib/types"
+    "declaration": true
   }
 }


### PR DESCRIPTION
Fixed a regression from https://github.com/webstudio-is/webstudio-builder/pull/1470 . @TrySound noticed that by putting `declarationDir` in the base config all declaration were emitted relative to... that base config. By switching back to the CLI argument the issue is fixed.