### PR TITLE
Fix: can't delete a form element from canvas

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -279,7 +279,7 @@ export const Builder = ({
     authToken,
     authPermit,
   });
-  useSharedShortcuts();
+  useSharedShortcuts({ isOnCanvas: false });
   useSetIsPreviewMode(authPermit === "view");
   const [isPreviewMode] = useIsPreviewMode();
   usePublishShortcuts(publish);

--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -279,7 +279,7 @@ export const Builder = ({
     authToken,
     authPermit,
   });
-  useSharedShortcuts({ isOnCanvas: false });
+  useSharedShortcuts({ source: "builder" });
   useSetIsPreviewMode(authPermit === "view");
   const [isPreviewMode] = useIsPreviewMode();
   usePublishShortcuts(publish);

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -138,7 +138,7 @@ export const Canvas = ({
 
   // e.g. toggling preview is still needed in both modes
   useCanvasShortcuts();
-  useSharedShortcuts({ isOnCanvas: true });
+  useSharedShortcuts({ source: "canvas" });
   const selectedPage = useStore(selectedPageStore);
 
   useEffect(() => {

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -138,7 +138,7 @@ export const Canvas = ({
 
   // e.g. toggling preview is still needed in both modes
   useCanvasShortcuts();
-  useSharedShortcuts();
+  useSharedShortcuts({ isOnCanvas: true });
   const selectedPage = useStore(selectedPageStore);
 
   useEffect(() => {

--- a/apps/builder/app/shared/shortcuts/shortcuts.ts
+++ b/apps/builder/app/shared/shortcuts/shortcuts.ts
@@ -17,7 +17,7 @@ export const options: Options = {
   enableOnFormTags: true,
 };
 
-export const useSharedShortcuts = () => {
+export const useSharedShortcuts = ({ isOnCanvas }: { isOnCanvas: boolean }) => {
   useHotkeys(
     // safari use cmd+z to reopen closed tabs so fallback to ctrl
     "meta+z, ctrl+z",
@@ -37,8 +37,11 @@ export const useSharedShortcuts = () => {
   useHotkeys(
     "backspace, delete",
     deleteSelectedInstance,
-    // prevent instance deletion while deleting text
-    { enableOnFormTags: true, enableOnContentEditable: false },
+    {
+      // prevent instance deletion while deleting text in a control at style panel etc.
+      enableOnFormTags: isOnCanvas,
+      enableOnContentEditable: false,
+    },
     []
   );
 

--- a/apps/builder/app/shared/shortcuts/shortcuts.ts
+++ b/apps/builder/app/shared/shortcuts/shortcuts.ts
@@ -38,7 +38,7 @@ export const useSharedShortcuts = () => {
     "backspace, delete",
     deleteSelectedInstance,
     // prevent instance deletion while deleting text
-    { enableOnFormTags: false, enableOnContentEditable: false },
+    { enableOnFormTags: true, enableOnContentEditable: false },
     []
   );
 

--- a/apps/builder/app/shared/shortcuts/shortcuts.ts
+++ b/apps/builder/app/shared/shortcuts/shortcuts.ts
@@ -17,7 +17,11 @@ export const options: Options = {
   enableOnFormTags: true,
 };
 
-export const useSharedShortcuts = ({ isOnCanvas }: { isOnCanvas: boolean }) => {
+export const useSharedShortcuts = ({
+  source,
+}: {
+  source: "canvas" | "builder";
+}) => {
   useHotkeys(
     // safari use cmd+z to reopen closed tabs so fallback to ctrl
     "meta+z, ctrl+z",
@@ -38,8 +42,10 @@ export const useSharedShortcuts = ({ isOnCanvas }: { isOnCanvas: boolean }) => {
     "backspace, delete",
     deleteSelectedInstance,
     {
-      // prevent instance deletion while deleting text in a control at style panel etc.
-      enableOnFormTags: isOnCanvas,
+      // When in builder, we don't want to delete instances,
+      // when user edits text in a control on style panel etc.
+      // But when a form control on canvas has focus, we want the shortcut to work.
+      enableOnFormTags: source === "canvas",
       enableOnContentEditable: false,
     },
     []


### PR DESCRIPTION
## Description

Fixes bug:

- select an Input instance by clicking on it on canvas
- press backspace to delete it
- nothing happens

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @TrySound, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
