### PR TITLE
Enforce server constraints for packages

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -3,7 +3,7 @@ import { type Publish, usePublish } from "~/shared/pubsub";
 import type { Build } from "@webstudio-is/project-build";
 import type { Project } from "@webstudio-is/project";
 import { theme, Box, type CSS, Flex, Grid } from "@webstudio-is/design-system";
-import type { AuthPermit } from "@webstudio-is/trpc-interface/server";
+import type { AuthPermit } from "@webstudio-is/trpc-interface/index.server";
 import { registerContainers, useBuilderStore } from "~/shared/sync";
 import { useSyncServer } from "./shared/sync/sync-server";
 // eslint-disable-next-line import/no-internal-modules

--- a/apps/builder/app/builder/shared/sync/sync-server.ts
+++ b/apps/builder/app/builder/shared/sync/sync-server.ts
@@ -1,11 +1,11 @@
+import { useEffect } from "react";
+import { useBeforeUnload } from "react-use";
 import { sync } from "immerhin";
 import type { Project } from "@webstudio-is/project";
 import type { Build } from "@webstudio-is/project-build";
+import type { AuthPermit } from "@webstudio-is/trpc-interface/index.server";
 import { restPatchPath } from "~/shared/router-utils";
-import { useEffect } from "react";
 import { enqueue, dequeue, queueStatus } from "./queue";
-import { useBeforeUnload } from "react-use";
-import type { AuthPermit } from "@webstudio-is/trpc-interface/server";
 
 // Periodic check for new entries to group them into one job/call in sync queue.
 const NEW_ENTRIES_INTERVAL = 1000;

--- a/apps/builder/app/routes/builder.$projectId.tsx
+++ b/apps/builder/app/routes/builder.$projectId.tsx
@@ -1,10 +1,10 @@
 import { useLoaderData, useRouteError } from "@remix-run/react";
 import type { ShouldRevalidateFunction } from "@remix-run/react";
 import type { LoaderArgs } from "@remix-run/node";
-import { loadBuildByProjectId } from "@webstudio-is/project-build/server";
-import { db } from "@webstudio-is/project/server";
-import { authorizeProject } from "@webstudio-is/trpc-interface/server";
-import { loadByProject } from "@webstudio-is/asset-uploader/server";
+import { loadBuildByProjectId } from "@webstudio-is/project-build/index.server";
+import { db } from "@webstudio-is/project/index.server";
+import { authorizeProject } from "@webstudio-is/trpc-interface/index.server";
+import { loadByProject } from "@webstudio-is/asset-uploader/index.server";
 import { createContext } from "~/shared/context.server";
 import { ErrorMessage } from "~/shared/error";
 import { sentryException } from "~/shared/sentry";

--- a/apps/builder/app/routes/dashboard._index.tsx
+++ b/apps/builder/app/routes/dashboard._index.tsx
@@ -2,7 +2,7 @@ import type { ComponentProps } from "react";
 import { useLoaderData, useRouteError } from "@remix-run/react";
 import type { LoaderArgs } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
-import { dashboardProjectRouter } from "@webstudio-is/dashboard/server";
+import { dashboardProjectRouter } from "@webstudio-is/dashboard/index.server";
 import { Dashboard } from "~/dashboard";
 import { findAuthenticatedUser } from "~/services/auth.server";
 import { loginPath } from "~/shared/router-utils";

--- a/apps/builder/app/routes/dashboard.projects.$method.ts
+++ b/apps/builder/app/routes/dashboard.projects.$method.ts
@@ -1,5 +1,5 @@
 import type { ActionArgs } from "@remix-run/node";
-import { dashboardProjectRouter } from "@webstudio-is/dashboard/server";
+import { dashboardProjectRouter } from "@webstudio-is/dashboard/index.server";
 import { findAuthenticatedUser } from "~/services/auth.server";
 import { createContext } from "~/shared/context.server";
 import { handleTrpcRemixAction } from "~/shared/remix/trpc-remix-request.server";

--- a/apps/builder/app/routes/rest.assets.$projectId.tsx
+++ b/apps/builder/app/routes/rest.assets.$projectId.tsx
@@ -5,7 +5,7 @@ import { MaxAssets, type Asset } from "@webstudio-is/asset-uploader";
 import {
   uploadAssets,
   loadByProject,
-} from "@webstudio-is/asset-uploader/server";
+} from "@webstudio-is/asset-uploader/index.server";
 import { toast } from "@webstudio-is/design-system";
 import type { ActionData } from "~/builder/shared/assets";
 import { sentryException } from "~/shared/sentry";

--- a/apps/builder/app/routes/rest.authorization-token.$method.ts
+++ b/apps/builder/app/routes/rest.authorization-token.$method.ts
@@ -1,5 +1,5 @@
 import type { ActionArgs } from "@remix-run/node";
-import { authorizationTokenRouter } from "@webstudio-is/authorization-token/server";
+import { authorizationTokenRouter } from "@webstudio-is/authorization-token/index.server";
 import { findAuthenticatedUser } from "~/services/auth.server";
 import { createContext } from "~/shared/context.server";
 import { handleTrpcRemixAction } from "~/shared/remix/trpc-remix-request.server";

--- a/apps/builder/app/routes/rest.patch.ts
+++ b/apps/builder/app/routes/rest.patch.ts
@@ -9,8 +9,8 @@ import {
   patchStyleSourceSelections,
   patchInstances,
   patchPages,
-} from "@webstudio-is/project-build/server";
-import { patchAssets } from "@webstudio-is/asset-uploader/server";
+} from "@webstudio-is/project-build/index.server";
+import { patchAssets } from "@webstudio-is/asset-uploader/index.server";
 import type { Project } from "@webstudio-is/project";
 import { createContext } from "~/shared/context.server";
 import { createAssetClient } from "~/shared/asset-client";

--- a/apps/builder/app/routes/rest.project.clone.$domain.ts
+++ b/apps/builder/app/routes/rest.project.clone.$domain.ts
@@ -1,7 +1,7 @@
 import { redirect, type LoaderArgs } from "@remix-run/node";
-import { db as projectDb } from "@webstudio-is/project/server";
+import { db as projectDb } from "@webstudio-is/project/index.server";
 import type { Project } from "@webstudio-is/project";
-import type { AppContext } from "@webstudio-is/trpc-interface/server";
+import type { AppContext } from "@webstudio-is/trpc-interface/index.server";
 import { findAuthenticatedUser } from "~/services/auth.server";
 import { builderPath, loginPath } from "~/shared/router-utils";
 import { createContext } from "~/shared/context.server";

--- a/apps/builder/app/routes/s.css.ts
+++ b/apps/builder/app/routes/s.css.ts
@@ -1,6 +1,6 @@
 import { type ActionArgs, json } from "@remix-run/node";
 import { generateCssText } from "@webstudio-is/react-sdk";
-import { db } from "@webstudio-is/project/server";
+import { db } from "@webstudio-is/project/index.server";
 import { createCssEngine } from "@webstudio-is/css-engine";
 import env from "~/env/env.public.server";
 import { getBuildParams } from "~/shared/router-utils";

--- a/apps/builder/app/services/trpc.server.ts
+++ b/apps/builder/app/services/trpc.server.ts
@@ -1,4 +1,4 @@
-import { createTrpcProxyServiceClient } from "@webstudio-is/trpc-interface/server";
+import { createTrpcProxyServiceClient } from "@webstudio-is/trpc-interface/index.server";
 import env from "~/env/env.server";
 
 const TRPC_SERVER_URL = env.TRPC_SERVER_URL ?? "";

--- a/apps/builder/app/shared/asset-client.ts
+++ b/apps/builder/app/shared/asset-client.ts
@@ -3,7 +3,7 @@ import { MaxSize } from "@webstudio-is/asset-uploader";
 import {
   createFsClient,
   createS3Client,
-} from "@webstudio-is/asset-uploader/server";
+} from "@webstudio-is/asset-uploader/index.server";
 import env from "~/env/env.server";
 
 export const createAssetClient = () => {

--- a/apps/builder/app/shared/context.server.ts
+++ b/apps/builder/app/shared/context.server.ts
@@ -1,4 +1,4 @@
-import type { AppContext } from "@webstudio-is/trpc-interface/server";
+import type { AppContext } from "@webstudio-is/trpc-interface/index.server";
 import { authenticator } from "~/services/auth.server";
 import { trpcClient } from "~/services/trpc.server";
 

--- a/apps/builder/app/shared/db/canvas.server.ts
+++ b/apps/builder/app/shared/db/canvas.server.ts
@@ -1,9 +1,9 @@
 import type { Project } from "@webstudio-is/project";
 import type { Data } from "@webstudio-is/react-sdk";
-import { loadBuildByProjectId } from "@webstudio-is/project-build/server";
-import { db as projectDb } from "@webstudio-is/project/server";
-import { loadByProject } from "@webstudio-is/asset-uploader/server";
-import type { AppContext } from "@webstudio-is/trpc-interface/server";
+import { loadBuildByProjectId } from "@webstudio-is/project-build/index.server";
+import { db as projectDb } from "@webstudio-is/project/index.server";
+import { loadByProject } from "@webstudio-is/asset-uploader/index.server";
+import type { AppContext } from "@webstudio-is/trpc-interface/index.server";
 import { findPageByIdOrPath } from "@webstudio-is/project-build";
 
 export const loadProductionCanvasData = async (

--- a/apps/builder/app/shared/db/misc.server.ts
+++ b/apps/builder/app/shared/db/misc.server.ts
@@ -1,10 +1,10 @@
-import { db } from "@webstudio-is/project/server";
+import { db } from "@webstudio-is/project/index.server";
 import { prisma } from "@webstudio-is/prisma-client";
-import type { AppContext } from "@webstudio-is/trpc-interface/server";
+import type { AppContext } from "@webstudio-is/trpc-interface/index.server";
 import {
   createBuild,
   loadBuildByProjectId,
-} from "@webstudio-is/project-build/server";
+} from "@webstudio-is/project-build/index.server";
 
 /**
  * Conceptually publishing is cloning all data that affects user site

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from "react";
 import { atom, computed, type WritableAtom } from "nanostores";
 import { useStore } from "@nanostores/react";
 import { nanoid } from "nanoid";
-import type { AuthPermit } from "@webstudio-is/trpc-interface/server";
+import type { AuthPermit } from "@webstudio-is/trpc-interface/index.server";
 import type { Asset, Assets } from "@webstudio-is/asset-uploader";
 import type { ItemDropTarget, Placement } from "@webstudio-is/design-system";
 import type {

--- a/packages/asset-uploader/package.json
+++ b/packages/asset-uploader/package.json
@@ -43,9 +43,9 @@
       "import": "./lib/index.js",
       "require": "./lib/cjs/index.js"
     },
-    "./server": {
+    "./index.server": {
       "source": "./src/index.server.ts",
-      "default": "./server.js"
+      "import": "./lib/index.server.js"
     }
   },
   "types": "lib/types/index.d.ts",

--- a/packages/asset-uploader/server.d.ts
+++ b/packages/asset-uploader/server.d.ts
@@ -1,1 +1,0 @@
-export * from "./lib/types/index.server";

--- a/packages/asset-uploader/server.js
+++ b/packages/asset-uploader/server.js
@@ -1,1 +1,0 @@
-export * from "./lib/index.server";

--- a/packages/asset-uploader/src/db/clone.ts
+++ b/packages/asset-uploader/src/db/clone.ts
@@ -2,7 +2,7 @@ import { prisma, type Prisma, type Project } from "@webstudio-is/prisma-client";
 import {
   authorizeProject,
   type AppContext,
-} from "@webstudio-is/trpc-interface/server";
+} from "@webstudio-is/trpc-interface/index.server";
 
 export const cloneAssets = async (
   {

--- a/packages/asset-uploader/src/db/create.ts
+++ b/packages/asset-uploader/src/db/create.ts
@@ -5,12 +5,12 @@ import {
   type Project,
   type Asset,
 } from "@webstudio-is/prisma-client";
-import type { ImageMeta } from "../schema";
-import { formatAsset } from "../utils/format-asset";
 import {
   authorizeProject,
   type AppContext,
-} from "@webstudio-is/trpc-interface/server";
+} from "@webstudio-is/trpc-interface/index.server";
+import type { ImageMeta } from "../schema";
+import { formatAsset } from "../utils/format-asset";
 
 type BaseOptions = {
   id: string;

--- a/packages/asset-uploader/src/db/delete.ts
+++ b/packages/asset-uploader/src/db/delete.ts
@@ -1,9 +1,9 @@
 import { prisma, type Project } from "@webstudio-is/prisma-client";
-import type { Asset } from "../schema";
 import {
   authorizeProject,
   type AppContext,
-} from "@webstudio-is/trpc-interface/server";
+} from "@webstudio-is/trpc-interface/index.server";
+import type { Asset } from "../schema";
 
 export const deleteFromDb = async (
   props: {

--- a/packages/asset-uploader/src/db/load.ts
+++ b/packages/asset-uploader/src/db/load.ts
@@ -1,10 +1,10 @@
 import { prisma, type Project } from "@webstudio-is/prisma-client";
-import type { Asset } from "../schema";
-import { formatAsset } from "../utils/format-asset";
 import {
   authorizeProject,
   type AppContext,
-} from "@webstudio-is/trpc-interface/server";
+} from "@webstudio-is/trpc-interface/index.server";
+import type { Asset } from "../schema";
+import { formatAsset } from "../utils/format-asset";
 
 export const loadByProject = async (
   projectId: Project["id"],

--- a/packages/asset-uploader/src/delete.ts
+++ b/packages/asset-uploader/src/delete.ts
@@ -2,7 +2,7 @@ import { prisma, type Project } from "@webstudio-is/prisma-client";
 import {
   authorizeProject,
   type AppContext,
-} from "@webstudio-is/trpc-interface/server";
+} from "@webstudio-is/trpc-interface/index.server";
 import type { AssetClient } from "./client";
 import { deleteFromDb } from "./db";
 import type { Asset } from "./schema";

--- a/packages/asset-uploader/src/patch.ts
+++ b/packages/asset-uploader/src/patch.ts
@@ -3,7 +3,7 @@ import type { Project } from "@webstudio-is/prisma-client";
 import {
   type AppContext,
   authorizeProject,
-} from "@webstudio-is/trpc-interface/server";
+} from "@webstudio-is/trpc-interface/index.server";
 import { type Asset, Assets } from "./schema";
 import { deleteAssets } from "./delete";
 import { loadByProject } from "./db/load";

--- a/packages/asset-uploader/src/upload.ts
+++ b/packages/asset-uploader/src/upload.ts
@@ -1,4 +1,4 @@
-import type { AppContext } from "@webstudio-is/trpc-interface/server";
+import type { AppContext } from "@webstudio-is/trpc-interface/index.server";
 import type { AssetClient } from "./client";
 import { createAssetWithLimit } from "./db/create";
 

--- a/packages/asset-uploader/src/utils/get-asset-data.ts
+++ b/packages/asset-uploader/src/utils/get-asset-data.ts
@@ -1,9 +1,8 @@
 import { z } from "zod";
-
 import sharp from "sharp";
-import { Location, ImageMeta } from "../schema";
 import { FontMeta } from "@webstudio-is/fonts";
-import { getFontData } from "@webstudio-is/fonts/server";
+import { getFontData } from "@webstudio-is/fonts/index.server";
+import { Location, ImageMeta } from "../schema";
 
 const BaseData = z.object({
   id: z.string(),

--- a/packages/authorization-token/package.json
+++ b/packages/authorization-token/package.json
@@ -33,9 +33,9 @@
       "import": "./lib/index.js",
       "require": "./lib/cjs/index.js"
     },
-    "./server": {
+    "./index.server": {
       "source": "./src/index.server.ts",
-      "default": "./server.js"
+      "import": "./lib/index.server.js"
     }
   },
   "types": "lib/types/index.d.ts",

--- a/packages/authorization-token/server.d.ts
+++ b/packages/authorization-token/server.d.ts
@@ -1,1 +1,0 @@
-export * from "./lib/types/index.server";

--- a/packages/authorization-token/server.js
+++ b/packages/authorization-token/server.js
@@ -1,1 +1,0 @@
-export * from "./lib/index.server";

--- a/packages/authorization-token/src/db/authorization-token.ts
+++ b/packages/authorization-token/src/db/authorization-token.ts
@@ -1,3 +1,4 @@
+import { v4 as uuid } from "uuid";
 import {
   prisma,
   type AuthorizationToken,
@@ -7,8 +8,7 @@ import {
   authorizeProject,
   authorizeAuthorizationToken,
   type AppContext,
-} from "@webstudio-is/trpc-interface/server";
-import { v4 as uuid } from "uuid";
+} from "@webstudio-is/trpc-interface/index.server";
 
 export const findMany = async (
   props: { projectId: Project["id"] },

--- a/packages/authorization-token/src/trpc/authorization-tokens-router.ts
+++ b/packages/authorization-token/src/trpc/authorization-tokens-router.ts
@@ -1,7 +1,7 @@
-import { initTRPC } from "@trpc/server";
-import type { AppContext } from "@webstudio-is/trpc-interface/server";
-import { db } from "../db";
 import { z } from "zod";
+import { initTRPC } from "@trpc/server";
+import type { AppContext } from "@webstudio-is/trpc-interface/index.server";
+import { db } from "../db";
 
 const { router, procedure } = initTRPC.context<AppContext>().create();
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -33,9 +33,9 @@
       "import": "./lib/index.js",
       "require": "./lib/cjs/index.js"
     },
-    "./server": {
+    "./index.server": {
       "source": "./src/index.server.ts",
-      "default": "./server.js"
+      "import": "./lib/index.server.js"
     }
   },
   "types": "lib/types/index.d.ts",

--- a/packages/dashboard/server.d.ts
+++ b/packages/dashboard/server.d.ts
@@ -1,1 +1,0 @@
-export * from "./lib/types/index.server";

--- a/packages/dashboard/server.js
+++ b/packages/dashboard/server.js
@@ -1,1 +1,0 @@
-export * from "./lib/index.server";

--- a/packages/dashboard/src/db/projects.ts
+++ b/packages/dashboard/src/db/projects.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@webstudio-is/prisma-client";
-import type { AppContext } from "@webstudio-is/trpc-interface/server";
+import type { AppContext } from "@webstudio-is/trpc-interface/index.server";
 import { DashboardProjects } from "./schema";
 
 export const findMany = async (userId: string, context: AppContext) => {

--- a/packages/dashboard/src/trpc/project-router.ts
+++ b/packages/dashboard/src/trpc/project-router.ts
@@ -1,11 +1,11 @@
+import { z } from "zod";
 import {
   mergeRouters,
   router,
   procedure,
   projectRouter as baseProjectRouter,
-} from "@webstudio-is/project/server";
+} from "@webstudio-is/project/index.server";
 import { db } from "../db";
-import { z } from "zod";
 
 const projectRouter = router({
   findMany: procedure

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -38,9 +38,9 @@
       "import": "./lib/index.js",
       "require": "./lib/cjs/index.js"
     },
-    "./server": {
+    "./index.server": {
       "source": "./src/index.server.ts",
-      "default": "./server.js"
+      "import": "./lib/index.server.js"
     }
   },
   "types": "lib/types/index.d.ts",

--- a/packages/fonts/server.d.ts
+++ b/packages/fonts/server.d.ts
@@ -1,1 +1,0 @@
-export * from "./lib/types/index.server";

--- a/packages/fonts/server.js
+++ b/packages/fonts/server.js
@@ -1,1 +1,0 @@
-export * from "./lib/index.server";

--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -12,9 +12,9 @@
       "import": "./lib/index.js",
       "require": "./lib/cjs/index.js"
     },
-    "./server": {
+    "./index.server": {
       "source": "./src/index.server.ts",
-      "default": "./server.js"
+      "import": "./lib/index.server.js"
     }
   },
   "types": "lib/types/index.d.ts",

--- a/packages/project-build/server.d.ts
+++ b/packages/project-build/server.d.ts
@@ -1,1 +1,0 @@
-export * from "./lib/types/index.server";

--- a/packages/project-build/server.js
+++ b/packages/project-build/server.js
@@ -1,1 +1,0 @@
-export * from "./lib/index.server";

--- a/packages/project-build/src/db/breakpoints.ts
+++ b/packages/project-build/src/db/breakpoints.ts
@@ -1,6 +1,10 @@
 import { nanoid } from "nanoid";
 import { applyPatches, type Patch } from "immer";
 import { type Project, prisma } from "@webstudio-is/prisma-client";
+import {
+  authorizeProject,
+  type AppContext,
+} from "@webstudio-is/trpc-interface/index.server";
 import type { Build } from "../types";
 import {
   type Breakpoint,
@@ -8,10 +12,6 @@ import {
   BreakpointsList,
   initialBreakpoints,
 } from "../schema/breakpoints";
-import {
-  authorizeProject,
-  type AppContext,
-} from "@webstudio-is/trpc-interface/server";
 
 export const parseBreakpoints = (
   breakpointsString: string,

--- a/packages/project-build/src/db/build.ts
+++ b/packages/project-build/src/db/build.ts
@@ -6,7 +6,7 @@ import {
   prisma,
   Prisma,
 } from "@webstudio-is/prisma-client";
-import type { AppContext } from "@webstudio-is/trpc-interface/server";
+import type { AppContext } from "@webstudio-is/trpc-interface/index.server";
 import type { Build } from "../types";
 import { Pages } from "../schema/pages";
 import {

--- a/packages/project-build/src/db/instances.ts
+++ b/packages/project-build/src/db/instances.ts
@@ -3,7 +3,7 @@ import { type Project, type Build, prisma } from "@webstudio-is/prisma-client";
 import {
   authorizeProject,
   type AppContext,
-} from "@webstudio-is/trpc-interface/server";
+} from "@webstudio-is/trpc-interface/index.server";
 import { Instances, InstancesList } from "../schema/instances";
 
 export const parseInstances = (

--- a/packages/project-build/src/db/pages.ts
+++ b/packages/project-build/src/db/pages.ts
@@ -3,7 +3,7 @@ import { type Project, type Build, prisma } from "@webstudio-is/prisma-client";
 import {
   authorizeProject,
   type AppContext,
-} from "@webstudio-is/trpc-interface/server";
+} from "@webstudio-is/trpc-interface/index.server";
 import { Pages } from "../schema/pages";
 
 export const patchPages = async (

--- a/packages/project-build/src/db/props.ts
+++ b/packages/project-build/src/db/props.ts
@@ -3,7 +3,7 @@ import { type Project, type Build, prisma } from "@webstudio-is/prisma-client";
 import {
   authorizeProject,
   type AppContext,
-} from "@webstudio-is/trpc-interface/server";
+} from "@webstudio-is/trpc-interface/index.server";
 import { Props, PropsList } from "../schema/props";
 
 export const parseProps = (

--- a/packages/project-build/src/db/style-source-selections.ts
+++ b/packages/project-build/src/db/style-source-selections.ts
@@ -3,7 +3,7 @@ import { type Project, type Build, prisma } from "@webstudio-is/prisma-client";
 import {
   authorizeProject,
   type AppContext,
-} from "@webstudio-is/trpc-interface/server";
+} from "@webstudio-is/trpc-interface/index.server";
 import {
   StyleSourceSelectionsList,
   StyleSourceSelections,

--- a/packages/project-build/src/db/style-sources.ts
+++ b/packages/project-build/src/db/style-sources.ts
@@ -3,7 +3,7 @@ import { type Project, prisma } from "@webstudio-is/prisma-client";
 import {
   authorizeProject,
   type AppContext,
-} from "@webstudio-is/trpc-interface/server";
+} from "@webstudio-is/trpc-interface/index.server";
 import type { Build } from "../types";
 import { StyleSourcesList, StyleSources } from "../schema/style-sources";
 

--- a/packages/project-build/src/db/styles.ts
+++ b/packages/project-build/src/db/styles.ts
@@ -3,7 +3,7 @@ import { type Project, prisma } from "@webstudio-is/prisma-client";
 import {
   authorizeProject,
   type AppContext,
-} from "@webstudio-is/trpc-interface/server";
+} from "@webstudio-is/trpc-interface/index.server";
 import type { Build } from "../types";
 import { Styles, StylesList, getStyleDeclKey } from "../schema/styles";
 

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -36,9 +36,9 @@
       "import": "./lib/index.js",
       "require": "./lib/cjs/index.js"
     },
-    "./server": {
+    "./index.server": {
       "source": "./src/index.server.ts",
-      "default": "./server.js"
+      "import": "./lib/index.server.js"
     }
   },
   "types": "lib/types/index.d.ts",

--- a/packages/project/server.d.ts
+++ b/packages/project/server.d.ts
@@ -1,1 +1,0 @@
-export * from "./lib/types/index.server";

--- a/packages/project/server.js
+++ b/packages/project/server.js
@@ -1,1 +1,0 @@
-export * from "./lib/index.server";

--- a/packages/project/src/db/project.ts
+++ b/packages/project/src/db/project.ts
@@ -2,15 +2,15 @@ import slugify from "slugify";
 import { customAlphabet } from "nanoid";
 import { v4 as uuid } from "uuid";
 import { prisma, Prisma } from "@webstudio-is/prisma-client";
-import { cloneAssets } from "@webstudio-is/asset-uploader/server";
+import { cloneAssets } from "@webstudio-is/asset-uploader/index.server";
 import {
   authorizeProject,
   type AppContext,
-} from "@webstudio-is/trpc-interface/server";
+} from "@webstudio-is/trpc-interface/index.server";
 import {
   createBuild,
   loadBuildByProjectId,
-} from "@webstudio-is/project-build/server";
+} from "@webstudio-is/project-build/index.server";
 import { Project, Title } from "../shared/schema";
 
 const nanoid = customAlphabet("1234567890abcdefghijklmnopqrstuvwxyz");

--- a/packages/project/src/trpc/trpc.ts
+++ b/packages/project/src/trpc/trpc.ts
@@ -1,5 +1,5 @@
 import { initTRPC } from "@trpc/server";
-import type { AppContext } from "@webstudio-is/trpc-interface/server";
+import type { AppContext } from "@webstudio-is/trpc-interface/index.server";
 
 export const { router, procedure, middleware, mergeRouters } = initTRPC
   .context<AppContext>()

--- a/packages/trpc-interface/package.json
+++ b/packages/trpc-interface/package.json
@@ -30,9 +30,9 @@
     "typescript": "5.0.3"
   },
   "exports": {
-    "./server": {
+    "./index.server": {
       "source": "./src/index.server.ts",
-      "default": "./server.js"
+      "import": "./lib/index.server.js"
     }
   },
   "files": [

--- a/packages/trpc-interface/server.d.ts
+++ b/packages/trpc-interface/server.d.ts
@@ -1,1 +1,0 @@
-export * from "./lib/types/index.server";

--- a/packages/trpc-interface/server.js
+++ b/packages/trpc-interface/server.js
@@ -1,1 +1,0 @@
-export * from "./lib/index.server";


### PR DESCRIPTION
Ref https://remix.run/docs/en/1.15.0/guides/constraints#server-code-pruning

Remix use NAME.server.ts extension to enforce omitting module from client bundles. Though we heavily used `/server` in packages which had no affect and blocked us in using a few node apis which were not polifilled with empty modules while bundling for client.

Here I replaced `/server` with `/index.server` and removed all legacy server entry points which are not longer necessary with new typescript resolution.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
