### PR TITLE
Radix Tabs

### DIFF
--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@nanostores/react": "^0.4.1",
     "@react-aria/utils": "^3.13.3",
+    "@radix-ui/react-tabs": "^1.0.0",
     "@webstudio-is/asset-uploader": "workspace:^",
     "@webstudio-is/css-data": "workspace:^",
     "@webstudio-is/css-engine": "workspace:^",

--- a/packages/react-sdk/src/components/__generated__/tabs-content.props.ts
+++ b/packages/react-sdk/src/components/__generated__/tabs-content.props.ts
@@ -1,0 +1,450 @@
+import type { PropMeta } from "@webstudio-is/generate-arg-types";
+
+export const props: Record<string, PropMeta> = {
+  slot: { required: false, control: "text", type: "string" },
+  style: { required: false, control: "text", type: "string" },
+  title: { required: false, control: "text", type: "string" },
+  defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
+  suppressContentEditableWarning: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  suppressHydrationWarning: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  accessKey: { required: false, control: "text", type: "string" },
+  autoFocus: { required: false, control: "boolean", type: "boolean" },
+  className: { required: false, control: "text", type: "string" },
+  contentEditable: { required: false, control: "text", type: "string" },
+  contextMenu: { required: false, control: "text", type: "string" },
+  dir: { required: false, control: "text", type: "string" },
+  draggable: { required: false, control: "boolean", type: "boolean" },
+  hidden: { required: false, control: "boolean", type: "boolean" },
+  id: { required: false, control: "text", type: "string" },
+  lang: { required: false, control: "text", type: "string" },
+  nonce: { required: false, control: "text", type: "string" },
+  placeholder: { required: false, control: "text", type: "string" },
+  spellCheck: { required: false, control: "boolean", type: "boolean" },
+  tabIndex: { required: false, control: "number", type: "number" },
+  translate: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["yes", "no"],
+  },
+  radioGroup: { required: false, control: "text", type: "string" },
+  role: { required: false, control: "text", type: "string" },
+  about: { required: false, control: "text", type: "string" },
+  content: { required: false, control: "text", type: "string" },
+  datatype: { required: false, control: "text", type: "string" },
+  inlist: { required: false, control: "text", type: "string" },
+  prefix: { required: false, control: "text", type: "string" },
+  property: { required: false, control: "text", type: "string" },
+  rel: { required: false, control: "text", type: "string" },
+  resource: { required: false, control: "text", type: "string" },
+  rev: { required: false, control: "text", type: "string" },
+  typeof: { required: false, control: "text", type: "string" },
+  vocab: { required: false, control: "text", type: "string" },
+  autoCapitalize: { required: false, control: "text", type: "string" },
+  autoCorrect: { required: false, control: "text", type: "string" },
+  autoSave: { required: false, control: "text", type: "string" },
+  color: { required: false, control: "color", type: "string" },
+  itemProp: { required: false, control: "text", type: "string" },
+  itemScope: { required: false, control: "boolean", type: "boolean" },
+  itemType: { required: false, control: "text", type: "string" },
+  itemID: { required: false, control: "text", type: "string" },
+  itemRef: { required: false, control: "text", type: "string" },
+  results: { required: false, control: "number", type: "number" },
+  security: { required: false, control: "text", type: "string" },
+  unselectable: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["on", "off"],
+  },
+  inputMode: {
+    description:
+      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+    required: false,
+    control: "select",
+    type: "string",
+    options: [
+      "text",
+      "none",
+      "search",
+      "tel",
+      "url",
+      "email",
+      "numeric",
+      "decimal",
+    ],
+  },
+  is: {
+    description:
+      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-activedescendant": {
+    description:
+      "Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-atomic": {
+    description:
+      "Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-autocomplete": {
+    description:
+      "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be\npresented if they are made.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["list", "none", "inline", "both"],
+  },
+  "aria-busy": {
+    description:
+      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-checked": {
+    description:
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-colcount": {
+    description:
+      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-colindex": {
+    description:
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-colspan": {
+    description:
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-controls": {
+    description:
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-current": {
+    description:
+      "Indicates the element that represents the current item within a container or set of related elements.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-describedby": {
+    description:
+      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-details": {
+    description:
+      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-disabled": {
+    description:
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-dropeffect": {
+    description:
+      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["link", "none", "copy", "execute", "move", "popup"],
+  },
+  "aria-errormessage": {
+    description:
+      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-expanded": {
+    description:
+      "Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-flowto": {
+    description:
+      "Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,\nallows assistive technology to override the general default of reading in document source order.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-grabbed": {
+    description:
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-haspopup": {
+    description:
+      "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-hidden": {
+    description:
+      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-invalid": {
+    description:
+      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-keyshortcuts": {
+    description:
+      "Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-label": {
+    description:
+      "Defines a string value that labels the current element.\n@see aria-labelledby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-labelledby": {
+    description:
+      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-level": {
+    description:
+      "Defines the hierarchical level of an element within a structure.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-live": {
+    description:
+      "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.",
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["off", "assertive", "polite"],
+  },
+  "aria-modal": {
+    description: "Indicates whether an element is modal when displayed.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-multiline": {
+    description:
+      "Indicates whether a text box accepts multiple lines of input or only a single line.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-multiselectable": {
+    description:
+      "Indicates that the user may select more than one item from the current selectable descendants.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-orientation": {
+    description:
+      "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.",
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["horizontal", "vertical"],
+  },
+  "aria-owns": {
+    description:
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-placeholder": {
+    description:
+      "Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.\nA hint could be a sample value or a brief description of the expected format.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-posinset": {
+    description:
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-pressed": {
+    description:
+      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-readonly": {
+    description:
+      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-relevant": {
+    description:
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: [
+      "text",
+      "additions",
+      "additions removals",
+      "additions text",
+      "all",
+      "removals",
+      "removals additions",
+      "removals text",
+      "text additions",
+      "text removals",
+    ],
+  },
+  "aria-required": {
+    description:
+      "Indicates that user input is required on the element before a form may be submitted.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-roledescription": {
+    description:
+      "Defines a human-readable, author-localized description for the role of an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-rowcount": {
+    description:
+      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-rowindex": {
+    description:
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-rowspan": {
+    description:
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-selected": {
+    description:
+      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-setsize": {
+    description:
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-sort": {
+    description:
+      "Indicates if items in a table or grid are sorted in ascending or descending order.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["none", "ascending", "descending", "other"],
+  },
+  "aria-valuemax": {
+    description: "Defines the maximum allowed value for a range widget.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuemin": {
+    description: "Defines the minimum allowed value for a range widget.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuenow": {
+    description:
+      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuetext": {
+    description:
+      "Defines the human readable text alternative of aria-valuenow for a range widget.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  asChild: { required: false, control: "boolean", type: "boolean" },
+  value: {
+    required: false,
+    control: "text",
+    type: "string",
+    defaultValue: "tab",
+  },
+};

--- a/packages/react-sdk/src/components/__generated__/tabs-list.props.ts
+++ b/packages/react-sdk/src/components/__generated__/tabs-list.props.ts
@@ -1,0 +1,445 @@
+import type { PropMeta } from "@webstudio-is/generate-arg-types";
+
+export const props: Record<string, PropMeta> = {
+  slot: { required: false, control: "text", type: "string" },
+  style: { required: false, control: "text", type: "string" },
+  title: { required: false, control: "text", type: "string" },
+  defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
+  suppressContentEditableWarning: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  suppressHydrationWarning: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  accessKey: { required: false, control: "text", type: "string" },
+  autoFocus: { required: false, control: "boolean", type: "boolean" },
+  className: { required: false, control: "text", type: "string" },
+  contentEditable: { required: false, control: "text", type: "string" },
+  contextMenu: { required: false, control: "text", type: "string" },
+  dir: { required: false, control: "text", type: "string" },
+  draggable: { required: false, control: "boolean", type: "boolean" },
+  hidden: { required: false, control: "boolean", type: "boolean" },
+  id: { required: false, control: "text", type: "string" },
+  lang: { required: false, control: "text", type: "string" },
+  nonce: { required: false, control: "text", type: "string" },
+  placeholder: { required: false, control: "text", type: "string" },
+  spellCheck: { required: false, control: "boolean", type: "boolean" },
+  tabIndex: { required: false, control: "number", type: "number" },
+  translate: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["yes", "no"],
+  },
+  radioGroup: { required: false, control: "text", type: "string" },
+  role: { required: false, control: "text", type: "string" },
+  about: { required: false, control: "text", type: "string" },
+  content: { required: false, control: "text", type: "string" },
+  datatype: { required: false, control: "text", type: "string" },
+  inlist: { required: false, control: "text", type: "string" },
+  prefix: { required: false, control: "text", type: "string" },
+  property: { required: false, control: "text", type: "string" },
+  rel: { required: false, control: "text", type: "string" },
+  resource: { required: false, control: "text", type: "string" },
+  rev: { required: false, control: "text", type: "string" },
+  typeof: { required: false, control: "text", type: "string" },
+  vocab: { required: false, control: "text", type: "string" },
+  autoCapitalize: { required: false, control: "text", type: "string" },
+  autoCorrect: { required: false, control: "text", type: "string" },
+  autoSave: { required: false, control: "text", type: "string" },
+  color: { required: false, control: "color", type: "string" },
+  itemProp: { required: false, control: "text", type: "string" },
+  itemScope: { required: false, control: "boolean", type: "boolean" },
+  itemType: { required: false, control: "text", type: "string" },
+  itemID: { required: false, control: "text", type: "string" },
+  itemRef: { required: false, control: "text", type: "string" },
+  results: { required: false, control: "number", type: "number" },
+  security: { required: false, control: "text", type: "string" },
+  unselectable: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["on", "off"],
+  },
+  inputMode: {
+    description:
+      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+    required: false,
+    control: "select",
+    type: "string",
+    options: [
+      "text",
+      "none",
+      "search",
+      "tel",
+      "url",
+      "email",
+      "numeric",
+      "decimal",
+    ],
+  },
+  is: {
+    description:
+      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-activedescendant": {
+    description:
+      "Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-atomic": {
+    description:
+      "Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-autocomplete": {
+    description:
+      "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be\npresented if they are made.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["list", "none", "inline", "both"],
+  },
+  "aria-busy": {
+    description:
+      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-checked": {
+    description:
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-colcount": {
+    description:
+      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-colindex": {
+    description:
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-colspan": {
+    description:
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-controls": {
+    description:
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-current": {
+    description:
+      "Indicates the element that represents the current item within a container or set of related elements.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-describedby": {
+    description:
+      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-details": {
+    description:
+      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-disabled": {
+    description:
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-dropeffect": {
+    description:
+      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["link", "none", "copy", "execute", "move", "popup"],
+  },
+  "aria-errormessage": {
+    description:
+      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-expanded": {
+    description:
+      "Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-flowto": {
+    description:
+      "Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,\nallows assistive technology to override the general default of reading in document source order.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-grabbed": {
+    description:
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-haspopup": {
+    description:
+      "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-hidden": {
+    description:
+      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-invalid": {
+    description:
+      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-keyshortcuts": {
+    description:
+      "Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-label": {
+    description:
+      "Defines a string value that labels the current element.\n@see aria-labelledby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-labelledby": {
+    description:
+      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-level": {
+    description:
+      "Defines the hierarchical level of an element within a structure.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-live": {
+    description:
+      "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.",
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["off", "assertive", "polite"],
+  },
+  "aria-modal": {
+    description: "Indicates whether an element is modal when displayed.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-multiline": {
+    description:
+      "Indicates whether a text box accepts multiple lines of input or only a single line.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-multiselectable": {
+    description:
+      "Indicates that the user may select more than one item from the current selectable descendants.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-orientation": {
+    description:
+      "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.",
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["horizontal", "vertical"],
+  },
+  "aria-owns": {
+    description:
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-placeholder": {
+    description:
+      "Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.\nA hint could be a sample value or a brief description of the expected format.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-posinset": {
+    description:
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-pressed": {
+    description:
+      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-readonly": {
+    description:
+      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-relevant": {
+    description:
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: [
+      "text",
+      "additions",
+      "additions removals",
+      "additions text",
+      "all",
+      "removals",
+      "removals additions",
+      "removals text",
+      "text additions",
+      "text removals",
+    ],
+  },
+  "aria-required": {
+    description:
+      "Indicates that user input is required on the element before a form may be submitted.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-roledescription": {
+    description:
+      "Defines a human-readable, author-localized description for the role of an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-rowcount": {
+    description:
+      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-rowindex": {
+    description:
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-rowspan": {
+    description:
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-selected": {
+    description:
+      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-setsize": {
+    description:
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-sort": {
+    description:
+      "Indicates if items in a table or grid are sorted in ascending or descending order.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["none", "ascending", "descending", "other"],
+  },
+  "aria-valuemax": {
+    description: "Defines the maximum allowed value for a range widget.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuemin": {
+    description: "Defines the minimum allowed value for a range widget.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuenow": {
+    description:
+      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuetext": {
+    description:
+      "Defines the human readable text alternative of aria-valuenow for a range widget.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  asChild: { required: false, control: "boolean", type: "boolean" },
+  loop: { required: false, control: "boolean", type: "boolean" },
+};

--- a/packages/react-sdk/src/components/__generated__/tabs-root.props.ts
+++ b/packages/react-sdk/src/components/__generated__/tabs-root.props.ts
@@ -1,0 +1,455 @@
+import type { PropMeta } from "@webstudio-is/generate-arg-types";
+
+export const props: Record<string, PropMeta> = {
+  slot: { required: false, control: "text", type: "string" },
+  style: { required: false, control: "text", type: "string" },
+  title: { required: false, control: "text", type: "string" },
+  defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  suppressContentEditableWarning: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  suppressHydrationWarning: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  accessKey: { required: false, control: "text", type: "string" },
+  autoFocus: { required: false, control: "boolean", type: "boolean" },
+  className: { required: false, control: "text", type: "string" },
+  contentEditable: { required: false, control: "text", type: "string" },
+  contextMenu: { required: false, control: "text", type: "string" },
+  draggable: { required: false, control: "boolean", type: "boolean" },
+  hidden: { required: false, control: "boolean", type: "boolean" },
+  id: { required: false, control: "text", type: "string" },
+  lang: { required: false, control: "text", type: "string" },
+  nonce: { required: false, control: "text", type: "string" },
+  placeholder: { required: false, control: "text", type: "string" },
+  spellCheck: { required: false, control: "boolean", type: "boolean" },
+  tabIndex: { required: false, control: "number", type: "number" },
+  translate: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["yes", "no"],
+  },
+  radioGroup: { required: false, control: "text", type: "string" },
+  role: { required: false, control: "text", type: "string" },
+  about: { required: false, control: "text", type: "string" },
+  content: { required: false, control: "text", type: "string" },
+  datatype: { required: false, control: "text", type: "string" },
+  inlist: { required: false, control: "text", type: "string" },
+  prefix: { required: false, control: "text", type: "string" },
+  property: { required: false, control: "text", type: "string" },
+  rel: { required: false, control: "text", type: "string" },
+  resource: { required: false, control: "text", type: "string" },
+  rev: { required: false, control: "text", type: "string" },
+  typeof: { required: false, control: "text", type: "string" },
+  vocab: { required: false, control: "text", type: "string" },
+  autoCapitalize: { required: false, control: "text", type: "string" },
+  autoCorrect: { required: false, control: "text", type: "string" },
+  autoSave: { required: false, control: "text", type: "string" },
+  color: { required: false, control: "color", type: "string" },
+  itemProp: { required: false, control: "text", type: "string" },
+  itemScope: { required: false, control: "boolean", type: "boolean" },
+  itemType: { required: false, control: "text", type: "string" },
+  itemID: { required: false, control: "text", type: "string" },
+  itemRef: { required: false, control: "text", type: "string" },
+  results: { required: false, control: "number", type: "number" },
+  security: { required: false, control: "text", type: "string" },
+  unselectable: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["on", "off"],
+  },
+  inputMode: {
+    description:
+      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+    required: false,
+    control: "select",
+    type: "string",
+    options: [
+      "text",
+      "none",
+      "search",
+      "tel",
+      "url",
+      "email",
+      "numeric",
+      "decimal",
+    ],
+  },
+  is: {
+    description:
+      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-activedescendant": {
+    description:
+      "Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-atomic": {
+    description:
+      "Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-autocomplete": {
+    description:
+      "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be\npresented if they are made.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["list", "none", "inline", "both"],
+  },
+  "aria-busy": {
+    description:
+      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-checked": {
+    description:
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-colcount": {
+    description:
+      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-colindex": {
+    description:
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-colspan": {
+    description:
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-controls": {
+    description:
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-current": {
+    description:
+      "Indicates the element that represents the current item within a container or set of related elements.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-describedby": {
+    description:
+      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-details": {
+    description:
+      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-disabled": {
+    description:
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-dropeffect": {
+    description:
+      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["link", "none", "copy", "execute", "move", "popup"],
+  },
+  "aria-errormessage": {
+    description:
+      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-expanded": {
+    description:
+      "Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-flowto": {
+    description:
+      "Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,\nallows assistive technology to override the general default of reading in document source order.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-grabbed": {
+    description:
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-haspopup": {
+    description:
+      "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-hidden": {
+    description:
+      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-invalid": {
+    description:
+      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-keyshortcuts": {
+    description:
+      "Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-label": {
+    description:
+      "Defines a string value that labels the current element.\n@see aria-labelledby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-labelledby": {
+    description:
+      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-level": {
+    description:
+      "Defines the hierarchical level of an element within a structure.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-live": {
+    description:
+      "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.",
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["off", "assertive", "polite"],
+  },
+  "aria-modal": {
+    description: "Indicates whether an element is modal when displayed.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-multiline": {
+    description:
+      "Indicates whether a text box accepts multiple lines of input or only a single line.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-multiselectable": {
+    description:
+      "Indicates that the user may select more than one item from the current selectable descendants.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-orientation": {
+    description:
+      "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.",
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["horizontal", "vertical"],
+  },
+  "aria-owns": {
+    description:
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-placeholder": {
+    description:
+      "Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.\nA hint could be a sample value or a brief description of the expected format.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-posinset": {
+    description:
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-pressed": {
+    description:
+      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-readonly": {
+    description:
+      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-relevant": {
+    description:
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: [
+      "text",
+      "additions",
+      "additions removals",
+      "additions text",
+      "all",
+      "removals",
+      "removals additions",
+      "removals text",
+      "text additions",
+      "text removals",
+    ],
+  },
+  "aria-required": {
+    description:
+      "Indicates that user input is required on the element before a form may be submitted.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-roledescription": {
+    description:
+      "Defines a human-readable, author-localized description for the role of an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-rowcount": {
+    description:
+      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-rowindex": {
+    description:
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-rowspan": {
+    description:
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-selected": {
+    description:
+      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-setsize": {
+    description:
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-sort": {
+    description:
+      "Indicates if items in a table or grid are sorted in ascending or descending order.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["none", "ascending", "descending", "other"],
+  },
+  "aria-valuemax": {
+    description: "Defines the maximum allowed value for a range widget.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuemin": {
+    description: "Defines the minimum allowed value for a range widget.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuenow": {
+    description:
+      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuetext": {
+    description:
+      "Defines the human readable text alternative of aria-valuenow for a range widget.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  asChild: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
+  activationMode: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["automatic", "manual"],
+  },
+  orientation: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["horizontal", "vertical"],
+  },
+};

--- a/packages/react-sdk/src/components/__generated__/tabs-trigger.props.ts
+++ b/packages/react-sdk/src/components/__generated__/tabs-trigger.props.ts
@@ -1,0 +1,470 @@
+import type { PropMeta } from "@webstudio-is/generate-arg-types";
+
+export const props: Record<string, PropMeta> = {
+  form: { required: false, control: "text", type: "string" },
+  slot: { required: false, control: "text", type: "string" },
+  style: { required: false, control: "text", type: "string" },
+  title: { required: false, control: "text", type: "string" },
+  disabled: { required: false, control: "boolean", type: "boolean" },
+  formAction: { required: false, control: "text", type: "string" },
+  formEncType: { required: false, control: "text", type: "string" },
+  formMethod: { required: false, control: "text", type: "string" },
+  formNoValidate: { required: false, control: "boolean", type: "boolean" },
+  formTarget: { required: false, control: "text", type: "string" },
+  name: { required: false, control: "text", type: "string" },
+  type: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["button", "submit", "reset"],
+  },
+  defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
+  suppressContentEditableWarning: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  suppressHydrationWarning: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  accessKey: { required: false, control: "text", type: "string" },
+  autoFocus: { required: false, control: "boolean", type: "boolean" },
+  className: { required: false, control: "text", type: "string" },
+  contentEditable: { required: false, control: "text", type: "string" },
+  contextMenu: { required: false, control: "text", type: "string" },
+  dir: { required: false, control: "text", type: "string" },
+  draggable: { required: false, control: "boolean", type: "boolean" },
+  hidden: { required: false, control: "boolean", type: "boolean" },
+  id: { required: false, control: "text", type: "string" },
+  lang: { required: false, control: "text", type: "string" },
+  nonce: { required: false, control: "text", type: "string" },
+  placeholder: { required: false, control: "text", type: "string" },
+  spellCheck: { required: false, control: "boolean", type: "boolean" },
+  tabIndex: { required: false, control: "number", type: "number" },
+  translate: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["yes", "no"],
+  },
+  radioGroup: { required: false, control: "text", type: "string" },
+  role: { required: false, control: "text", type: "string" },
+  about: { required: false, control: "text", type: "string" },
+  content: { required: false, control: "text", type: "string" },
+  datatype: { required: false, control: "text", type: "string" },
+  inlist: { required: false, control: "text", type: "string" },
+  prefix: { required: false, control: "text", type: "string" },
+  property: { required: false, control: "text", type: "string" },
+  rel: { required: false, control: "text", type: "string" },
+  resource: { required: false, control: "text", type: "string" },
+  rev: { required: false, control: "text", type: "string" },
+  typeof: { required: false, control: "text", type: "string" },
+  vocab: { required: false, control: "text", type: "string" },
+  autoCapitalize: { required: false, control: "text", type: "string" },
+  autoCorrect: { required: false, control: "text", type: "string" },
+  autoSave: { required: false, control: "text", type: "string" },
+  color: { required: false, control: "color", type: "string" },
+  itemProp: { required: false, control: "text", type: "string" },
+  itemScope: { required: false, control: "boolean", type: "boolean" },
+  itemType: { required: false, control: "text", type: "string" },
+  itemID: { required: false, control: "text", type: "string" },
+  itemRef: { required: false, control: "text", type: "string" },
+  results: { required: false, control: "number", type: "number" },
+  security: { required: false, control: "text", type: "string" },
+  unselectable: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["on", "off"],
+  },
+  inputMode: {
+    description:
+      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+    required: false,
+    control: "select",
+    type: "string",
+    options: [
+      "text",
+      "none",
+      "search",
+      "tel",
+      "url",
+      "email",
+      "numeric",
+      "decimal",
+    ],
+  },
+  is: {
+    description:
+      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-activedescendant": {
+    description:
+      "Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-atomic": {
+    description:
+      "Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-autocomplete": {
+    description:
+      "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be\npresented if they are made.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["list", "none", "inline", "both"],
+  },
+  "aria-busy": {
+    description:
+      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-checked": {
+    description:
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-colcount": {
+    description:
+      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-colindex": {
+    description:
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-colspan": {
+    description:
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-controls": {
+    description:
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-current": {
+    description:
+      "Indicates the element that represents the current item within a container or set of related elements.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-describedby": {
+    description:
+      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-details": {
+    description:
+      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-disabled": {
+    description:
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-dropeffect": {
+    description:
+      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["link", "none", "copy", "execute", "move", "popup"],
+  },
+  "aria-errormessage": {
+    description:
+      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-expanded": {
+    description:
+      "Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-flowto": {
+    description:
+      "Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,\nallows assistive technology to override the general default of reading in document source order.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-grabbed": {
+    description:
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-haspopup": {
+    description:
+      "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-hidden": {
+    description:
+      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-invalid": {
+    description:
+      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-keyshortcuts": {
+    description:
+      "Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-label": {
+    description:
+      "Defines a string value that labels the current element.\n@see aria-labelledby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-labelledby": {
+    description:
+      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-level": {
+    description:
+      "Defines the hierarchical level of an element within a structure.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-live": {
+    description:
+      "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.",
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["off", "assertive", "polite"],
+  },
+  "aria-modal": {
+    description: "Indicates whether an element is modal when displayed.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-multiline": {
+    description:
+      "Indicates whether a text box accepts multiple lines of input or only a single line.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-multiselectable": {
+    description:
+      "Indicates that the user may select more than one item from the current selectable descendants.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-orientation": {
+    description:
+      "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.",
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["horizontal", "vertical"],
+  },
+  "aria-owns": {
+    description:
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-placeholder": {
+    description:
+      "Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.\nA hint could be a sample value or a brief description of the expected format.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-posinset": {
+    description:
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-pressed": {
+    description:
+      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-readonly": {
+    description:
+      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-relevant": {
+    description:
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: [
+      "text",
+      "additions",
+      "additions removals",
+      "additions text",
+      "all",
+      "removals",
+      "removals additions",
+      "removals text",
+      "text additions",
+      "text removals",
+    ],
+  },
+  "aria-required": {
+    description:
+      "Indicates that user input is required on the element before a form may be submitted.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-roledescription": {
+    description:
+      "Defines a human-readable, author-localized description for the role of an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-rowcount": {
+    description:
+      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-rowindex": {
+    description:
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-rowspan": {
+    description:
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-selected": {
+    description:
+      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-setsize": {
+    description:
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-sort": {
+    description:
+      "Indicates if items in a table or grid are sorted in ascending or descending order.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["none", "ascending", "descending", "other"],
+  },
+  "aria-valuemax": {
+    description: "Defines the maximum allowed value for a range widget.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuemin": {
+    description: "Defines the minimum allowed value for a range widget.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuenow": {
+    description:
+      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuetext": {
+    description:
+      "Defines the human readable text alternative of aria-valuenow for a range widget.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  asChild: { required: false, control: "boolean", type: "boolean" },
+  innerText: {
+    required: false,
+    control: "text",
+    type: "string",
+    defaultValue: "Tab",
+  },
+  value: {
+    required: false,
+    control: "text",
+    type: "string",
+    defaultValue: "tab",
+  },
+};

--- a/packages/react-sdk/src/components/__generated__/tabs.props.ts
+++ b/packages/react-sdk/src/components/__generated__/tabs.props.ts
@@ -1,0 +1,455 @@
+import type { PropMeta } from "@webstudio-is/generate-arg-types";
+
+export const props: Record<string, PropMeta> = {
+  slot: { required: false, control: "text", type: "string" },
+  style: { required: false, control: "text", type: "string" },
+  title: { required: false, control: "text", type: "string" },
+  defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  suppressContentEditableWarning: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  suppressHydrationWarning: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  accessKey: { required: false, control: "text", type: "string" },
+  autoFocus: { required: false, control: "boolean", type: "boolean" },
+  className: { required: false, control: "text", type: "string" },
+  contentEditable: { required: false, control: "text", type: "string" },
+  contextMenu: { required: false, control: "text", type: "string" },
+  draggable: { required: false, control: "boolean", type: "boolean" },
+  hidden: { required: false, control: "boolean", type: "boolean" },
+  id: { required: false, control: "text", type: "string" },
+  lang: { required: false, control: "text", type: "string" },
+  nonce: { required: false, control: "text", type: "string" },
+  placeholder: { required: false, control: "text", type: "string" },
+  spellCheck: { required: false, control: "boolean", type: "boolean" },
+  tabIndex: { required: false, control: "number", type: "number" },
+  translate: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["yes", "no"],
+  },
+  radioGroup: { required: false, control: "text", type: "string" },
+  role: { required: false, control: "text", type: "string" },
+  about: { required: false, control: "text", type: "string" },
+  content: { required: false, control: "text", type: "string" },
+  datatype: { required: false, control: "text", type: "string" },
+  inlist: { required: false, control: "text", type: "string" },
+  prefix: { required: false, control: "text", type: "string" },
+  property: { required: false, control: "text", type: "string" },
+  rel: { required: false, control: "text", type: "string" },
+  resource: { required: false, control: "text", type: "string" },
+  rev: { required: false, control: "text", type: "string" },
+  typeof: { required: false, control: "text", type: "string" },
+  vocab: { required: false, control: "text", type: "string" },
+  autoCapitalize: { required: false, control: "text", type: "string" },
+  autoCorrect: { required: false, control: "text", type: "string" },
+  autoSave: { required: false, control: "text", type: "string" },
+  color: { required: false, control: "color", type: "string" },
+  itemProp: { required: false, control: "text", type: "string" },
+  itemScope: { required: false, control: "boolean", type: "boolean" },
+  itemType: { required: false, control: "text", type: "string" },
+  itemID: { required: false, control: "text", type: "string" },
+  itemRef: { required: false, control: "text", type: "string" },
+  results: { required: false, control: "number", type: "number" },
+  security: { required: false, control: "text", type: "string" },
+  unselectable: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["on", "off"],
+  },
+  inputMode: {
+    description:
+      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+    required: false,
+    control: "select",
+    type: "string",
+    options: [
+      "text",
+      "none",
+      "search",
+      "tel",
+      "url",
+      "email",
+      "numeric",
+      "decimal",
+    ],
+  },
+  is: {
+    description:
+      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-activedescendant": {
+    description:
+      "Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-atomic": {
+    description:
+      "Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-autocomplete": {
+    description:
+      "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be\npresented if they are made.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["list", "none", "inline", "both"],
+  },
+  "aria-busy": {
+    description:
+      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-checked": {
+    description:
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-colcount": {
+    description:
+      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-colindex": {
+    description:
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-colspan": {
+    description:
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-controls": {
+    description:
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-current": {
+    description:
+      "Indicates the element that represents the current item within a container or set of related elements.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-describedby": {
+    description:
+      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-details": {
+    description:
+      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-disabled": {
+    description:
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-dropeffect": {
+    description:
+      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["link", "none", "copy", "execute", "move", "popup"],
+  },
+  "aria-errormessage": {
+    description:
+      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-expanded": {
+    description:
+      "Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-flowto": {
+    description:
+      "Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,\nallows assistive technology to override the general default of reading in document source order.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-grabbed": {
+    description:
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-haspopup": {
+    description:
+      "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-hidden": {
+    description:
+      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-invalid": {
+    description:
+      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-keyshortcuts": {
+    description:
+      "Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-label": {
+    description:
+      "Defines a string value that labels the current element.\n@see aria-labelledby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-labelledby": {
+    description:
+      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-level": {
+    description:
+      "Defines the hierarchical level of an element within a structure.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-live": {
+    description:
+      "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.",
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["off", "assertive", "polite"],
+  },
+  "aria-modal": {
+    description: "Indicates whether an element is modal when displayed.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-multiline": {
+    description:
+      "Indicates whether a text box accepts multiple lines of input or only a single line.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-multiselectable": {
+    description:
+      "Indicates that the user may select more than one item from the current selectable descendants.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-orientation": {
+    description:
+      "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.",
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["horizontal", "vertical"],
+  },
+  "aria-owns": {
+    description:
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-placeholder": {
+    description:
+      "Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.\nA hint could be a sample value or a brief description of the expected format.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-posinset": {
+    description:
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-pressed": {
+    description:
+      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-readonly": {
+    description:
+      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-relevant": {
+    description:
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: [
+      "text",
+      "additions",
+      "additions removals",
+      "additions text",
+      "all",
+      "removals",
+      "removals additions",
+      "removals text",
+      "text additions",
+      "text removals",
+    ],
+  },
+  "aria-required": {
+    description:
+      "Indicates that user input is required on the element before a form may be submitted.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-roledescription": {
+    description:
+      "Defines a human-readable, author-localized description for the role of an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-rowcount": {
+    description:
+      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-rowindex": {
+    description:
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-rowspan": {
+    description:
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-selected": {
+    description:
+      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-setsize": {
+    description:
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-sort": {
+    description:
+      "Indicates if items in a table or grid are sorted in ascending or descending order.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["none", "ascending", "descending", "other"],
+  },
+  "aria-valuemax": {
+    description: "Defines the maximum allowed value for a range widget.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuemin": {
+    description: "Defines the minimum allowed value for a range widget.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuenow": {
+    description:
+      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuetext": {
+    description:
+      "Defines the human readable text alternative of aria-valuenow for a range widget.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  asChild: { required: false, control: "boolean", type: "boolean" },
+  defaultValue: { required: false, control: "text", type: "string" },
+  activationMode: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["automatic", "manual"],
+  },
+  orientation: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["horizontal", "vertical"],
+  },
+};

--- a/packages/react-sdk/src/components/__generated__/tabs.props.ts
+++ b/packages/react-sdk/src/components/__generated__/tabs.props.ts
@@ -440,6 +440,7 @@ export const props: Record<string, PropMeta> = {
   },
   asChild: { required: false, control: "boolean", type: "boolean" },
   defaultValue: { required: false, control: "text", type: "string" },
+  value: { required: false, control: "text", type: "string" },
   activationMode: {
     required: false,
     control: "radio",

--- a/packages/react-sdk/src/components/component-meta.ts
+++ b/packages/react-sdk/src/components/component-meta.ts
@@ -21,7 +21,7 @@ export const componentCategories = [
   "typography",
   "media",
   "forms",
-  "advanced",
+  "Radix UI",
 ] as const;
 
 export const stateCategories = ["states", "component-states"] as const;

--- a/packages/react-sdk/src/components/component-meta.ts
+++ b/packages/react-sdk/src/components/component-meta.ts
@@ -21,6 +21,7 @@ export const componentCategories = [
   "typography",
   "media",
   "forms",
+  "advanced",
 ] as const;
 
 export const stateCategories = ["states", "component-states"] as const;

--- a/packages/react-sdk/src/components/components.ts
+++ b/packages/react-sdk/src/components/components.ts
@@ -38,3 +38,7 @@ export { RadioButtonField } from "./radio-button-field";
 export { RadioButton } from "./radio-button";
 export { CheckboxField } from "./checkbox-field";
 export { Checkbox } from "./checkbox";
+export { Tabs } from "./tabs";
+export { TabsList } from "./tabs-list";
+export { TabsTrigger } from "./tabs-trigger";
+export { TabsContent } from "./tabs-content";

--- a/packages/react-sdk/src/components/index.ts
+++ b/packages/react-sdk/src/components/index.ts
@@ -33,6 +33,10 @@ import { meta as RadioButtonFieldMeta } from "./radio-button-field.ws";
 import { meta as RadioButtonMeta } from "./radio-button.ws";
 import { meta as CheckboxFieldMeta } from "./checkbox-field.ws";
 import { meta as CheckboxMeta } from "./checkbox.ws";
+import { meta as TabsRootMeta } from "./tabs.ws";
+import { meta as TabsList } from "./tabs-list.ws";
+import { meta as TabsTrigger } from "./tabs-trigger.ws";
+import { meta as TabsContent } from "./tabs-content.ws";
 
 // these are huge JSON objects that we want to be tree-shaken when not used!
 import { propsMeta as SlotMetaPropsMeta } from "./slot.ws";
@@ -68,6 +72,10 @@ import { propsMeta as RadioButtonFieldPropsMeta } from "./radio-button-field.ws"
 import { propsMeta as RadioButtonPropsMeta } from "./radio-button.ws";
 import { propsMeta as CheckboxFieldPropsMeta } from "./checkbox-field.ws";
 import { propsMeta as CheckboxPropsMeta } from "./checkbox.ws";
+import { propsMeta as TabsRootPropsMeta } from "./tabs.ws";
+import { propsMeta as TabsListPropsMeta } from "./tabs-list.ws";
+import { propsMeta as TabsTriggerPropsMeta } from "./tabs-trigger.ws";
+import { propsMeta as TabsContentPropsMeta } from "./tabs-content.ws";
 
 // @todo this list should not be hardcoded!
 export const defaultMetas: Record<string, WsComponentMeta> = {
@@ -104,6 +112,10 @@ export const defaultMetas: Record<string, WsComponentMeta> = {
   RadioButton: RadioButtonMeta,
   CheckboxField: CheckboxFieldMeta,
   Checkbox: CheckboxMeta,
+  Tabs: TabsRootMeta,
+  TabsList: TabsList,
+  TabsTrigger: TabsTrigger,
+  TabsContent: TabsContent,
 };
 
 let currentMetas = defaultMetas;
@@ -157,7 +169,11 @@ export const defaultPropsMetas: Record<string, WsComponentPropsMeta> = {
   RadioButton: RadioButtonPropsMeta,
   CheckboxField: CheckboxFieldPropsMeta,
   Checkbox: CheckboxPropsMeta,
-};
+  Tabs: TabsRootPropsMeta,
+  TabsList: TabsListPropsMeta,
+  TabsTrigger: TabsTriggerPropsMeta,
+  TabsContent: TabsContentPropsMeta,
+} as const;
 
 type RegisteredComponents = Partial<{
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/packages/react-sdk/src/components/tabs-content.tsx
+++ b/packages/react-sdk/src/components/tabs-content.tsx
@@ -9,7 +9,7 @@ export const TabsContent = forwardRef<
   Omit<TabsContentProps, "value"> & {
     value?: TabsContentProps["value"];
   }
->(({ value = "tab", children, ...props }, ref) => (
+>(({ value = "tab", ...props }, ref) => (
   <Content value={value} {...props} ref={ref} />
 ));
 

--- a/packages/react-sdk/src/components/tabs-content.tsx
+++ b/packages/react-sdk/src/components/tabs-content.tsx
@@ -1,0 +1,16 @@
+import { Content, type TabsContentProps } from "@radix-ui/react-tabs";
+import { forwardRef, type ElementRef } from "react";
+
+export const defaultTag = "div";
+
+// @todo for some reason when I use typeof TabsContent, it looses the `value` type.
+export const TabsContent = forwardRef<
+  ElementRef<typeof defaultTag>,
+  Omit<TabsContentProps, "value"> & {
+    value?: TabsContentProps["value"];
+  }
+>(({ value = "tab", children, ...props }, ref) => (
+  <Content value={value} {...props} ref={ref} />
+));
+
+TabsContent.displayName = "TabsContent";

--- a/packages/react-sdk/src/components/tabs-content.ws.tsx
+++ b/packages/react-sdk/src/components/tabs-content.ws.tsx
@@ -1,13 +1,16 @@
 import { BoxIcon } from "@webstudio-is/icons/svg";
-import type { WsComponentMeta, WsComponentPropsMeta } from "./component-meta";
+import type {
+  PresetStyle,
+  WsComponentMeta,
+  WsComponentPropsMeta,
+} from "./component-meta";
 import { props } from "./__generated__/tabs-content.props";
-import type { Style } from "@webstudio-is/css-data";
 import { div } from "../css/normalize";
 import { defaultTag } from "./tabs-content";
 
 const presetStyle = {
   div,
-} as const satisfies Record<typeof defaultTag, Style>;
+} satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
   type: "container",

--- a/packages/react-sdk/src/components/tabs-content.ws.tsx
+++ b/packages/react-sdk/src/components/tabs-content.ws.tsx
@@ -1,0 +1,38 @@
+import { BoxIcon } from "@webstudio-is/icons";
+import type { WsComponentMeta, WsComponentPropsMeta } from "./component-meta";
+import { props } from "./__generated__/tabs-content.props";
+import type { Style } from "@webstudio-is/css-data";
+import { div } from "../css/normalize";
+import { defaultTag } from "./tabs-content";
+
+const presetStyle = {
+  div,
+} as const satisfies Record<typeof defaultTag, Style>;
+
+export const meta: WsComponentMeta = {
+  category: "advanced",
+  type: "container",
+  label: "Tabs Content",
+  Icon: BoxIcon,
+  presetStyle,
+  states: [
+    {
+      selector: "[data-state=active]",
+      label: "Active",
+    },
+    {
+      selector: "[data-state=inactive]",
+      label: "Inactive",
+    },
+    { selector: "[data-orientation=vertical]", label: "Vertical orientation" },
+    {
+      selector: "[data-orientation=horizontal]",
+      label: "Horizontal orientation",
+    },
+  ],
+};
+
+export const propsMeta: WsComponentPropsMeta = {
+  props,
+  initialProps: ["value"],
+};

--- a/packages/react-sdk/src/components/tabs-content.ws.tsx
+++ b/packages/react-sdk/src/components/tabs-content.ws.tsx
@@ -17,6 +17,7 @@ export const meta: WsComponentMeta = {
   label: "Tabs Content",
   icon: BoxIcon,
   presetStyle,
+  acceptedParents: ["Tabs"],
   states: [
     {
       selector: "[data-state=active]",

--- a/packages/react-sdk/src/components/tabs-content.ws.tsx
+++ b/packages/react-sdk/src/components/tabs-content.ws.tsx
@@ -1,4 +1,4 @@
-import { BoxIcon } from "@webstudio-is/icons";
+import { BoxIcon } from "@webstudio-is/icons/svg";
 import type { WsComponentMeta, WsComponentPropsMeta } from "./component-meta";
 import { props } from "./__generated__/tabs-content.props";
 import type { Style } from "@webstudio-is/css-data";
@@ -10,10 +10,9 @@ const presetStyle = {
 } as const satisfies Record<typeof defaultTag, Style>;
 
 export const meta: WsComponentMeta = {
-  category: "advanced",
   type: "container",
   label: "Tabs Content",
-  Icon: BoxIcon,
+  icon: BoxIcon,
   presetStyle,
   states: [
     {

--- a/packages/react-sdk/src/components/tabs-list.tsx
+++ b/packages/react-sdk/src/components/tabs-list.tsx
@@ -1,0 +1,11 @@
+import { List, type TabsListProps } from "@radix-ui/react-tabs";
+import type { ForwardRefExoticComponent, RefAttributes } from "react";
+
+export const defaultTag = "div";
+
+// @todo for some reason when I use typeof TabsContent, it looses the `value` type.
+export const TabsList: ForwardRefExoticComponent<
+  Omit<TabsListProps, "loop"> & {
+    loop?: TabsListProps["loop"];
+  } & RefAttributes<HTMLDivElement>
+> = List;

--- a/packages/react-sdk/src/components/tabs-list.ws.tsx
+++ b/packages/react-sdk/src/components/tabs-list.ws.tsx
@@ -1,4 +1,4 @@
-import { BoxIcon } from "@webstudio-is/icons";
+import { BoxIcon } from "@webstudio-is/icons/svg";
 import type { WsComponentMeta, WsComponentPropsMeta } from "./component-meta";
 import { props } from "./__generated__/tabs-list.props";
 import type { Style } from "@webstudio-is/css-data";
@@ -10,10 +10,9 @@ const presetStyle = {
 } as const satisfies Record<typeof defaultTag, Style>;
 
 export const meta: WsComponentMeta = {
-  category: "advanced",
   type: "container",
   label: "Tabs List",
-  Icon: BoxIcon,
+  icon: BoxIcon,
   presetStyle,
   states: [
     { selector: "[data-orientation=vertical]", label: "Vertical orientation" },

--- a/packages/react-sdk/src/components/tabs-list.ws.tsx
+++ b/packages/react-sdk/src/components/tabs-list.ws.tsx
@@ -16,6 +16,7 @@ export const meta: WsComponentMeta = {
   type: "container",
   label: "Tabs List",
   icon: BoxIcon,
+  acceptedParents: ["Tabs"],
   presetStyle,
   states: [
     { selector: "[data-orientation=vertical]", label: "Vertical orientation" },

--- a/packages/react-sdk/src/components/tabs-list.ws.tsx
+++ b/packages/react-sdk/src/components/tabs-list.ws.tsx
@@ -1,13 +1,16 @@
 import { BoxIcon } from "@webstudio-is/icons/svg";
-import type { WsComponentMeta, WsComponentPropsMeta } from "./component-meta";
+import type {
+  PresetStyle,
+  WsComponentMeta,
+  WsComponentPropsMeta,
+} from "./component-meta";
 import { props } from "./__generated__/tabs-list.props";
-import type { Style } from "@webstudio-is/css-data";
 import { div } from "../css/normalize";
 import type { defaultTag } from "./tabs-list";
 
 const presetStyle = {
   div,
-} as const satisfies Record<typeof defaultTag, Style>;
+} satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
   type: "container",

--- a/packages/react-sdk/src/components/tabs-list.ws.tsx
+++ b/packages/react-sdk/src/components/tabs-list.ws.tsx
@@ -1,0 +1,30 @@
+import { BoxIcon } from "@webstudio-is/icons";
+import type { WsComponentMeta, WsComponentPropsMeta } from "./component-meta";
+import { props } from "./__generated__/tabs-list.props";
+import type { Style } from "@webstudio-is/css-data";
+import { div } from "../css/normalize";
+import type { defaultTag } from "./tabs-list";
+
+const presetStyle = {
+  div,
+} as const satisfies Record<typeof defaultTag, Style>;
+
+export const meta: WsComponentMeta = {
+  category: "advanced",
+  type: "container",
+  label: "Tabs List",
+  Icon: BoxIcon,
+  presetStyle,
+  states: [
+    { selector: "[data-orientation=vertical]", label: "Vertical orientation" },
+    {
+      selector: "[data-orientation=horizontal]",
+      label: "Horizontal orientation",
+    },
+  ],
+};
+
+export const propsMeta: WsComponentPropsMeta = {
+  props,
+  initialProps: ["loop"],
+};

--- a/packages/react-sdk/src/components/tabs-trigger.tsx
+++ b/packages/react-sdk/src/components/tabs-trigger.tsx
@@ -9,10 +9,12 @@ export const TabsTrigger = forwardRef<
     innerText?: string;
     value?: TabsTriggerProps["value"];
   }
->(({ innerText = "Tab", value = "tab", children, ...props }, ref) => (
-  <Trigger value={value} {...props} ref={ref}>
-    {children || innerText}
-  </Trigger>
-));
+>(({ innerText = "Tab", value = "tab", children, ...props }, ref) => {
+  return (
+    <Trigger value={value} {...props} ref={ref}>
+      {children || innerText}
+    </Trigger>
+  );
+});
 
 TabsTrigger.displayName = "TabsTrigger";

--- a/packages/react-sdk/src/components/tabs-trigger.tsx
+++ b/packages/react-sdk/src/components/tabs-trigger.tsx
@@ -1,0 +1,18 @@
+import { forwardRef, type ElementRef } from "react";
+import { Trigger, type TabsTriggerProps } from "@radix-ui/react-tabs";
+
+export const defaultTag = "button";
+
+export const TabsTrigger = forwardRef<
+  ElementRef<typeof defaultTag>,
+  Omit<TabsTriggerProps, "value"> & {
+    innerText?: string;
+    value?: TabsTriggerProps["value"];
+  }
+>(({ innerText = "Tab", value = "tab", children, ...props }, ref) => (
+  <Trigger value={value} {...props} ref={ref}>
+    {children || innerText}
+  </Trigger>
+));
+
+TabsTrigger.displayName = "TabsTrigger";

--- a/packages/react-sdk/src/components/tabs-trigger.ws.tsx
+++ b/packages/react-sdk/src/components/tabs-trigger.ws.tsx
@@ -1,4 +1,4 @@
-import { BoxIcon } from "@webstudio-is/icons";
+import { BoxIcon } from "@webstudio-is/icons/svg";
 import type { WsComponentMeta, WsComponentPropsMeta } from "./component-meta";
 import { props } from "./__generated__/tabs-trigger.props";
 import type { Style } from "@webstudio-is/css-data";
@@ -13,7 +13,7 @@ export const meta: WsComponentMeta = {
   category: "advanced",
   type: "container",
   label: "Tabs Trigger",
-  Icon: BoxIcon,
+  icon: BoxIcon,
   presetStyle,
   states: [
     {

--- a/packages/react-sdk/src/components/tabs-trigger.ws.tsx
+++ b/packages/react-sdk/src/components/tabs-trigger.ws.tsx
@@ -1,0 +1,42 @@
+import { BoxIcon } from "@webstudio-is/icons";
+import type { WsComponentMeta, WsComponentPropsMeta } from "./component-meta";
+import { props } from "./__generated__/tabs-trigger.props";
+import type { Style } from "@webstudio-is/css-data";
+import { button } from "../css/normalize";
+import type { defaultTag } from "./button";
+
+const presetStyle = {
+  button,
+} as const satisfies Record<typeof defaultTag, Style>;
+
+export const meta: WsComponentMeta = {
+  category: "advanced",
+  type: "container",
+  label: "Tabs Trigger",
+  Icon: BoxIcon,
+  presetStyle,
+  states: [
+    {
+      selector: "[data-state=active]",
+      label: "Active",
+    },
+    {
+      selector: "[data-state=inactive]",
+      label: "Inactive",
+    },
+    {
+      selector: "[data-disabled]",
+      label: "Disabled",
+    },
+    { selector: "[data-orientation=vertical]", label: "Vertical orientation" },
+    {
+      selector: "[data-orientation=horizontal]",
+      label: "Horizontal orientation",
+    },
+  ],
+};
+
+export const propsMeta: WsComponentPropsMeta = {
+  props,
+  initialProps: ["innerText", "value", "disabled"],
+};

--- a/packages/react-sdk/src/components/tabs-trigger.ws.tsx
+++ b/packages/react-sdk/src/components/tabs-trigger.ws.tsx
@@ -17,6 +17,7 @@ export const meta: WsComponentMeta = {
   label: "Tabs Trigger",
   icon: BoxIcon,
   presetStyle,
+  acceptedParents: ["TabsList"],
   states: [
     {
       selector: "[data-state=active]",

--- a/packages/react-sdk/src/components/tabs-trigger.ws.tsx
+++ b/packages/react-sdk/src/components/tabs-trigger.ws.tsx
@@ -1,16 +1,18 @@
 import { BoxIcon } from "@webstudio-is/icons/svg";
-import type { WsComponentMeta, WsComponentPropsMeta } from "./component-meta";
+import type {
+  PresetStyle,
+  WsComponentMeta,
+  WsComponentPropsMeta,
+} from "./component-meta";
 import { props } from "./__generated__/tabs-trigger.props";
-import type { Style } from "@webstudio-is/css-data";
 import { button } from "../css/normalize";
 import type { defaultTag } from "./button";
 
 const presetStyle = {
   button,
-} as const satisfies Record<typeof defaultTag, Style>;
+} satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
-  category: "advanced",
   type: "container",
   label: "Tabs Trigger",
   icon: BoxIcon,

--- a/packages/react-sdk/src/components/tabs.tsx
+++ b/packages/react-sdk/src/components/tabs.tsx
@@ -1,0 +1,12 @@
+import { Root, type TabsProps } from "@radix-ui/react-tabs";
+import type { ForwardRefExoticComponent, RefAttributes } from "react";
+
+export const defaultTag = "div";
+
+export const Tabs: ForwardRefExoticComponent<
+  Omit<TabsProps, "defaultValue" | "activationMode" | "orientation"> & {
+    defaultValue?: TabsProps["defaultValue"];
+    activationMode?: TabsProps["activationMode"];
+    orientation?: TabsProps["orientation"];
+  } & RefAttributes<HTMLDivElement>
+> = Root;

--- a/packages/react-sdk/src/components/tabs.tsx
+++ b/packages/react-sdk/src/components/tabs.tsx
@@ -4,8 +4,12 @@ import type { ForwardRefExoticComponent, RefAttributes } from "react";
 export const defaultTag = "div";
 
 export const Tabs: ForwardRefExoticComponent<
-  Omit<TabsProps, "defaultValue" | "activationMode" | "orientation"> & {
+  Omit<
+    TabsProps,
+    "defaultValue" | "value" | "activationMode" | "orientation"
+  > & {
     defaultValue?: TabsProps["defaultValue"];
+    value?: TabsProps["value"];
     activationMode?: TabsProps["activationMode"];
     orientation?: TabsProps["orientation"];
   } & RefAttributes<HTMLDivElement>

--- a/packages/react-sdk/src/components/tabs.ws.tsx
+++ b/packages/react-sdk/src/components/tabs.ws.tsx
@@ -1,0 +1,42 @@
+import { BoxIcon } from "@webstudio-is/icons";
+import type { WsComponentMeta, WsComponentPropsMeta } from "./component-meta";
+import { props } from "./__generated__/tabs.props";
+import type { Style } from "@webstudio-is/css-data";
+import { div } from "../css/normalize";
+import type { defaultTag } from "./tabs";
+
+const presetStyle = {
+  div: {
+    ...div,
+    display: {
+      type: "keyword",
+      value: "flex",
+    },
+    flexDirection: {
+      type: "keyword",
+      value: "column",
+    },
+  },
+} as const satisfies Record<typeof defaultTag, Style>;
+
+export const meta: WsComponentMeta = {
+  category: "advanced",
+  type: "container",
+  label: "Tabs",
+  Icon: BoxIcon,
+  presetStyle,
+  states: [
+    { selector: "[data-orientation=vertical]", label: "Vertical orientation" },
+    {
+      selector: "[data-orientation=horizontal]",
+      label: "Horizontal orientation",
+    },
+  ],
+  // @todo needs TreeTemplate data structure
+  children: [],
+};
+
+export const propsMeta: WsComponentPropsMeta = {
+  props,
+  initialProps: ["defaultValue", "orientation", "activationMode"],
+};

--- a/packages/react-sdk/src/components/tabs.ws.tsx
+++ b/packages/react-sdk/src/components/tabs.ws.tsx
@@ -43,20 +43,29 @@ export const meta: WsComponentMeta = {
         {
           type: "instance",
           component: "TabsTrigger",
-          props: [{ type: "string", name: "value", value: "tab1" }],
-          children: [{ type: "text", value: "One" }],
+          props: [
+            { type: "string", name: "value", value: "tab1" },
+            { type: "string", name: "innerText", value: "One" },
+          ],
+          children: [],
         },
         {
           type: "instance",
           component: "TabsTrigger",
-          props: [{ type: "string", name: "value", value: "tab2" }],
-          children: [{ type: "text", value: "Two" }],
+          props: [
+            { type: "string", name: "value", value: "tab2" },
+            { type: "string", name: "innerText", value: "Two" },
+          ],
+          children: [],
         },
         {
           type: "instance",
           component: "TabsTrigger",
-          props: [{ type: "string", name: "value", value: "tab3" }],
-          children: [{ type: "text", value: "Three" }],
+          props: [
+            { type: "string", name: "value", value: "tab3" },
+            { type: "string", name: "innerText", value: "Three" },
+          ],
+          children: [],
         },
       ],
     },
@@ -64,24 +73,42 @@ export const meta: WsComponentMeta = {
       type: "instance",
       component: "TabsContent",
       props: [{ type: "string", name: "value", value: "tab1" }],
-      children: [{ type: "text", value: "One" }],
+      children: [
+        {
+          type: "instance",
+          component: "Paragraph",
+          children: [{ type: "text", value: "One" }],
+        },
+      ],
     },
     {
       type: "instance",
       component: "TabsContent",
       props: [{ type: "string", name: "value", value: "tab2" }],
-      children: [{ type: "text", value: "Two" }],
+      children: [
+        {
+          type: "instance",
+          component: "Paragraph",
+          children: [{ type: "text", value: "Two" }],
+        },
+      ],
     },
     {
       type: "instance",
       component: "TabsContent",
       props: [{ type: "string", name: "value", value: "tab3" }],
-      children: [{ type: "text", value: "Three" }],
+      children: [
+        {
+          type: "instance",
+          component: "Paragraph",
+          children: [{ type: "text", value: "Three" }],
+        },
+      ],
     },
   ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {
   props,
-  initialProps: ["defaultValue", "orientation", "activationMode"],
+  initialProps: ["defaultValue", "value", "orientation", "activationMode"],
 };

--- a/packages/react-sdk/src/components/tabs.ws.tsx
+++ b/packages/react-sdk/src/components/tabs.ws.tsx
@@ -1,26 +1,29 @@
 import { BoxIcon } from "@webstudio-is/icons/svg";
-import type { WsComponentMeta, WsComponentPropsMeta } from "./component-meta";
+import type {
+  PresetStyle,
+  WsComponentMeta,
+  WsComponentPropsMeta,
+} from "./component-meta";
 import { props } from "./__generated__/tabs.props";
-import type { Style } from "@webstudio-is/css-data";
 import { div } from "../css/normalize";
 import type { defaultTag } from "./tabs";
 
 const presetStyle = {
-  div: {
+  div: [
     ...div,
-    display: {
-      type: "keyword",
-      value: "flex",
+    {
+      property: "display",
+      value: { type: "keyword", value: "flex" },
     },
-    flexDirection: {
-      type: "keyword",
-      value: "column",
+    {
+      property: "flexDirection",
+      value: { type: "keyword", value: "column" },
     },
-  },
-} as const satisfies Record<typeof defaultTag, Style>;
+  ],
+} satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
-  category: "advanced",
+  category: "Radix UI",
   type: "container",
   label: "Tabs",
   icon: BoxIcon,
@@ -32,8 +35,50 @@ export const meta: WsComponentMeta = {
       label: "Horizontal orientation",
     },
   ],
-  // @todo needs TreeTemplate data structure
-  children: [],
+  children: [
+    {
+      type: "instance",
+      component: "TabsList",
+      children: [
+        {
+          type: "instance",
+          component: "TabsTrigger",
+          props: [{ type: "string", name: "value", value: "tab1" }],
+          children: [{ type: "text", value: "One" }],
+        },
+        {
+          type: "instance",
+          component: "TabsTrigger",
+          props: [{ type: "string", name: "value", value: "tab2" }],
+          children: [{ type: "text", value: "Two" }],
+        },
+        {
+          type: "instance",
+          component: "TabsTrigger",
+          props: [{ type: "string", name: "value", value: "tab3" }],
+          children: [{ type: "text", value: "Three" }],
+        },
+      ],
+    },
+    {
+      type: "instance",
+      component: "TabsContent",
+      props: [{ type: "string", name: "value", value: "tab1" }],
+      children: [{ type: "text", value: "One" }],
+    },
+    {
+      type: "instance",
+      component: "TabsContent",
+      props: [{ type: "string", name: "value", value: "tab2" }],
+      children: [{ type: "text", value: "Two" }],
+    },
+    {
+      type: "instance",
+      component: "TabsContent",
+      props: [{ type: "string", name: "value", value: "tab3" }],
+      children: [{ type: "text", value: "Three" }],
+    },
+  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/tabs.ws.tsx
+++ b/packages/react-sdk/src/components/tabs.ws.tsx
@@ -1,4 +1,4 @@
-import { BoxIcon } from "@webstudio-is/icons";
+import { BoxIcon } from "@webstudio-is/icons/svg";
 import type { WsComponentMeta, WsComponentPropsMeta } from "./component-meta";
 import { props } from "./__generated__/tabs.props";
 import type { Style } from "@webstudio-is/css-data";
@@ -23,7 +23,7 @@ export const meta: WsComponentMeta = {
   category: "advanced",
   type: "container",
   label: "Tabs",
-  Icon: BoxIcon,
+  icon: BoxIcon,
   presetStyle,
   states: [
     { selector: "[data-orientation=vertical]", label: "Vertical orientation" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1174,6 +1174,9 @@ importers:
       '@nanostores/react':
         specifier: ^0.4.1
         version: 0.4.1(nanostores@0.7.1)(react@18.2.0)
+      '@radix-ui/react-tabs':
+        specifier: ^1.0.0
+        version: 1.0.0(react-dom@18.2.0)(react@18.2.0)
       '@react-aria/utils':
         specifier: ^3.13.3
         version: 3.15.0(react@18.2.0)


### PR DESCRIPTION
## Description

1. This is the first attempt to use advanced/complex components on cavnas

## Todo

- [x] Tree Template - a data structure we can place into `children` in meta that we can use to create real data structure and render. Default template should have by default 2 tabs and 2 contents that work out of the box.
- [x] Remove category from Trigger, Content, Tabs List metas, so they don't show up standalone in components list, but they still can be copy/pasted from tab. 
- [x] Recover from misplaced component error or any error on canvas after dragging component in the right position or removing it
      <img width="793" alt="Screenshot 2023-04-22 at 14 10 00" src="https://user-images.githubusercontent.com/52824/233784024-1410b9cd-4252-4e93-8c67-e45e82b67702.png">
- [ ]  generate-arg-types doesn't seem to work with interfaces (not blocking right now, since we can retype the types, but will be blocking for the next stage with user components) 



## Steps for reproduction

1. click button
3. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
