### PR TITLE
Reset selected instance on page manipulation

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/settings.tsx
@@ -38,6 +38,7 @@ import { deleteInstance } from "~/shared/instance-utils";
 import {
   instancesStore,
   pagesStore,
+  selectedInstanceSelectorStore,
   selectedPageIdStore,
 } from "~/shared/nano-states";
 import { nanoid } from "nanoid";
@@ -293,6 +294,7 @@ export const NewPageSettings = ({
             component: "Body",
             children: [],
           });
+          selectedInstanceSelectorStore.set(undefined);
         }
       );
       onSuccess(pageId);
@@ -420,6 +422,7 @@ const deletePage = (pageId: Page["id"]) => {
   // deselect page before deleting to avoid flash of content
   if (selectedPageIdStore.get() === pageId) {
     selectedPageIdStore.set(pages?.homePage.id);
+    selectedInstanceSelectorStore.set(undefined);
   }
   const rootInstanceId = pages?.pages.find(
     (page) => page.id === pageId

--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -1,7 +1,11 @@
 import { useNavigate } from "@remix-run/react";
 import type { Page } from "@webstudio-is/project-build";
 import { projectContainer } from "~/builder/shared/nano-states";
-import { authTokenStore, pagesStore } from "~/shared/nano-states";
+import {
+  authTokenStore,
+  pagesStore,
+  selectedInstanceSelectorStore,
+} from "~/shared/nano-states";
 import { builderPath } from "~/shared/router-utils";
 import { useSubscribe } from "~/shared/pubsub";
 
@@ -18,6 +22,8 @@ export const useSwitchPage = () => {
     if (project === undefined || pages === undefined) {
       return;
     }
+
+    selectedInstanceSelectorStore.set(undefined);
 
     navigate(
       builderPath({


### PR DESCRIPTION
Forced reset when page is created, deleted or navigated. Selected instance should be reset to avoid manipulation from another page.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
