### PR TITLE
Fix switching to base breakpoint on a small screen

### DIFF
--- a/apps/builder/app/builder/features/breakpoints/find-initial-width.test.ts
+++ b/apps/builder/app/builder/features/breakpoints/find-initial-width.test.ts
@@ -13,11 +13,31 @@ const breakpoints = [
 ];
 
 describe("Find initial width", () => {
-  test("base", () => {
+  test("base default", () => {
+    expect(
+      findInitialWidth(breakpoints, breakpoints[0], workspaceWidth)
+    ).toStrictEqual(992);
+  });
+
+  test("base while workspace is small", () => {
+    expect(findInitialWidth(breakpoints, breakpoints[0], 500)).toStrictEqual(
+      992
+    );
+  });
+
+  test("base min-width only", () => {
+    const workspaceWidth = 1000;
+
+    const breakpoints = [
+      { id: "0", label: "Base" },
+      { id: "4", label: "Large", minWidth: 1280 },
+      { id: "5", label: "Extra Large", minWidth: 1440 },
+    ];
     expect(
       findInitialWidth(breakpoints, breakpoints[0], workspaceWidth)
     ).toStrictEqual(workspaceWidth);
   });
+
   test("tablet", () => {
     expect(
       findInitialWidth(breakpoints, breakpoints[1], workspaceWidth)

--- a/apps/builder/app/builder/features/breakpoints/find-initial-width.test.ts
+++ b/apps/builder/app/builder/features/breakpoints/find-initial-width.test.ts
@@ -25,7 +25,7 @@ describe("Find initial width", () => {
     );
   });
 
-  test("base min-width only", () => {
+  test("base and min-width only", () => {
     const workspaceWidth = 1000;
 
     const breakpoints = [
@@ -38,7 +38,21 @@ describe("Find initial width", () => {
     ).toStrictEqual(workspaceWidth);
   });
 
-  test("base is the only breakpoint", () => {
+  test("base and max-width only", () => {
+    const workspaceWidth = 1000;
+
+    const breakpoints = [
+      { id: "0", label: "Base" },
+      { id: "1", label: "Tablet", maxWidth: 991 },
+      { id: "2", label: "Mobile landscape", maxWidth: 767 },
+      { id: "3", label: "Mobile portrait", maxWidth: 479 },
+    ];
+    expect(
+      findInitialWidth(breakpoints, breakpoints[0], workspaceWidth)
+    ).toStrictEqual(992);
+  });
+
+  test("base only", () => {
     const breakpoints = [{ id: "0", label: "Base" }];
     expect(
       findInitialWidth(breakpoints, breakpoints[0], workspaceWidth)

--- a/apps/builder/app/builder/features/breakpoints/find-initial-width.test.ts
+++ b/apps/builder/app/builder/features/breakpoints/find-initial-width.test.ts
@@ -38,6 +38,13 @@ describe("Find initial width", () => {
     ).toStrictEqual(workspaceWidth);
   });
 
+  test("base is the only breakpoint", () => {
+    const breakpoints = [{ id: "0", label: "Base" }];
+    expect(
+      findInitialWidth(breakpoints, breakpoints[0], workspaceWidth)
+    ).toStrictEqual(workspaceWidth);
+  });
+
   test("tablet", () => {
     expect(
       findInitialWidth(breakpoints, breakpoints[1], workspaceWidth)

--- a/apps/builder/app/builder/features/breakpoints/find-initial-width.ts
+++ b/apps/builder/app/builder/features/breakpoints/find-initial-width.ts
@@ -12,9 +12,10 @@ export const findInitialWidth = (
   selectedBreakpoint: Breakpoint,
   workspaceWidth: number
 ) => {
+  // Finding the canvas width when user selects base breakpoint is a bit more complicated.
+  // We want to find the lowest possible size that is bigger than all max breakpoints and smaller than all min breakpoints.
+  // Note: it is still possible to get intersecting min and max breakpoints.
   if (isBaseBreakpoint(selectedBreakpoint)) {
-    // Finding the canvas width when user selects base breakpoint is a bit more complicated.
-    // We want to find the lowest possible size that is bigger than all max breakpoints and smaller than all min breakpoints.
     const grouped = groupBreakpoints(breakpoints);
     const baseIndex = grouped.findIndex(
       ({ id }) => selectedBreakpoint.id === id

--- a/apps/builder/app/builder/features/breakpoints/find-initial-width.ts
+++ b/apps/builder/app/builder/features/breakpoints/find-initial-width.ts
@@ -16,6 +16,10 @@ export const findInitialWidth = (
   // We want to find the lowest possible size that is bigger than all max breakpoints and smaller than all min breakpoints.
   // Note: it is still possible to get intersecting min and max breakpoints.
   if (isBaseBreakpoint(selectedBreakpoint)) {
+    // Base is the only breakpoint
+    if (breakpoints.length === 1) {
+      return workspaceWidth;
+    }
     const grouped = groupBreakpoints(breakpoints);
     const baseIndex = grouped.findIndex(
       ({ id }) => selectedBreakpoint.id === id

--- a/apps/builder/app/builder/features/breakpoints/trigger-button.tsx
+++ b/apps/builder/app/builder/features/breakpoints/trigger-button.tsx
@@ -38,6 +38,7 @@ export const TriggerButton = (props: TriggerButtonProps) => {
   if (breakpoint === undefined || canvasWidth === undefined) {
     return null;
   }
+  const roundedScale = Math.round(scale);
   return (
     <DropdownMenuTrigger
       aria-label="Show breakpoints"
@@ -48,9 +49,9 @@ export const TriggerButton = (props: TriggerButtonProps) => {
       <Value unit="PX" minWidth={55}>
         {Math.round(canvasWidth)}
       </Value>
-      {scale !== 100 && (
+      {roundedScale !== 100 && (
         <Value unit="%" minWidth={30}>
-          {Math.round(scale)}
+          {roundedScale}
         </Value>
       )}
     </DropdownMenuTrigger>

--- a/apps/builder/app/builder/features/breakpoints/use-set-initial-canvas-width.ts
+++ b/apps/builder/app/builder/features/breakpoints/use-set-initial-canvas-width.ts
@@ -1,17 +1,13 @@
 import { useStore } from "@nanostores/react";
 import { useCallback, useEffect, useRef } from "react";
-import { findApplicableMedia } from "@webstudio-is/css-engine";
 import type { Breakpoint } from "@webstudio-is/project-build";
 import {
   useCanvasWidth,
   workspaceRectStore,
 } from "~/builder/shared/nano-states";
-import {
-  breakpointsStore,
-  selectedBreakpointIdStore,
-} from "~/shared/nano-states";
+import { breakpointsStore } from "~/shared/nano-states";
 import { findInitialWidth } from "./find-initial-width";
-import { groupBreakpoints, isBaseBreakpoint } from "~/shared/breakpoints";
+import { isBaseBreakpoint } from "~/shared/breakpoints";
 
 // Set canvas width based on workspace width, breakpoints and passed breakpoint id.
 export const useSetInitialCanvasWidth = () => {
@@ -24,6 +20,7 @@ export const useSetInitialCanvasWidth = () => {
       if (workspaceRect === undefined || breakpoint === undefined) {
         return false;
       }
+
       const width = findInitialWidth(
         Array.from(breakpoints.values()),
         breakpoint,
@@ -56,24 +53,12 @@ export const useSetInitialCanvasWidthOnce = () => {
     // When there is base breakpoint, we want to find the lowest possible size
     // that is bigger than all max breakpoints and smaller than all min breakpoints.
     if (baseBreakpoint) {
-      const grouped = groupBreakpoints(breakpointValues);
-      const baseIndex = grouped.findIndex(isBaseBreakpoint);
-      const nextAfterBase = grouped[baseIndex + 1];
-      if (nextAfterBase?.maxWidth !== undefined) {
-        const width = nextAfterBase.maxWidth + 1;
-        setCanvasWidth(width);
-        return;
-      }
+      const width = findInitialWidth(
+        breakpointValues,
+        baseBreakpoint,
+        workspaceRect.width
+      );
+      setCanvasWidth(width);
     }
-
-    // Find the breakpoint that applies according to the workspace width.
-    const applicableBreakpoint = findApplicableMedia(
-      breakpointValues,
-      workspaceRect.width
-    );
-    if (applicableBreakpoint) {
-      selectedBreakpointIdStore.set(applicableBreakpoint.id);
-    }
-    setCanvasWidth(workspaceRect.width);
   }, [breakpoints, setCanvasWidth, workspaceRect]);
 };


### PR DESCRIPTION
when base breakpoint selected, always use a width between max and min breakpoints at the lowest value

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
