### PR TITLE
Fix new element outline issue

### DIFF
--- a/apps/builder/app/canvas/collapsed.ts
+++ b/apps/builder/app/canvas/collapsed.ts
@@ -208,10 +208,15 @@ const recalculate = () => {
  * For such elements we set collapsedAttribute and then style helpers add padding to
  * prevent collapsing.
  **/
-export const setDataCollapsed = (instanceId: string) => {
+export const setDataCollapsed = (instanceId: string, syncExec = false) => {
   instanceIdSet.add(instanceId);
 
   cancelAnimationFrame(rafHandle);
+
+  if (syncExec) {
+    recalculate();
+    return;
+  }
 
   rafHandle = requestAnimationFrame(() => {
     recalculate();

--- a/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
+++ b/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
@@ -16,6 +16,7 @@ import { getAllElementsBoundingBox } from "~/shared/dom-utils";
 import { subscribeScrollState } from "~/canvas/shared/scroll-state";
 import { selectedInstanceOutlineStore } from "~/shared/nano-states";
 import type { UnitSizes } from "~/builder/features/style-panel/shared/css-value-input/convert-units";
+import { setDataCollapsed } from "~/canvas/collapsed";
 
 const isHtmlTag = (tag: string): tag is HtmlTags =>
   htmlTags.includes(tag as HtmlTags);
@@ -79,6 +80,10 @@ export const SelectedInstanceConnector = ({
   const instances = useStore(instancesStore);
 
   useEffect(() => {
+    // Synchronously execute setDataCollapsed to calculate right outline
+    // This fixes an issue, when new element outline was calulated before collapsed elements calculations
+    setDataCollapsed(instance.id, true);
+
     const element = instanceElementRef.current;
     if (element === undefined) {
       return;

--- a/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
+++ b/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
@@ -99,6 +99,8 @@ export const SelectedInstanceConnector = ({
     showOutline();
 
     const resizeObserver = new ResizeObserver(() => {
+      // Having hover etc, element can have no size because of that
+      setDataCollapsed(instance.id, true);
       // contentRect has wrong x/y values for absolutely positioned element.
       // getBoundingClientRect is used instead.
       showOutline();


### PR DESCRIPTION
## Description

Outline calculated incorrectly for new elements in case if new element has size and added into collapsed item

<img width="361" alt="image" src="https://user-images.githubusercontent.com/5077042/233684755-27be5da9-9c6a-4fbf-b81a-481ec2abab60.png">

## Steps for reproduction

Create Box
Add Image inside
See outline now is on Image


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
