### PR TITLE
Fix unstable lostpixel

### DIFF
--- a/apps/builder/.storybook/preview.tsx
+++ b/apps/builder/.storybook/preview.tsx
@@ -3,6 +3,7 @@ import { TooltipProvider } from "@radix-ui/react-tooltip";
 import { theme, globalCss } from "@webstudio-is/design-system";
 import { setEnv } from "@webstudio-is/feature-flags";
 import "@webstudio-is/storybook-config/setup-fonts";
+import { decorators as globalDecorators } from "@webstudio-is/storybook-config/decorators";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
@@ -23,6 +24,7 @@ const globalStyles = globalCss({
 });
 
 export const decorators = [
+  ...globalDecorators,
   (StoryFn: any) => {
     globalStyles();
     setEnv("*");

--- a/packages/design-system/.storybook/preview.js
+++ b/packages/design-system/.storybook/preview.js
@@ -1,6 +1,8 @@
 import "@webstudio-is/storybook-config/setup-fonts";
 import { color } from "../src/__generated__/figma-design-tokens";
 
+export { decorators } from "@webstudio-is/storybook-config/decorators";
+
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
   controls: {

--- a/packages/storybook-config/decorators.tsx
+++ b/packages/storybook-config/decorators.tsx
@@ -2,21 +2,21 @@ import * as React from "react";
 import { useEffect } from "react";
 
 const WaitForFonts = ({ children }) => {
-  const [fontsLoaded, setFontsLoaded] = React.useState(false);
+  const [isFontsLoaded, setIsFontsLoaded] = React.useState(false);
 
   useEffect(() => {
-    let unsubscribed = false;
+    let isUnsubscribed = false;
     document.fonts.ready.then(() => {
-      if (!unsubscribed) {
-        setFontsLoaded(true);
+      if (isUnsubscribed === false) {
+        setIsFontsLoaded(true);
       }
     });
     return () => {
-      unsubscribed = true;
+      isUnsubscribed = true;
     };
   }, []);
 
-  return fontsLoaded ? (
+  return isFontsLoaded ? (
     children
   ) : (
     <div>

--- a/packages/storybook-config/decorators.tsx
+++ b/packages/storybook-config/decorators.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 
 const WaitForFonts = ({ children }) => {
   const [fontsLoaded, setFontsLoaded] = React.useState(false);
+
   useEffect(() => {
     let unsubscribed = false;
     document.fonts.ready.then(() => {
@@ -15,7 +16,16 @@ const WaitForFonts = ({ children }) => {
     };
   }, []);
 
-  return fontsLoaded ? children : <div>Waiting for fonts to load ...</div>;
+  return fontsLoaded ? (
+    children
+  ) : (
+    <div>
+      Waiting for fonts to load ...
+      {/* not rendering children initially breaks backgrounds addon,
+       * so we always render it */}
+      <div style={{ display: "none" }}>{children}</div>
+    </div>
+  );
 };
 
 export const decorators = [

--- a/packages/storybook-config/decorators.tsx
+++ b/packages/storybook-config/decorators.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { useEffect } from "react";
+
+const WaitForFonts = ({ children }) => {
+  const [fontsLoaded, setFontsLoaded] = React.useState(false);
+  useEffect(() => {
+    let unsubscribed = false;
+    document.fonts.ready.then(() => {
+      if (!unsubscribed) {
+        setFontsLoaded(true);
+      }
+    });
+    return () => {
+      unsubscribed = true;
+    };
+  }, []);
+
+  return fontsLoaded ? children : <div>Waiting for fonts to load ...</div>;
+};
+
+export const decorators = [
+  // waiting for fonts makes screenshot tests more stable
+  (Story) => (
+    <WaitForFonts>
+      <Story />
+    </WaitForFonts>
+  ),
+];


### PR DESCRIPTION
## Description

<img width="152" alt="Screenshot 2023-04-19 at 16 53 54" src="https://user-images.githubusercontent.com/825702/233097071-8c2ca542-eb75-48fa-ba11-a1a74f83377a.png">

This should hopefully fix the unstable popover arrow ^. 

The theory is:
 - when arrow position is calculated, fonts may or may not be loaded yet;
 - arrow position does not update after the fonts load.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @TrySound, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)


## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
