### PR TITLE
Units menu in css value input

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -34,6 +34,7 @@ import { toValue } from "@webstudio-is/css-engine";
 import { useDebouncedCallback } from "use-debounce";
 import type { StyleSource } from "../style-info";
 import { toPascalCase } from "../keyword-utils";
+
 import {
   selectedInstanceBrowserStyleStore,
   selectedInstanceUnitSizesStore,
@@ -364,7 +365,14 @@ export const CssValueInput = ({
   const [isUnitsOpen, unitSelectElement] = useUnitSelect({
     property,
     value,
-    onChange: (unit) => {
+    onChange: (unitOrKeyword) => {
+      if (unitOrKeyword.type === "keyword") {
+        onChangeComplete(unitOrKeyword, "unit-select");
+        return;
+      }
+
+      const unit = unitOrKeyword.value;
+
       // value looks like a number and just edited (type === "intermediate")
       // no additional conversions are necessary
       if (

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -34,7 +34,6 @@ import { toValue } from "@webstudio-is/css-engine";
 import { useDebouncedCallback } from "use-debounce";
 import type { StyleSource } from "../style-info";
 import { toPascalCase } from "../keyword-utils";
-import { isValid } from "../parse-css-value";
 import {
   selectedInstanceBrowserStyleStore,
   selectedInstanceUnitSizesStore,
@@ -364,14 +363,7 @@ export const CssValueInput = ({
 
   const [isUnitsOpen, unitSelectElement] = useUnitSelect({
     property,
-    showUnitless:
-      value.type === "unit" || value.type === "intermediate"
-        ? isValid(property, `${value.value}`)
-        : false,
-    value:
-      value.type === "unit" || value.type === "intermediate"
-        ? value.unit
-        : undefined,
+    value,
     onChange: (unit) => {
       // value looks like a number and just edited (type === "intermediate")
       // no additional conversions are necessary

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/unit-select.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/unit-select.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from "react";
-import type { Unit } from "@webstudio-is/css-data";
+import { keywordValues, type Unit } from "@webstudio-is/css-data";
 import { properties, units } from "@webstudio-is/css-data";
 import * as SelectPrimitive from "@radix-ui/react-select";
 import {
@@ -12,18 +12,34 @@ import {
   nestedSelectButtonUnitless,
 } from "@webstudio-is/design-system";
 import { ChevronDownIcon, ChevronUpIcon } from "@webstudio-is/icons";
+import type { CssValueInputValue } from "./css-value-input";
+import { isValid } from "../parse-css-value";
+import { toPascalCase } from "../keyword-utils";
 
 type UnitOption = {
-  id: Unit;
+  id: string;
   label: string;
 };
 
-const visibleLengthUnits = ["px", "em", "rem", "ch", "vw", "vh"] as const;
+// To make sorting stable
+const unitPreferedSorting = [
+  ...units.length,
+  ...units.percentage,
+  "number",
+  ...units.angle,
+  ...units.decibel,
+  ...units.flex,
+  ...units.frequency,
+  ...units.resolution,
+  ...units.semitones,
+  ...units.time,
+];
+
+const visibleLengthUnits = ["px", "em", "rem", "dvw", "dvh"] as const;
 
 type UseUnitSelectType = {
   property: string;
-  value?: Unit;
-  showUnitless: boolean;
+  value: CssValueInputValue;
   onChange: (value: Unit) => void;
   onCloseAutoFocus: (event: Event) => void;
 };
@@ -32,20 +48,27 @@ export const useUnitSelect = ({
   property,
   value,
   // edge-case, most css properties accept unitless value 0
-  showUnitless,
+
   onChange,
   onCloseAutoFocus,
 }: UseUnitSelectType): [boolean, JSX.Element | null] => {
   const [isOpen, setIsOpen] = useState(false);
 
+  const unit =
+    value.type === "unit" || value.type === "intermediate"
+      ? value.unit
+      : undefined;
+
   const options = useMemo(() => {
     const options: UnitOption[] = [];
     const { unitGroups } = properties[property as keyof typeof properties];
+
     for (const unitGroup of unitGroups) {
       if (unitGroup === "number") {
         options.push({ id: "number", label: nestedSelectButtonUnitless });
         continue;
       }
+
       const visibleUnits =
         unitGroup === "length" ? visibleLengthUnits : units[unitGroup];
       for (const unit of visibleUnits) {
@@ -53,30 +76,79 @@ export const useUnitSelect = ({
       }
     }
 
-    if (showUnitless && !options.some((o) => o.id === "number")) {
+    // Edge case for 0, which is often can be an unitless value
+    const showUnitless =
+      value.type === "unit" || value.type === "intermediate"
+        ? isValid(property, `${value.value}`)
+        : false;
+
+    if (showUnitless && options.some((o) => o.id === "number") === false) {
       options.push({ id: "number", label: nestedSelectButtonUnitless });
     }
 
-    return options;
-  }, [property, showUnitless]);
+    // Add valid unit like ch or vw even if it's not in the list of visible units
+    // that allows to show selected value when menu is opened
+    if (
+      unit !== undefined &&
+      options.some((option) => option.id === unit) === false
+    ) {
+      options.push({
+        id: unit,
+        label:
+          unit === "number"
+            ? nestedSelectButtonUnitless
+            : unit.toLocaleUpperCase(),
+      });
+    }
 
-  if (
-    options.length === 0 ||
-    // hide unit select when value cannot have units
-    (options.length === 1 && options[0].id === "number")
-  ) {
+    const indexSortValue = (number: number) =>
+      number === -1 ? Number.POSITIVE_INFINITY : number;
+
+    // Use stable sort at least for known dimensions (i.e. percents after length etc)
+    options.sort(
+      (optionA, optionB) =>
+        indexSortValue(unitPreferedSorting.indexOf(optionA.id)) -
+        indexSortValue(unitPreferedSorting.indexOf(optionB.id))
+    );
+
+    // This value can't have units, skip select
+    if (options.length === 0) {
+      return [];
+    }
+
+    const propertyKeywordsSet = new Set(
+      keywordValues[property as keyof typeof keywordValues]
+    );
+
+    // Opinionated set of keywords to show
+    const webstudioKeywords = ["auto", "normal", "none"].filter((keyword) =>
+      propertyKeywordsSet.has(keyword as never)
+    );
+
+    for (const keyword of webstudioKeywords) {
+      options.push({ id: keyword, label: toPascalCase(keyword) });
+    }
+
+    return options;
+  }, [property, value, unit]);
+
+  // hide unit select when value cannot have units
+  if (options.length === 0) {
     return [isOpen, null];
   }
 
+  const unitOrKeyword: string | undefined =
+    unit ?? (value.type === "keyword" ? value.value : undefined);
+
   const select = (
     <UnitSelect
-      value={value}
+      value={unitOrKeyword}
+      label={unit ?? nestedSelectButtonUnitless}
       options={options}
       open={isOpen}
       onCloseAutoFocus={onCloseAutoFocus}
       onOpenChange={setIsOpen}
       onChange={onChange}
-      labelFallback={options[0].label}
     />
   );
 
@@ -86,23 +158,22 @@ export const useUnitSelect = ({
 type UnitSelectProps = {
   options: Array<UnitOption>;
   value?: string | undefined;
+  label?: string | undefined;
   onChange: (value: Unit) => void;
   onOpenChange: (open: boolean) => void;
   onCloseAutoFocus: (event: Event) => void;
   open: boolean;
-  labelFallback: string;
 };
 
 const UnitSelect = ({
   options,
   value,
+  label,
   onChange,
   onOpenChange,
   onCloseAutoFocus,
   open,
-  labelFallback,
 }: UnitSelectProps) => {
-  const matchedOption = options.find((item) => item.id === value);
   return (
     <SelectPrimitive.Root
       value={value}
@@ -113,10 +184,7 @@ const UnitSelect = ({
       <SelectPrimitive.SelectTrigger asChild>
         <NestedSelectButton tabIndex={-1}>
           <SelectPrimitive.Value>
-            {matchedOption?.label ??
-              (value === "number"
-                ? nestedSelectButtonUnitless
-                : value ?? labelFallback)}
+            {value === "number" ? nestedSelectButtonUnitless : label}
           </SelectPrimitive.Value>
         </NestedSelectButton>
       </SelectPrimitive.SelectTrigger>


### PR DESCRIPTION
## Description

closes #1464


- [ ] rename "UnitMenu" to just "Menu" because we are going to bring in some keywords
- [ ] put in the menu the most popular units/keywords to keep it short and usable in this order:
    "-",
    "px",
    "%",
    "em",
    "rem",
    "dvw",
    "dvh",
    "auto",
    "normal",
    "none"
- [ ] add "auto" , "normal" , "none" to properties that support these keywords into the menu
- [ ] use "-" when value is unit-less (detect unitless value from mdn-data)
- [ ] use "-" when keyword value is selected
- [ ] allow any unit to be typed even if its not in a menu, when its typed and user hits enter - we show it as a unit, just not part of the menu 
- [ ] adjust margin for keywords menu to 2px from the bottom edge of the input 

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
