### PR TITLE
Run dts as additional checks in actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,4 +25,4 @@ jobs:
 
       - run: pnpm prettier --cache --check "**/*.{js,md,ts,tsx}"
 
-      - run: pnpm turbo run size-test build checks
+      - run: pnpm turbo run size-test build checks dts

--- a/packages/react-sdk/src/embed-template.ts
+++ b/packages/react-sdk/src/embed-template.ts
@@ -47,7 +47,7 @@ export const EmbedTemplateStyleDecl = z.object({
 
 export type EmbedTemplateStyleDecl = z.infer<typeof EmbedTemplateStyleDecl>;
 
-type EmbedTemplateInstance = {
+export type EmbedTemplateInstance = {
   type: "instance";
   component: string;
   props?: EmbedTemplateProp[];
@@ -55,16 +55,19 @@ type EmbedTemplateInstance = {
   children: Array<EmbedTemplateInstance | EmbedTemplateText>;
 };
 
-const EmbedTemplateInstance: z.ZodType<EmbedTemplateInstance> = z.object({
-  type: z.literal("instance"),
-  component: z.string(),
-  props: z.optional(z.array(EmbedTemplateProp)),
-  styles: z.optional(z.array(EmbedTemplateStyleDecl)),
-  children: z.lazy(() => WsEmbedTemplate),
-});
+export const EmbedTemplateInstance: z.ZodType<EmbedTemplateInstance> = z.lazy(
+  () =>
+    z.object({
+      type: z.literal("instance"),
+      component: z.string(),
+      props: z.optional(z.array(EmbedTemplateProp)),
+      styles: z.optional(z.array(EmbedTemplateStyleDecl)),
+      children: WsEmbedTemplate,
+    })
+);
 
-export const WsEmbedTemplate = z.array(
-  z.union([z.lazy(() => EmbedTemplateInstance), EmbedTemplateText])
+export const WsEmbedTemplate = z.lazy(() =>
+  z.array(z.union([EmbedTemplateInstance, EmbedTemplateText]))
 );
 
 export type WsEmbedTemplate = z.infer<typeof WsEmbedTemplate>;


### PR DESCRIPTION
This fixes the bug introduced in my previous PRs and reproducable only by running dts generation. Here added it to checks so we could avoid broken publishes while releasing.

## Code Review

- [ ] hi @Andarist, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
