### PR TITLE
Drop baseUrl from tsconfig in packages

### DIFF
--- a/packages/asset-uploader/tsconfig.json
+++ b/packages/asset-uploader/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
-    "baseUrl": ".",
     "outDir": "./lib",
     "rootDir": "./src"
   }

--- a/packages/css-data/tsconfig.json
+++ b/packages/css-data/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
-    "baseUrl": ".",
     "outDir": "./lib"
   }
 }

--- a/packages/css-engine/tsconfig.json
+++ b/packages/css-engine/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
-    "baseUrl": ".",
     "outDir": "./lib",
     "rootDir": "./src"
   }

--- a/packages/css-vars/tsconfig.json
+++ b/packages/css-vars/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
-    "baseUrl": ".",
     "outDir": "./lib",
     "rootDir": "./src"
   }

--- a/packages/dashboard/tsconfig.json
+++ b/packages/dashboard/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
-    "baseUrl": ".",
     "outDir": "./lib",
     "rootDir": "./src"
   }

--- a/packages/design-system/tsconfig.json
+++ b/packages/design-system/tsconfig.json
@@ -5,7 +5,6 @@
     "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "module": "ES2020",
     "target": "ES2020",
-    "baseUrl": ".",
     "rootDir": "./src",
     "outDir": "./lib"
   }

--- a/packages/feature-flags/tsconfig.json
+++ b/packages/feature-flags/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
-    "baseUrl": ".",
     "outDir": "./lib",
     "rootDir": "./src"
   }

--- a/packages/fonts/tsconfig.json
+++ b/packages/fonts/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
-    "baseUrl": ".",
     "rootDir": "./src",
     "outDir": "./lib"
   }

--- a/packages/generate-arg-types/tsconfig.json
+++ b/packages/generate-arg-types/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
-    "baseUrl": ".",
     "rootDir": "./src",
     "outDir": "./lib"
   }

--- a/packages/http-client/tsconfig.json
+++ b/packages/http-client/tsconfig.json
@@ -5,7 +5,6 @@
     "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "module": "ES2020",
     "target": "ES2020",
-    "baseUrl": ".",
     "outDir": "./lib",
     "rootDir": "./src"
   }

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -5,7 +5,6 @@
     "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "module": "es2020",
     "target": "ES2020",
-    "baseUrl": ".",
     "outDir": "./lib",
     "rootDir": "./src"
   }

--- a/packages/image/tsconfig.json
+++ b/packages/image/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
-    "baseUrl": ".",
     "rootDir": "./src",
     "outDir": "./lib"
   }

--- a/packages/prisma-client/tsconfig.json
+++ b/packages/prisma-client/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2019",
-    "baseUrl": ".",
     "rootDir": "./src",
     "outDir": "./lib"
   }

--- a/packages/project/tsconfig.json
+++ b/packages/project/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
-    "baseUrl": ".",
     "outDir": "./lib",
     "rootDir": "./src"
   }

--- a/packages/react-sdk/tsconfig.json
+++ b/packages/react-sdk/tsconfig.json
@@ -9,7 +9,6 @@
     "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "module": "ES2020",
     "target": "ES2020",
-    "baseUrl": ".",
     "outDir": "./lib",
     "rootDir": "./src"
   }

--- a/packages/sdk-size-test/tsconfig.json
+++ b/packages/sdk-size-test/tsconfig.json
@@ -8,8 +8,6 @@
     "../../@types/**/*.d.ts"
   ],
   "compilerOptions": {
-    "paths": { "~/*": ["app/*"] },
-    "baseUrl": ".",
     "rootDir": "./app"
   }
 }

--- a/packages/trpc-interface/tsconfig.json
+++ b/packages/trpc-interface/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
-    "baseUrl": ".",
     "outDir": "./lib",
     "rootDir": "./src"
   }


### PR DESCRIPTION
This should fix auto import from parent folders
which is very annoying right because tries to import from 'src'.

## Code Review

- [ ] hi @andarsit, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
