### PR TITLE
Update css-engine transformValue on every update

### DIFF
--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -191,19 +191,16 @@ const getOrCreateRule = ({
   const key = `${instanceId}:${breakpointId}:${state}`;
   let rule = wrappedRulesMap.get(key);
   if (rule === undefined) {
-    const params = getParams();
-    rule = cssEngine.addStyleRule(
-      `[${idAttribute}="${instanceId}"]${state}`,
-      {
-        breakpoint: breakpointId,
-        style: {},
-      },
-      createImageValueTransformer(assets, {
-        assetBaseUrl: params.assetBaseUrl,
-      })
-    );
+    rule = cssEngine.addStyleRule(`[${idAttribute}="${instanceId}"]${state}`, {
+      breakpoint: breakpointId,
+      style: {},
+    });
     wrappedRulesMap.set(key, rule);
   }
+  const params = getParams();
+  rule.styleMap.setTransformer(
+    createImageValueTransformer(assets, { assetBaseUrl: params.assetBaseUrl })
+  );
   return rule;
 };
 

--- a/packages/css-engine/src/core/rules.ts
+++ b/packages/css-engine/src/core/rules.ts
@@ -11,6 +11,9 @@ class StylePropertyMap {
   constructor(transformValue?: TransformValue) {
     this.#transformValue = transformValue;
   }
+  setTransformer(transformValue: TransformValue) {
+    this.#transformValue = transformValue;
+  }
   set(property: StyleProperty, value?: StyleValue) {
     this.#styleMap.set(property, value);
     this.#isDirty = true;


### PR DESCRIPTION
We have a bug that asset cannot be applied in background style section. This is because image transformer was set only once on rule creation. We need to reset it with actual assets on every styles updates.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
