### PR TITLE
Compute remote style source

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
@@ -7,7 +7,6 @@ import {
   Button,
   Flex,
   Box,
-  DeprecatedText2,
   Label,
   Tooltip,
   Separator,
@@ -15,6 +14,7 @@ import {
   PopoverTrigger,
   PopoverPortal,
   PopoverContent,
+  Text,
 } from "@webstudio-is/design-system";
 import { UndoIcon } from "@webstudio-is/icons";
 import {
@@ -73,10 +73,10 @@ const PropertyPopoverContent = ({
                 name = `"${styleSource.name}" token`;
               }
               return (
-                <DeprecatedText2 key={property} color="hint">
+                <Text key={property} color="subtle">
                   Resetting will change {property} value to {toValue(value)}{" "}
                   from {name}
-                </DeprecatedText2>
+                </Text>
               );
             }
 
@@ -84,10 +84,10 @@ const PropertyPopoverContent = ({
               const { value, breakpointId } = styleValueInfo.cascaded;
               const breakpoint = breakpoints.get(breakpointId);
               return (
-                <DeprecatedText2 key={property} color="hint">
+                <Text key={property} color="subtle">
                   Resetting will change {property} to cascaded {toValue(value)}{" "}
                   from {breakpoint?.label}
-                </DeprecatedText2>
+                </Text>
               );
             }
 
@@ -95,17 +95,17 @@ const PropertyPopoverContent = ({
               const { value, instanceId } = styleValueInfo.inherited;
               const instance = instances.get(instanceId);
               return (
-                <DeprecatedText2 key={property} color="hint">
+                <Text key={property} color="subtle">
                   Resetting will change {property} to inherited {toValue(value)}{" "}
                   from {instance?.component}
-                </DeprecatedText2>
+                </Text>
               );
             }
 
             return (
-              <DeprecatedText2 key={property} color="hint">
+              <Text key={property} color="subtle">
                 Resetting will change to initial value
-              </DeprecatedText2>
+              </Text>
             );
           })}
         </Box>
@@ -129,9 +129,9 @@ const PropertyPopoverContent = ({
             name = `"${styleSource.name}" token`;
           }
           return (
-            <DeprecatedText2 key={property} color="hint">
+            <Text key={property} color="subtle">
               {property} value is defined in {name}
-            </DeprecatedText2>
+            </Text>
           );
         }
 
@@ -139,9 +139,9 @@ const PropertyPopoverContent = ({
           const { breakpointId } = styleValueInfo.cascaded;
           const breakpoint = breakpoints.get(breakpointId);
           return (
-            <DeprecatedText2 key={property} color="hint">
+            <Text key={property} color="subtle">
               {property} value is cascaded from {breakpoint?.label}
-            </DeprecatedText2>
+            </Text>
           );
         }
 
@@ -149,9 +149,9 @@ const PropertyPopoverContent = ({
           const { instanceId } = styleValueInfo.inherited;
           const instance = instances.get(instanceId);
           return (
-            <DeprecatedText2 key={property} color="hint">
+            <Text key={property} color="subtle">
               {property} value is inherited from {instance?.component}
-            </DeprecatedText2>
+            </Text>
           );
         }
       })}

--- a/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
@@ -17,7 +17,11 @@ import {
   PopoverContent,
 } from "@webstudio-is/design-system";
 import { UndoIcon } from "@webstudio-is/icons";
-import { breakpointsStore, instancesStore } from "~/shared/nano-states";
+import {
+  breakpointsStore,
+  instancesStore,
+  styleSourcesStore,
+} from "~/shared/nano-states";
 import { type StyleInfo, type StyleSource, getStyleSource } from "./style-info";
 
 const PropertyPopoverContent = ({
@@ -33,6 +37,7 @@ const PropertyPopoverContent = ({
 }) => {
   const breakpoints = useStore(breakpointsStore);
   const instances = useStore(instancesStore);
+  const styleSources = useStore(styleSourcesStore);
 
   if (styleSource === "local") {
     return (
@@ -56,6 +61,24 @@ const PropertyPopoverContent = ({
         >
           {properties.map((property) => {
             const styleValueInfo = style[property];
+
+            if (styleValueInfo?.previousSource) {
+              const { value, styleSourceId } = styleValueInfo.previousSource;
+              const styleSource = styleSources.get(styleSourceId);
+              let name: undefined | string = undefined;
+              if (styleSource?.type === "local") {
+                name = "local style source";
+              }
+              if (styleSource?.type === "token") {
+                name = `"${styleSource.name}" token`;
+              }
+              return (
+                <DeprecatedText2 key={property} color="hint">
+                  Resetting will change {property} value to {toValue(value)}{" "}
+                  from {name}
+                </DeprecatedText2>
+              );
+            }
 
             if (styleValueInfo?.cascaded) {
               const { value, breakpointId } = styleValueInfo.cascaded;
@@ -94,6 +117,23 @@ const PropertyPopoverContent = ({
     <Box css={{ px: theme.spacing[4], py: theme.spacing[3] }}>
       {properties.map((property) => {
         const styleValueInfo = style[property];
+
+        if (styleValueInfo?.previousSource) {
+          const { styleSourceId } = styleValueInfo.previousSource;
+          const styleSource = styleSources.get(styleSourceId);
+          let name: undefined | string = undefined;
+          if (styleSource?.type === "local") {
+            name = "local style source";
+          }
+          if (styleSource?.type === "token") {
+            name = `"${styleSource.name}" token`;
+          }
+          return (
+            <DeprecatedText2 key={property} color="hint">
+              {property} value is defined in {name}
+            </DeprecatedText2>
+          );
+        }
 
         if (styleValueInfo?.cascaded) {
           const { breakpointId } = styleValueInfo.cascaded;

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
@@ -4,11 +4,13 @@ import type {
   Instance,
   Instances,
   StyleDecl,
+  StylesList,
 } from "@webstudio-is/project-build";
 import {
   getCascadedBreakpointIds,
   getCascadedInfo,
   getInheritedInfo,
+  getPreviousSourceInfo,
 } from "./style-info";
 
 const breakpoints: Breakpoints = new Map([
@@ -207,6 +209,65 @@ test("compute inherited styles", () => {
           "type": "unit",
           "unit": "number",
           "value": 1.5,
+        },
+      },
+    }
+  `);
+});
+
+test("compute styles from previous sources", () => {
+  const styleSourceSelections = new Map([
+    ["3", { instanceId: "3", values: ["1", "2", "3", "4"] }],
+  ]);
+  const selectedStyleSourceSelector = {
+    styleSourceId: "3",
+  };
+  const stylesByInstanceId = new Map<Instance["id"], StylesList>([
+    [
+      "3",
+      [
+        {
+          breakpointId: "bp",
+          styleSourceId: "1",
+          property: "width",
+          value: { type: "unit", value: 100, unit: "px" },
+        },
+        {
+          breakpointId: "bp",
+          styleSourceId: "2",
+          property: "width",
+          value: { type: "unit", value: 200, unit: "px" },
+        },
+        {
+          breakpointId: "bp",
+          styleSourceId: "3",
+          property: "width",
+          value: { type: "unit", value: 300, unit: "px" },
+        },
+        {
+          breakpointId: "bp",
+          styleSourceId: "4",
+          property: "width",
+          value: { type: "unit", value: 400, unit: "px" },
+        },
+      ],
+    ],
+  ]);
+  expect(
+    getPreviousSourceInfo(
+      styleSourceSelections,
+      stylesByInstanceId,
+      selectedInstanceSelector,
+      selectedStyleSourceSelector
+    )
+  ).toMatchInlineSnapshot(`
+    {
+      "width": {
+        "styleSourceId": "2",
+        "value": {
+          "type": "unit",
+          "unit": "px",
+          "value": 200,
         },
       },
     }

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.ts
@@ -2,12 +2,13 @@ import { useMemo } from "react";
 import { useStore } from "@nanostores/react";
 import type { Style, StyleProperty, StyleValue } from "@webstudio-is/css-data";
 import { properties } from "@webstudio-is/css-data";
-import type {
-  Breakpoints,
-  Instance,
-  Instances,
-  StyleDecl,
-  StyleSource as StyleSourceType,
+import {
+  StyleSourceSelections,
+  type Breakpoints,
+  type Instance,
+  type Instances,
+  type StyleDecl,
+  type StyleSource as StyleSourceType,
 } from "@webstudio-is/project-build";
 import {
   type StyleSourceSelector,
@@ -18,6 +19,7 @@ import {
   stylesIndexStore,
   selectedOrLastStyleSourceSelectorStore,
   breakpointsStore,
+  styleSourceSelectionsStore,
 } from "~/shared/nano-states";
 import { selectedBreakpointStore } from "~/shared/nano-states";
 import type { InstanceSelector } from "~/shared/tree-utils";
@@ -43,9 +45,19 @@ type InheritedProperties = {
   [property in StyleProperty]?: InheritedValueInfo;
 };
 
+type PreviousSourceValueInfo = {
+  styleSourceId: string;
+  value: StyleValue;
+};
+
+type PreviousSourceProperties = {
+  [property in StyleProperty]?: PreviousSourceValueInfo;
+};
+
 export type StyleValueInfo = {
   value: StyleValue;
   local?: StyleValue;
+  previousSource?: PreviousSourceValueInfo;
   cascaded?: CascadedValueInfo;
   inherited?: InheritedValueInfo;
   preset?: StyleValue;
@@ -80,7 +92,11 @@ export const getStyleSource = (
     }
   }
   for (const info of styleValueInfos) {
-    if (info?.cascaded !== undefined || info?.inherited !== undefined) {
+    if (
+      info?.previousSource !== undefined ||
+      info?.cascaded !== undefined ||
+      info?.inherited !== undefined
+    ) {
       return "remote";
     }
   }
@@ -253,6 +269,36 @@ export const getInheritedInfo = (
   return inheritedStyle;
 };
 
+export const getPreviousSourceInfo = (
+  styleSourceSelections: StyleSourceSelections,
+  stylesByInstanceId: Map<Instance["id"], StyleDecl[]>,
+  selectedInstanceSelector: InstanceSelector,
+  selectedStyleSourceSelector: StyleSourceSelector
+) => {
+  const previousSourceStyle: PreviousSourceProperties = {};
+  const [selectedInstanceId] = selectedInstanceSelector;
+  const { styleSourceId } = selectedStyleSourceSelector;
+  const styleSourceSelection = styleSourceSelections.get(selectedInstanceId);
+  const instanceStyles = stylesByInstanceId.get(selectedInstanceId);
+  if (styleSourceSelection === undefined || instanceStyles === undefined) {
+    return previousSourceStyle;
+  }
+  const previousSourceIds = styleSourceSelection.values.slice(
+    0,
+    styleSourceSelection.values.indexOf(styleSourceId)
+  );
+  // expect instance styles to be ordered
+  for (const styleDecl of instanceStyles) {
+    if (previousSourceIds.includes(styleDecl.styleSourceId)) {
+      previousSourceStyle[styleDecl.property] = {
+        styleSourceId: styleDecl.styleSourceId,
+        value: styleDecl.value,
+      };
+    }
+  }
+  return previousSourceStyle;
+};
+
 /**
  * combine all local, cascaded, inherited and browser styles
  */
@@ -272,6 +318,7 @@ export const useStyleInfo = () => {
   const instances = useStore(instancesStore);
   const { stylesByInstanceId, stylesByStyleSourceId } =
     useStore(stylesIndexStore);
+  const styleSourceSelections = useStore(styleSourceSelectionsStore);
 
   const selectedStyle = useMemo(() => {
     if (
@@ -332,6 +379,26 @@ export const useStyleInfo = () => {
     );
   }, [stylesByInstanceId, selectedInstanceSelector, cascadedBreakpointIds]);
 
+  const previousSourceInfo = useMemo(() => {
+    if (
+      selectedInstanceSelector === undefined ||
+      selectedOrLastStyleSourceSelector === undefined
+    ) {
+      return {};
+    }
+    return getPreviousSourceInfo(
+      styleSourceSelections,
+      stylesByInstanceId,
+      selectedInstanceSelector,
+      selectedOrLastStyleSourceSelector
+    );
+  }, [
+    styleSourceSelections,
+    stylesByInstanceId,
+    selectedInstanceSelector,
+    selectedOrLastStyleSourceSelector,
+  ]);
+
   const presetStyle = useMemo(() => {
     const selectedInstanceId = selectedInstanceSelector?.[0];
     if (selectedInstanceId === undefined) {
@@ -352,14 +419,21 @@ export const useStyleInfo = () => {
       const preset = presetStyle?.[property];
       const inherited = inheritedInfo[property];
       const cascaded = cascadedInfo[property];
+      const previousSource = previousSourceInfo[property];
       const local = selectedStyle?.[property];
       const value =
-        local ?? cascaded?.value ?? inherited?.value ?? preset ?? computed;
+        local ??
+        previousSource?.value ??
+        cascaded?.value ??
+        inherited?.value ??
+        preset ??
+        computed;
       if (value) {
         if (property === "color") {
           styleInfoData[property] = {
             value,
             local,
+            previousSource,
             cascaded,
             inherited,
             preset,
@@ -369,6 +443,7 @@ export const useStyleInfo = () => {
           styleInfoData[property] = {
             value,
             local,
+            previousSource,
             cascaded,
             inherited,
             preset,

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.ts
@@ -452,7 +452,14 @@ export const useStyleInfo = () => {
       }
     }
     return styleInfoData;
-  }, [browserStyle, presetStyle, inheritedInfo, cascadedInfo, selectedStyle]);
+  }, [
+    browserStyle,
+    presetStyle,
+    inheritedInfo,
+    cascadedInfo,
+    previousSourceInfo,
+    selectedStyle,
+  ]);
 
   return styleInfoData;
 };


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1338 https://github.com/webstudio-is/webstudio-builder/issues/807

Used remote color for previous style sources and added messages to property name popup.

<img width="313" alt="Screenshot 2023-04-20 at 11 54 01" src="https://user-images.githubusercontent.com/5635476/233264852-739a3f7f-8542-482f-b41c-9c81d8a3d142.png">
<img width="298" alt="Screenshot 2023-04-20 at 11 54 50" src="https://user-images.githubusercontent.com/5635476/233264866-c1f8f00a-e428-46ca-b890-53aa27ce20f7.png">
<img width="254" alt="Screenshot 2023-04-20 at 11 58 04" src="https://user-images.githubusercontent.com/5635476/233264871-4228b48f-902f-44e4-beae-9cc8ab22045b.png">
<img width="283" alt="Screenshot 2023-04-20 at 11 58 15" src="https://user-images.githubusercontent.com/5635476/233264876-af1ebeb7-920b-4085-a6ef-86184d40d020.png">


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
