### PR TITLE
Use remix memory upload handler

### DIFF
--- a/packages/asset-uploader/src/utils/uuid-handler.ts
+++ b/packages/asset-uploader/src/utils/uuid-handler.ts
@@ -1,9 +1,0 @@
-import type { UploadHandler as UnstableUploadHandler } from "@remix-run/node";
-import { idsFormDataFieldName } from "../schema";
-import { toUint8Array } from "./to-uint8-array";
-
-export const uuidHandler: UnstableUploadHandler = async (part) => {
-  if (part.name === idsFormDataFieldName) {
-    return Buffer.from(await toUint8Array(part.data)).toString();
-  }
-};


### PR DESCRIPTION
We had own uuid-handler utility to buffer streamed values for formData. Remix has own memory upload handler to do the same. A little less custom code for us.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
