### PR TITLE
Insert styles from embed template

### DIFF
--- a/apps/builder/app/shared/tree-utils.ts
+++ b/apps/builder/app/shared/tree-utils.ts
@@ -51,10 +51,21 @@ export const areInstanceSelectorsEqual = (
   return left.join(",") === right.join(",");
 };
 
-export const createComponentInstance = (component: Instance["component"]) => {
+export const createComponentInstance = (
+  component: Instance["component"],
+  defaultBreakpointId: Breakpoint["id"]
+) => {
   const componentMeta = getComponentMeta(component);
-  const { children, instances, props } = generateDataFromEmbedTemplate(
-    componentMeta?.children ?? []
+  const {
+    children,
+    instances,
+    props,
+    styleSourceSelections,
+    styleSources,
+    styles,
+  } = generateDataFromEmbedTemplate(
+    componentMeta?.children ?? [],
+    defaultBreakpointId
   );
   // put first to be interpreted as root
   instances.unshift({
@@ -63,7 +74,7 @@ export const createComponentInstance = (component: Instance["component"]) => {
     component,
     children,
   });
-  return { instances, props };
+  return { instances, props, styleSourceSelections, styleSources, styles };
 };
 
 const isInstanceDroppable = (instance: Instance) => {

--- a/packages/react-sdk/src/embed-template.test.ts
+++ b/packages/react-sdk/src/embed-template.test.ts
@@ -3,19 +3,24 @@ import { generateDataFromEmbedTemplate } from "./embed-template";
 
 const expectString = expect.any(String) as unknown as string;
 
+const defaultBreakpointId = "base";
+
 test("generate data for embedding from instances and text", () => {
   expect(
-    generateDataFromEmbedTemplate([
-      { type: "text", value: "hello" },
-      {
-        type: "instance",
-        component: "Box1",
-        children: [
-          { type: "instance", component: "Box2", children: [] },
-          { type: "text", value: "world" },
-        ],
-      },
-    ])
+    generateDataFromEmbedTemplate(
+      [
+        { type: "text", value: "hello" },
+        {
+          type: "instance",
+          component: "Box1",
+          children: [
+            { type: "instance", component: "Box2", children: [] },
+            { type: "text", value: "world" },
+          ],
+        },
+      ],
+      defaultBreakpointId
+    )
   ).toEqual({
     children: [
       { type: "text", value: "hello" },
@@ -39,29 +44,35 @@ test("generate data for embedding from instances and text", () => {
       },
     ],
     props: [],
+    styleSourceSelections: [],
+    styleSources: [],
+    styles: [],
   });
 });
 
 test("generate data for embedding from props", () => {
   expect(
-    generateDataFromEmbedTemplate([
-      {
-        type: "instance",
-        component: "Box1",
-        props: [
-          { type: "string", name: "data-prop1", value: "value1" },
-          { type: "string", name: "data-prop2", value: "value2" },
-        ],
-        children: [
-          {
-            type: "instance",
-            component: "Box2",
-            props: [{ type: "string", name: "data-prop3", value: "value3" }],
-            children: [],
-          },
-        ],
-      },
-    ])
+    generateDataFromEmbedTemplate(
+      [
+        {
+          type: "instance",
+          component: "Box1",
+          props: [
+            { type: "string", name: "data-prop1", value: "value1" },
+            { type: "string", name: "data-prop2", value: "value2" },
+          ],
+          children: [
+            {
+              type: "instance",
+              component: "Box2",
+              props: [{ type: "string", name: "data-prop3", value: "value3" }],
+              children: [],
+            },
+          ],
+        },
+      ],
+      defaultBreakpointId
+    )
   ).toEqual({
     children: [{ type: "id", value: expectString }],
     instances: [
@@ -99,6 +110,100 @@ test("generate data for embedding from props", () => {
         instanceId: expectString,
         name: "data-prop3",
         value: "value3",
+      },
+    ],
+    styleSourceSelections: [],
+    styleSources: [],
+    styles: [],
+  });
+});
+
+test("generate data for embedding from styles", () => {
+  expect(
+    generateDataFromEmbedTemplate(
+      [
+        {
+          type: "instance",
+          component: "Box1",
+          styles: [
+            { property: "width", value: { type: "keyword", value: "auto" } },
+            { property: "height", value: { type: "keyword", value: "auto" } },
+          ],
+          children: [
+            {
+              type: "instance",
+              component: "Box2",
+              styles: [
+                {
+                  property: "color",
+                  value: { type: "keyword", value: "black" },
+                },
+              ],
+              children: [],
+            },
+          ],
+        },
+      ],
+      defaultBreakpointId
+    )
+  ).toEqual({
+    children: [{ type: "id", value: expectString }],
+    instances: [
+      {
+        type: "instance",
+        id: expectString,
+        component: "Box1",
+        children: [{ type: "id", value: expectString }],
+      },
+      {
+        type: "instance",
+        id: expectString,
+        component: "Box2",
+        children: [],
+      },
+    ],
+    props: [],
+    styleSourceSelections: [
+      {
+        instanceId: expectString,
+        values: [expectString],
+      },
+      {
+        instanceId: expectString,
+        values: [expectString],
+      },
+    ],
+    styleSources: [
+      {
+        type: "local",
+        id: expectString,
+      },
+      {
+        type: "local",
+        id: expectString,
+      },
+    ],
+    styles: [
+      {
+        breakpointId: "base",
+        styleSourceId: expectString,
+        state: undefined,
+        property: "width",
+        value: { type: "keyword", value: "auto" },
+      },
+      {
+        breakpointId: "base",
+        styleSourceId: expectString,
+        state: undefined,
+        property: "height",
+        value: { type: "keyword", value: "auto" },
+      },
+      {
+        breakpointId: "base",
+        styleSourceId: expectString,
+        state: undefined,
+        property: "color",
+        value: { type: "keyword", value: "black" },
       },
     ],
   });


### PR DESCRIPTION
Now embed templates can define simplified version of our styles which is useful for radix components and as AI output.

```
styles: [
  {
    property: 'backgroundColor',
    value: { type: 'keyword', value: 'red' }
  }
]
```

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
