### PR TITLE
Show initial and html style in style panel

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
@@ -168,11 +168,19 @@ test("compute inherited styles", () => {
         ["2", "div"],
         ["3", "div"],
       ]),
+
       cascadedBreakpointIds,
       selectedBreakpointId
     )
   ).toMatchInlineSnapshot(`
     {
+      "color": {
+        "instanceId": "1",
+        "value": {
+          "type": "keyword",
+          "value": "black",
+        },
+      },
       "fontFamily": {
         "instanceId": "1",
         "value": {

--- a/packages/css-data/bin/mdn-data.ts
+++ b/packages/css-data/bin/mdn-data.ts
@@ -55,8 +55,13 @@ const beautifyKeyword = (property: string, keyword: string) => {
   }
   // builder style panel cannot interpret "normal" and "bold"
   // always expected numeric value
-  if (property === "font-weight" && keyword === "normal") {
-    return "400";
+  if (property === "font-weight") {
+    if (keyword === "normal") {
+      return "400";
+    }
+    if (keyword === "bold") {
+      return "700";
+    }
   }
   return keyword;
 };

--- a/packages/css-data/bin/mdn-data.ts
+++ b/packages/css-data/bin/mdn-data.ts
@@ -49,9 +49,14 @@ const normalizedValues = {
   "text-size-adjust": autoValue,
 } as const;
 
-const beautifyKeyword = (keyword: string) => {
+const beautifyKeyword = (property: string, keyword: string) => {
   if (keyword === "currentcolor") {
     return "currentColor";
+  }
+  // builder style panel cannot interpret "normal" and "bold"
+  // always expected numeric value
+  if (property === "font-weight" && keyword === "normal") {
+    return "400";
   }
   return keyword;
 };
@@ -74,7 +79,7 @@ const parseInitialValue = (
   if (ast.children.first !== ast.children.last) {
     return {
       type: "keyword",
-      value: beautifyKeyword(value),
+      value: beautifyKeyword(property, value),
     };
   }
 
@@ -82,7 +87,7 @@ const parseInitialValue = (
   if (node?.type === "Identifier") {
     return {
       type: "keyword",
-      value: beautifyKeyword(node.name),
+      value: beautifyKeyword(property, node.name),
     };
   }
   if (node?.type === "Number") {
@@ -301,7 +306,7 @@ const keywordValues = (() => {
       filteredProperties[property as keyof typeof filteredProperties].syntax,
       (node) => {
         if (node.type === "Keyword") {
-          keywords.add(beautifyKeyword(node.name));
+          keywords.add(beautifyKeyword(property, node.name));
         }
       }
     );

--- a/packages/css-data/bin/mdn-data.ts
+++ b/packages/css-data/bin/mdn-data.ts
@@ -49,6 +49,13 @@ const normalizedValues = {
   "text-size-adjust": autoValue,
 } as const;
 
+const beautifyKeyword = (keyword: string) => {
+  if (keyword === "currentcolor") {
+    return "currentColor";
+  }
+  return keyword;
+};
+
 const parseInitialValue = (
   property: string,
   value: string,
@@ -67,7 +74,7 @@ const parseInitialValue = (
   if (ast.children.first !== ast.children.last) {
     return {
       type: "keyword",
-      value: value,
+      value: beautifyKeyword(value),
     };
   }
 
@@ -75,7 +82,7 @@ const parseInitialValue = (
   if (node?.type === "Identifier") {
     return {
       type: "keyword",
-      value: node.name,
+      value: beautifyKeyword(node.name),
     };
   }
   if (node?.type === "Number") {
@@ -280,13 +287,6 @@ const writeToFile = (fileName: string, constant: string, data: unknown) => {
 // Non-standard properties are just missing in mdn data
 const nonStandardValues = {
   "background-clip": ["text"],
-};
-
-const beautifyKeyword = (keyword: string) => {
-  if (keyword === "currentcolor") {
-    return "currentColor";
-  }
-  return keyword;
 };
 
 // https://www.w3.org/TR/css-values/#common-keywords

--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -20,6 +20,7 @@
     "@webstudio-is/tsconfig": "workspace:^",
     "camelcase": "^6.3.0",
     "css-tree": "^2.3.1",
+    "html-tags": "^3.2.0",
     "mdn-data": "2.0.30",
     "tsx": "^3.12.6",
     "typescript": "5.0.3",

--- a/packages/css-data/src/__generated__/keyword-values.ts
+++ b/packages/css-data/src/__generated__/keyword-values.ts
@@ -3836,7 +3836,7 @@ export const keywordValues = {
     "unset",
   ],
   fontWeight: [
-    "normal",
+    "400",
     "bold",
     "bolder",
     "lighter",

--- a/packages/css-data/src/__generated__/keyword-values.ts
+++ b/packages/css-data/src/__generated__/keyword-values.ts
@@ -3837,7 +3837,7 @@ export const keywordValues = {
   ],
   fontWeight: [
     "400",
-    "bold",
+    "700",
     "bolder",
     "lighter",
     "initial",

--- a/packages/css-data/src/__generated__/properties.ts
+++ b/packages/css-data/src/__generated__/properties.ts
@@ -330,7 +330,7 @@ export const properties = {
     inherited: false,
     initial: {
       type: "keyword",
-      value: "currentcolor",
+      value: "currentColor",
     },
     popularity: 0.00012849,
     appliesTo: "allElements",
@@ -360,7 +360,7 @@ export const properties = {
     inherited: false,
     initial: {
       type: "keyword",
-      value: "currentcolor",
+      value: "currentColor",
     },
     popularity: 0.00172099,
     appliesTo: "allElements",
@@ -390,7 +390,7 @@ export const properties = {
     inherited: false,
     initial: {
       type: "keyword",
-      value: "currentcolor",
+      value: "currentColor",
     },
     popularity: 0.00170188,
     appliesTo: "allElements",
@@ -420,7 +420,7 @@ export const properties = {
     inherited: false,
     initial: {
       type: "keyword",
-      value: "currentcolor",
+      value: "currentColor",
     },
     popularity: 0.42283564,
     appliesTo: "allElements",
@@ -557,7 +557,7 @@ export const properties = {
     inherited: false,
     initial: {
       type: "keyword",
-      value: "currentcolor",
+      value: "currentColor",
     },
     popularity: 0.00007844,
     appliesTo: "allElements",
@@ -587,7 +587,7 @@ export const properties = {
     inherited: false,
     initial: {
       type: "keyword",
-      value: "currentcolor",
+      value: "currentColor",
     },
     popularity: 0.00196849,
     appliesTo: "allElements",
@@ -617,7 +617,7 @@ export const properties = {
     inherited: false,
     initial: {
       type: "keyword",
-      value: "currentcolor",
+      value: "currentColor",
     },
     popularity: 0.00196928,
     appliesTo: "allElements",
@@ -647,7 +647,7 @@ export const properties = {
     inherited: false,
     initial: {
       type: "keyword",
-      value: "currentcolor",
+      value: "currentColor",
     },
     popularity: 0.30754028,
     appliesTo: "allElements",
@@ -677,7 +677,7 @@ export const properties = {
     inherited: false,
     initial: {
       type: "keyword",
-      value: "currentcolor",
+      value: "currentColor",
     },
     popularity: 0.29336595,
     appliesTo: "allElements",
@@ -740,7 +740,7 @@ export const properties = {
     inherited: false,
     initial: {
       type: "keyword",
-      value: "currentcolor",
+      value: "currentColor",
     },
     popularity: 0.43342948,
     appliesTo: "allElements",
@@ -983,7 +983,7 @@ export const properties = {
     inherited: false,
     initial: {
       type: "keyword",
-      value: "currentcolor",
+      value: "currentColor",
     },
     popularity: 0.01356616,
     appliesTo: "multicolElements",
@@ -3106,7 +3106,7 @@ export const properties = {
     inherited: false,
     initial: {
       type: "keyword",
-      value: "currentcolor",
+      value: "currentColor",
     },
     popularity: 0.05079903,
     appliesTo: "allElements",
@@ -3166,7 +3166,7 @@ export const properties = {
     inherited: false,
     initial: {
       type: "keyword",
-      value: "currentcolor",
+      value: "currentColor",
     },
     popularity: 0,
     appliesTo: "allElements",

--- a/packages/css-data/src/__generated__/properties.ts
+++ b/packages/css-data/src/__generated__/properties.ts
@@ -1425,7 +1425,7 @@ export const properties = {
     inherited: true,
     initial: {
       type: "keyword",
-      value: "normal",
+      value: "400",
     },
     popularity: 0.88598106,
     appliesTo: "allElements",

--- a/packages/css-data/src/html-check.ts
+++ b/packages/css-data/src/html-check.ts
@@ -3,6 +3,6 @@ import type { htmlTags as HtmlTags } from "html-tags";
 
 type ExportedTags = keyof typeof html;
 
-declare var exportedTags: ExportedTags;
+declare let exportedTags: ExportedTags;
 
 exportedTags satisfies HtmlTags;

--- a/packages/css-data/src/html-check.ts
+++ b/packages/css-data/src/html-check.ts
@@ -1,0 +1,8 @@
+import * as html from "./html";
+import type { htmlTags as HtmlTags } from "html-tags";
+
+type ExportedTags = keyof typeof html;
+
+declare var exportedTags: ExportedTags;
+
+exportedTags satisfies HtmlTags;

--- a/packages/css-data/src/html.ts
+++ b/packages/css-data/src/html.ts
@@ -1,0 +1,545 @@
+// all styles are taken from following source
+// https://searchfox.org/mozilla-central/source/layout/style/res/html.css
+// https://chromium.googlesource.com/chromium/blink/+/master/Source/core/css/html.css
+// https://trac.webkit.org/browser/trunk/Source/WebCore/css/html.css
+
+import type { htmlTags as HtmlTags } from "html-tags";
+import type { StyleProperty, StyleValue } from "./schema";
+
+type StyleDecl = {
+  property: StyleProperty;
+  value: StyleValue;
+};
+type Styles = StyleDecl[];
+
+export type Html = {
+  [tag in HtmlTags]?: Styles;
+};
+
+const displayBlock: Styles[number] = {
+  property: "display",
+  value: { type: "keyword", value: "block" },
+};
+
+const mt1em: Styles[number] = {
+  property: "marginTop",
+  value: { type: "unit", value: 1, unit: "em" },
+};
+
+const mb1em: Styles[number] = {
+  property: "marginBottom",
+  value: { type: "unit", value: 1, unit: "em" },
+};
+
+const ml40px: Styles[number] = {
+  property: "marginLeft",
+  value: { type: "unit", value: 40, unit: "px" },
+};
+
+const mr40px: Styles[number] = {
+  property: "marginRight",
+  value: { type: "unit", value: 40, unit: "px" },
+};
+
+const pl40px: Styles[number] = {
+  property: "paddingLeft",
+  value: { type: "unit", value: 40, unit: "px" },
+};
+
+const fontWeightBold: Styles[number] = {
+  property: "fontWeight",
+  // in browsers defined as bold
+  // though builder accepts only numeric values
+  value: { type: "keyword", value: "700" },
+};
+
+const fontStyleItalic: Styles[number] = {
+  property: "fontStyle",
+  value: { type: "keyword", value: "italic" },
+};
+
+const pt1px: Styles[number] = {
+  property: "paddingTop",
+  value: { type: "unit", value: 1, unit: "px" },
+};
+
+const pr1px: Styles[number] = {
+  property: "paddingRight",
+  value: { type: "unit", value: 1, unit: "px" },
+};
+
+const pb1px: Styles[number] = {
+  property: "paddingBottom",
+  value: { type: "unit", value: 1, unit: "px" },
+};
+
+const pl1px: Styles[number] = {
+  property: "paddingLeft",
+  value: { type: "unit", value: 1, unit: "px" },
+};
+
+/* blocks */
+
+export const article: Styles = [displayBlock];
+export {
+  article as aside,
+  article as details,
+  article as div,
+  article as dt,
+  article as figcaption,
+  article as footer,
+  article as form,
+  article as header,
+  article as hgroup,
+  article as html,
+  article as main,
+  article as nav,
+  article as section,
+  article as summary,
+};
+
+export const body: Styles = [
+  displayBlock,
+  {
+    property: "marginTop",
+    value: { type: "unit", value: 8, unit: "px" },
+  },
+  {
+    property: "marginRight",
+    value: { type: "unit", value: 8, unit: "px" },
+  },
+  {
+    property: "marginBottom",
+    value: { type: "unit", value: 8, unit: "px" },
+  },
+  {
+    property: "marginLeft",
+    value: { type: "unit", value: 8, unit: "px" },
+  },
+];
+
+export const p: Styles = [displayBlock, mt1em, mb1em];
+export { p as dl };
+
+export const dd: Styles = [displayBlock, ml40px];
+
+export const blockquote: Styles = [displayBlock, mt1em, mb1em, ml40px, mr40px];
+export { blockquote as figure };
+
+export const address: Styles = [displayBlock, fontStyleItalic];
+
+// h1 font-size, margin-top and margin-bottom depend on outer tags
+// so better define statically in preset styles
+export const h1: Styles = [
+  displayBlock,
+  fontWeightBold,
+  {
+    property: "fontSize",
+    value: { type: "unit", value: 2, unit: "em" },
+  },
+  {
+    property: "marginTop",
+    value: { type: "unit", value: 0.67, unit: "em" },
+  },
+  {
+    property: "marginBottom",
+    value: { type: "unit", value: 0.67, unit: "em" },
+  },
+];
+
+export const h2: Styles = [
+  displayBlock,
+  fontWeightBold,
+  {
+    property: "fontSize",
+    value: { type: "unit", value: 1.5, unit: "em" },
+  },
+  {
+    property: "marginTop",
+    value: { type: "unit", value: 0.83, unit: "em" },
+  },
+  {
+    property: "marginBottom",
+    value: { type: "unit", value: 0.83, unit: "em" },
+  },
+];
+
+export const h3: Styles = [
+  displayBlock,
+  fontWeightBold,
+  {
+    property: "fontSize",
+    value: { type: "unit", value: 1.17, unit: "em" },
+  },
+  {
+    property: "marginTop",
+    value: { type: "unit", value: 1, unit: "em" },
+  },
+  {
+    property: "marginBottom",
+    value: { type: "unit", value: 1, unit: "em" },
+  },
+];
+
+export const h4: Styles = [
+  displayBlock,
+  fontWeightBold,
+  {
+    property: "marginTop",
+    value: { type: "unit", value: 1.33, unit: "em" },
+  },
+  {
+    property: "marginBottom",
+    value: { type: "unit", value: 1.33, unit: "em" },
+  },
+];
+
+export const h5: Styles = [
+  displayBlock,
+  fontWeightBold,
+  {
+    property: "fontSize",
+    value: { type: "unit", value: 0.83, unit: "em" },
+  },
+  {
+    property: "marginTop",
+    value: { type: "unit", value: 1.67, unit: "em" },
+  },
+  {
+    property: "marginBottom",
+    value: { type: "unit", value: 1.67, unit: "em" },
+  },
+];
+
+export const h6: Styles = [
+  displayBlock,
+  fontWeightBold,
+  {
+    property: "fontSize",
+    value: { type: "unit", value: 0.67, unit: "em" },
+  },
+  {
+    property: "marginTop",
+    value: { type: "unit", value: 2.33, unit: "em" },
+  },
+  {
+    property: "marginBottom",
+    value: { type: "unit", value: 2.33, unit: "em" },
+  },
+];
+
+export const pre: Styles = [
+  displayBlock,
+  {
+    property: "whiteSpace",
+    value: { type: "keyword", value: "pre" },
+  },
+  mt1em,
+  mb1em,
+];
+
+/* tables */
+
+export const table: Styles = [
+  {
+    property: "display",
+    value: { type: "keyword", value: "table" },
+  },
+  {
+    property: "borderSpacing",
+    value: { type: "unit", value: 2, unit: "px" },
+  },
+  {
+    property: "borderCollapse",
+    value: { type: "keyword", value: "separate" },
+  },
+  {
+    property: "boxSizing",
+    value: { type: "keyword", value: "border-box" },
+  },
+  {
+    property: "borderSpacing",
+    value: { type: "unit", value: 0, unit: "number" },
+  },
+];
+
+export const caption: Styles = [
+  {
+    property: "display",
+    value: { type: "keyword", value: "table" },
+  },
+  {
+    property: "textAlign",
+    value: { type: "keyword", value: "center" },
+  },
+];
+
+export const tr: Styles = [
+  {
+    property: "display",
+    value: { type: "keyword", value: "table-row" },
+  },
+  {
+    property: "verticalAlign",
+    value: { type: "keyword", value: "inherit" },
+  },
+];
+
+export const col: Styles = [
+  {
+    property: "display",
+    value: { type: "keyword", value: "table-column" },
+  },
+];
+
+export const colgroup: Styles = [
+  {
+    property: "display",
+    value: { type: "keyword", value: "table-column-group" },
+  },
+];
+
+export const tbody: Styles = [
+  {
+    property: "display",
+    value: { type: "keyword", value: "table-row-group" },
+  },
+  {
+    property: "verticalAlign",
+    value: { type: "keyword", value: "middle" },
+  },
+];
+
+export const thead: Styles = [
+  {
+    property: "display",
+    value: { type: "keyword", value: "table-header-group" },
+  },
+  {
+    property: "verticalAlign",
+    value: { type: "keyword", value: "middle" },
+  },
+];
+
+export const tfoot: Styles = [
+  {
+    property: "display",
+    value: { type: "keyword", value: "table-footer-group" },
+  },
+  {
+    property: "verticalAlign",
+    value: { type: "keyword", value: "middle" },
+  },
+];
+
+export const td: Styles = [
+  {
+    property: "display",
+    value: { type: "keyword", value: "table-cell" },
+  },
+  {
+    property: "verticalAlign",
+    value: { type: "keyword", value: "inherit" },
+  },
+  {
+    property: "textAlign",
+    value: { type: "keyword", value: "unset" },
+  },
+  pt1px,
+  pr1px,
+  pb1px,
+  pl1px,
+];
+
+export const th: Styles = [
+  {
+    property: "display",
+    value: { type: "keyword", value: "table-cell" },
+  },
+  {
+    property: "verticalAlign",
+    value: { type: "keyword", value: "inherit" },
+  },
+  fontWeightBold,
+  pt1px,
+  pr1px,
+  pb1px,
+  pl1px,
+];
+
+/* inlines */
+
+export const b: Styles = [
+  // in firefox defined as bolder
+  fontWeightBold,
+];
+export { b as strong };
+
+export const i: Styles = [fontStyleItalic];
+export { i as cite, i as em, i as var, i as dfn };
+
+export const code: Styles = [
+  {
+    property: "fontFamily",
+    // in firefox defined as -moz-fixed
+    value: { type: "fontFamily", value: ["monospace"] },
+  },
+];
+export { code as kbd, code as samp };
+
+export const mark: Styles = [
+  {
+    property: "backgroundColor",
+    // in firefox defined as Mark
+    value: { type: "keyword", value: "yellow" },
+  },
+  {
+    property: "color",
+    // in firefox defined as MarkText
+    value: { type: "keyword", value: "blac" },
+  },
+];
+
+export const u: Styles = [
+  {
+    property: "textDecorationStyle",
+    value: { type: "keyword", value: "underline" },
+  },
+];
+export { u as ins };
+
+export const s: Styles = [
+  {
+    property: "textDecorationStyle",
+    value: { type: "keyword", value: "line-through" },
+  },
+];
+export { s as del };
+
+export const sub: Styles = [
+  {
+    property: "verticalAlign",
+    value: { type: "keyword", value: "sub" },
+  },
+  {
+    property: "fontSize",
+    value: { type: "keyword", value: "smaller" },
+  },
+];
+
+export const sup: Styles = [
+  {
+    property: "verticalAlign",
+    value: { type: "keyword", value: "super" },
+  },
+  {
+    property: "fontSize",
+    value: { type: "keyword", value: "smaller" },
+  },
+];
+
+/* lists */
+
+// nested lists have no top/bottom margins
+// so better redefine statically in preset
+export const ul: Styles = [
+  displayBlock,
+  {
+    property: "listStyleType",
+    value: { type: "keyword", value: "disc" },
+  },
+  mt1em,
+  mb1em,
+  pl40px,
+];
+
+export const ol: Styles = [
+  displayBlock,
+  {
+    property: "listStyleType",
+    value: { type: "keyword", value: "decimal" },
+  },
+  mt1em,
+  mb1em,
+  pl40px,
+];
+
+export const li: Styles = [
+  {
+    property: "display",
+    value: { type: "keyword", value: "list-item" },
+  },
+  {
+    property: "textAlign",
+    value: { type: "keyword", value: "match-parent" },
+  },
+];
+
+/* leafs */
+
+export const hr: Styles = [
+  {
+    property: "color",
+    value: { type: "keyword", value: "gray" },
+  },
+
+  {
+    property: "borderTopWidth",
+    value: { type: "unit", value: 1, unit: "px" },
+  },
+  {
+    property: "borderRightWidth",
+    value: { type: "unit", value: 1, unit: "px" },
+  },
+  {
+    property: "borderBottomWidth",
+    value: { type: "unit", value: 1, unit: "px" },
+  },
+  {
+    property: "borderLeftWidth",
+    value: { type: "unit", value: 1, unit: "px" },
+  },
+
+  {
+    property: "borderTopStyle",
+    value: { type: "keyword", value: "inset" },
+  },
+  {
+    property: "borderRightStyle",
+    value: { type: "keyword", value: "inset" },
+  },
+  {
+    property: "borderBottomStyle",
+    value: { type: "keyword", value: "inset" },
+  },
+  {
+    property: "borderLeftStyle",
+    value: { type: "keyword", value: "inset" },
+  },
+
+  {
+    property: "marginTop",
+    value: { type: "unit", value: 0.5, unit: "em" },
+  },
+  {
+    property: "marginBottom",
+    value: { type: "unit", value: 0.5, unit: "em" },
+  },
+  {
+    property: "marginLeft",
+    value: { type: "keyword", value: "auto" },
+  },
+  {
+    property: "marginRight",
+    value: { type: "keyword", value: "auto" },
+  },
+
+  // firefox only
+  {
+    property: "overflow",
+    value: { type: "keyword", value: "hidden" },
+  },
+
+  /* This is not really per spec but all browsers define it */
+  displayBlock,
+];

--- a/packages/css-data/src/html.ts
+++ b/packages/css-data/src/html.ts
@@ -396,7 +396,7 @@ export const mark: Styles = [
   {
     property: "color",
     // in firefox defined as MarkText
-    value: { type: "keyword", value: "blac" },
+    value: { type: "keyword", value: "black" },
   },
 ];
 

--- a/packages/css-data/src/index.ts
+++ b/packages/css-data/src/index.ts
@@ -1,3 +1,7 @@
+import type { Html } from "./html";
+import * as exportedHtml from "./html";
+export const html: Html = exportedHtml;
+
 export * from "./__generated__/keyword-values";
 export * from "./__generated__/properties";
 export * from "./__generated__/units";

--- a/packages/react-sdk/src/components/body.ws.tsx
+++ b/packages/react-sdk/src/components/body.ws.tsx
@@ -28,6 +28,12 @@ const presetStyle = {
       property: "lineHeight",
       value: { type: "unit", unit: "number", value: 1.5 },
     },
+    // temporary set root color
+    // until builder start to fallback "inherit" to black
+    {
+      property: "color",
+      value: { type: "keyword", value: "black" },
+    },
   ],
 } satisfies PresetStyle<typeof defaultTag>;
 

--- a/packages/react-sdk/src/css/normalize.ts
+++ b/packages/react-sdk/src/css/normalize.ts
@@ -163,7 +163,7 @@ Add the correct font weight in Edge and Safari.
 export const b = [
   {
     property: "fontWeight",
-    value: { type: "keyword", value: "bolder" },
+    value: { type: "keyword", value: "700" },
   },
   boxSizing,
   ...borders,

--- a/packages/react-sdk/src/css/presets.ts
+++ b/packages/react-sdk/src/css/presets.ts
@@ -2,23 +2,6 @@ import type { EmbedTemplateStyleDecl } from "../embed-template";
 
 export const borders: EmbedTemplateStyleDecl[] = [
   {
-    property: "borderTopColor",
-    value: { type: "keyword", value: "currentColor" },
-  },
-  {
-    property: "borderRightColor",
-    value: { type: "keyword", value: "currentColor" },
-  },
-  {
-    property: "borderBottomColor",
-    value: { type: "keyword", value: "currentColor" },
-  },
-  {
-    property: "borderLeftColor",
-    value: { type: "keyword", value: "currentColor" },
-  },
-
-  {
     property: "borderTopWidth",
     value: { type: "unit", value: 1, unit: "px" },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,6 +470,9 @@ importers:
       css-tree:
         specifier: ^2.3.1
         version: 2.3.1
+      html-tags:
+        specifier: ^3.2.0
+        version: 3.2.0
       mdn-data:
         specifier: 2.0.30
         version: 2.0.30
@@ -12555,7 +12558,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
+    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
     requiresBuild: true
     dependencies:
       bindings: 1.5.0


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1067

We need to move away from getComputedStyle for not local styles in style panel.

Here added default html style from browser sources. Now we can render it and properties initial styles instead of computed styles.

Also fixed in properties data generation currentcolor -> currentColor and removed same from border presets.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @rpominov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
