### PR TITLE
Prevent cyclic slot reparent

### DIFF
--- a/apps/builder/app/shared/tree-utils.test.ts
+++ b/apps/builder/app/shared/tree-utils.test.ts
@@ -450,6 +450,38 @@ test("reparent instance into slot", () => {
       ]),
     ])
   );
+
+  // prevent reparenting into own children to avoid infinite loop
+  reparentInstanceMutable(instances, ["slot1", "root"], {
+    parentSelector: ["fragment11", "slot1", "root"],
+    position: "end",
+  });
+  expect(instances).toEqual(
+    new Map([
+      createInstancePair("root", "Body", [
+        { type: "id", value: "slot1" },
+        { type: "id", value: "box3" },
+      ]),
+      createInstancePair("slot1", "Slot", [
+        { type: "id", value: "fragment11" },
+      ]),
+      createInstancePair("fragment11", "Fragment", []),
+      createInstancePair("box2", "Box", [
+        { type: "id", value: "box21" },
+        { type: "id", value: "box22" },
+        { type: "id", value: "box23" },
+      ]),
+      createInstancePair("box21", "Box", []),
+      createInstancePair("box22", "Box", []),
+      createInstancePair("box23", "Box", []),
+      createInstancePair("slot3", "Slot", [
+        { type: "id", value: expectString },
+      ]),
+      createInstancePair(expectString, "Fragment", [
+        { type: "id", value: "box2" },
+      ]),
+    ])
+  );
 });
 
 test("insert tree of instances copy and provide map from ids map", () => {

--- a/apps/builder/app/shared/tree-utils.ts
+++ b/apps/builder/app/shared/tree-utils.ts
@@ -176,7 +176,6 @@ export const reparentInstanceMutable = (
   );
   const instance = instances.get(instanceId);
 
-  // detect recursive reparent for example with slots
   // delect is target is one of own descendants
   // prevent reparenting to avoid infinite loop
   const instanceDescendants = findTreeInstanceIds(instances, instanceId);

--- a/apps/builder/app/shared/tree-utils.ts
+++ b/apps/builder/app/shared/tree-utils.ts
@@ -2,6 +2,7 @@ import { nanoid } from "nanoid";
 import {
   Breakpoint,
   Breakpoints,
+  findTreeInstanceIds,
   findTreeInstanceIdsExcludingSlotDescendants,
   getStyleDeclKey,
   Instance,
@@ -174,6 +175,17 @@ export const reparentInstanceMutable = (
     dropTarget.parentSelector[0]
   );
   const instance = instances.get(instanceId);
+
+  // detect recursive reparent for example with slots
+  // delect is target is one of own descendants
+  // prevent reparenting to avoid infinite loop
+  const instanceDescendants = findTreeInstanceIds(instances, instanceId);
+  for (const instanceId of instanceDescendants) {
+    if (dropTarget.parentSelector.includes(instanceId)) {
+      return;
+    }
+  }
+
   if (
     prevParent === undefined ||
     nextParent === undefined ||


### PR DESCRIPTION
Here consider this scenario when reparenting

- Create a slot
- Put a Box in it
- Copy the Slot
- Drag copy of the slot inside Box in the original slot

## Code Review

- [ ] hi @rpominov, I need you to do
  - detailed review (read every line)
- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
