### PR TITLE
Fix body preset styles

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -326,6 +326,7 @@ export const Builder = ({
             css={{
               height: "100%",
               width: "100%",
+              backgroundColor: "#fff",
             }}
           />
         </Workspace>

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
@@ -172,13 +172,6 @@ test("compute inherited styles", () => {
     )
   ).toMatchInlineSnapshot(`
     {
-      "color": {
-        "instanceId": "1",
-        "value": {
-          "type": "keyword",
-          "value": "black",
-        },
-      },
       "fontFamily": {
         "instanceId": "1",
         "value": {

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
@@ -176,7 +176,7 @@ test("compute inherited styles", () => {
         "instanceId": "1",
         "value": {
           "type": "keyword",
-          "value": "#232323",
+          "value": "black",
         },
       },
       "fontFamily": {

--- a/packages/react-sdk/src/components/body.ws.tsx
+++ b/packages/react-sdk/src/components/body.ws.tsx
@@ -15,11 +15,6 @@ const presetStyle = {
       value: 100,
     },
 
-    backgroundColor: {
-      type: "keyword",
-      value: "transparent",
-    },
-
     fontFamily: {
       type: "keyword",
       value: "Arial",
@@ -35,11 +30,6 @@ const presetStyle = {
       type: "unit",
       unit: "number",
       value: 1.5,
-    },
-
-    color: {
-      type: "keyword",
-      value: "black",
     },
   },
 } as const satisfies Record<typeof defaultTag, Style>;

--- a/packages/react-sdk/src/components/body.ws.tsx
+++ b/packages/react-sdk/src/components/body.ws.tsx
@@ -17,7 +17,7 @@ const presetStyle = {
 
     backgroundColor: {
       type: "keyword",
-      value: "white",
+      value: "transparent",
     },
 
     fontFamily: {
@@ -39,7 +39,7 @@ const presetStyle = {
 
     color: {
       type: "keyword",
-      value: "#232323",
+      value: "black",
     },
   },
 } as const satisfies Record<typeof defaultTag, Style>;


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1243

Changed body styles to black on transparent defaults.
Added white background to iframe to make canvas visible on workspace.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
