### PR TITLE
Allow to reset drop target

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/use-sortable.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/use-sortable.tsx
@@ -44,12 +44,16 @@ export const useSortable = <Item extends { id: string }>({
     },
     onDropTargetChange(dropTarget) {
       setDropTarget(dropTarget);
-      setPlacementIndicator(
-        computeIndicatorPlacement({
-          placement: dropTarget.placement,
-          element: dropTarget.element,
-        })
-      );
+      if (dropTarget === undefined) {
+        setPlacementIndicator(undefined);
+      } else {
+        setPlacementIndicator(
+          computeIndicatorPlacement({
+            placement: dropTarget.placement,
+            element: dropTarget.element,
+          })
+        );
+      }
     },
   });
 

--- a/apps/builder/app/builder/features/style-panel/style-source/use-sortable.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/use-sortable.tsx
@@ -54,13 +54,17 @@ export const useSortable = <Item extends { id: string }>({
     },
     onDropTargetChange(dropTarget) {
       setDropTarget(dropTarget);
-      setPlacementIndicator(
-        computeIndicatorPlacement({
-          ...sharedDropOptions,
-          placement: dropTarget.placement,
-          element: dropTarget.element,
-        })
-      );
+      if (dropTarget === undefined) {
+        setPlacementIndicator(undefined);
+      } else {
+        setPlacementIndicator(
+          computeIndicatorPlacement({
+            ...sharedDropOptions,
+            placement: dropTarget.placement,
+            element: dropTarget.element,
+          })
+        );
+      }
     },
   });
 
@@ -89,6 +93,7 @@ export const useSortable = <Item extends { id: string }>({
       useDropHandlers.handleEnd({ isCanceled });
       setDragItemId(undefined);
       setDropTarget(undefined);
+      setPlacementIndicator(undefined);
 
       if (isCanceled || dropTarget === undefined || dragItemId === undefined) {
         return;

--- a/apps/builder/app/builder/features/workspace/canvas-tools/canvas-tools.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/canvas-tools.tsx
@@ -44,11 +44,13 @@ export const CanvasTools = ({ publish }: CanvasToolsProps) => {
 
   if (
     dragAndDropState.isDragging &&
-    dragAndDropState.dropTarget !== undefined &&
     dragAndDropState.placementIndicator !== undefined
   ) {
     const { dropTarget, placementIndicator } = dragAndDropState;
-    const dropTargetInstance = instances.get(dropTarget.itemSelector[0]);
+    const dropTargetInstance =
+      dropTarget === undefined
+        ? undefined
+        : instances.get(dropTarget.itemSelector[0]);
     return dropTargetInstance ? (
       <div className={containerStyle({ overflow: "hidden" })}>
         <Outline rect={placementIndicator.parentRect}>

--- a/apps/builder/app/canvas/shared/use-drag-drop.ts
+++ b/apps/builder/app/canvas/shared/use-drag-drop.ts
@@ -10,7 +10,7 @@ import {
   computeIndicatorPlacement,
 } from "@webstudio-is/design-system";
 import { getComponentMeta } from "@webstudio-is/react-sdk";
-import { instancesStore, selectedPageStore } from "~/shared/nano-states";
+import { instancesStore } from "~/shared/nano-states";
 import { textEditingInstanceSelectorStore } from "~/shared/nano-states";
 import { publish, useSubscribe } from "~/shared/pubsub";
 import {
@@ -33,8 +33,8 @@ declare module "~/shared/pubsub" {
     dragEnd: DragEndPayload;
     dragMove: DragMovePayload;
     dragStart: DragStartPayload;
-    dropTargetChange: ItemDropTarget;
-    placementIndicatorChange: Placement;
+    dropTargetChange: undefined | ItemDropTarget;
+    placementIndicatorChange: undefined | Placement;
   }
 }
 
@@ -102,20 +102,6 @@ const sharedDropOptions = {
   },
 };
 
-const getDefaultDropTarget = () => {
-  const selectedPage = selectedPageStore.get();
-  if (selectedPage === undefined) {
-    throw new Error("Could not find selected page");
-  }
-  const rootInstanceSelector = [selectedPage.rootInstanceId];
-  const element = getElementByInstanceSelector(rootInstanceSelector);
-  // Should never happen
-  if (element === undefined) {
-    throw new Error("Could not find root instance element");
-  }
-  return { element, data: rootInstanceSelector };
-};
-
 export const useDragAndDrop = () => {
   const state = useRef({ ...initialState });
 
@@ -137,13 +123,10 @@ export const useDragAndDrop = () => {
       const { dragPayload } = state.current;
 
       if (dropTarget === undefined || dragPayload === undefined) {
-        return getDefaultDropTarget();
+        return;
       }
 
       const dropInstanceSelector = dropTarget.data;
-      if (dropInstanceSelector.length === 1) {
-        return dropTarget;
-      }
 
       const newDropInstanceSelector = dropInstanceSelector.slice();
       if (dropTarget.area !== "center") {
@@ -164,7 +147,7 @@ export const useDragAndDrop = () => {
         newDropInstanceSelector
       );
       if (droppableInstanceSelector === undefined) {
-        return getDefaultDropTarget();
+        return;
       }
 
       if (
@@ -178,7 +161,7 @@ export const useDragAndDrop = () => {
 
       const element = getElementByInstanceSelector(droppableInstanceSelector);
       if (element === undefined) {
-        return getDefaultDropTarget();
+        return;
       }
 
       return { data: droppableInstanceSelector, element };
@@ -187,11 +170,14 @@ export const useDragAndDrop = () => {
     onDropTargetChange(dropTarget) {
       publish({
         type: "dropTargetChange",
-        payload: {
-          placement: dropTarget.placement,
-          indexWithinChildren: dropTarget.indexWithinChildren,
-          itemSelector: dropTarget.data,
-        },
+        payload:
+          dropTarget === undefined
+            ? undefined
+            : {
+                placement: dropTarget.placement,
+                indexWithinChildren: dropTarget.indexWithinChildren,
+                itemSelector: dropTarget.data,
+              },
       });
     },
   });
@@ -282,6 +268,13 @@ export const useDragAndDrop = () => {
 
   useSubscribe("dropTargetChange", (dropTarget) => {
     state.current.dropTarget = dropTarget;
+    if (dropTarget === undefined) {
+      publish({
+        type: "placementIndicatorChange",
+        payload: undefined,
+      });
+      return;
+    }
     const element = getElementByInstanceSelector(dropTarget.itemSelector);
     if (element === undefined) {
       return;

--- a/packages/design-system/src/components/primitives/dnd/canvas.stories.tsx
+++ b/packages/design-system/src/components/primitives/dnd/canvas.stories.tsx
@@ -199,13 +199,6 @@ export const Canvas = () => {
 
   const rootRef = useRef<HTMLElement | null>(null);
 
-  const getDefaultDropTarget = () => {
-    if (rootRef.current === null) {
-      throw new Error("Unexpected empty rootRef during drag");
-    }
-    return { data: ROOT_ID, element: rootRef.current };
-  };
-
   const dropHandlers = useDrop<string>({
     edgeDistanceThreshold: 10,
 
@@ -216,14 +209,10 @@ export const Canvas = () => {
     swapDropTarget(dropTarget) {
       const rootElement = rootRef.current;
       if (dropTarget === undefined || rootElement === null) {
-        return getDefaultDropTarget();
+        return;
       }
 
       const { data: id, area } = dropTarget;
-
-      if (id === ROOT_ID) {
-        return dropTarget;
-      }
 
       const path = findItemPath(data, id) ?? [];
 
@@ -240,13 +229,13 @@ export const Canvas = () => {
       const newItem = path.find((item) => item.acceptsChildren);
 
       if (newItem === undefined) {
-        return getDefaultDropTarget();
+        return;
       }
 
       const element = idToElement(rootElement, newItem.id);
 
       if (element === undefined) {
-        return getDefaultDropTarget();
+        return;
       }
 
       return { data: newItem.id, element };
@@ -254,12 +243,16 @@ export const Canvas = () => {
 
     onDropTargetChange(dropTarget) {
       setCurrentDropTarget(dropTarget);
-      setPlacementIndicator(
-        computeIndicatorPlacement({
-          placement: dropTarget.placement,
-          element: dropTarget.element,
-        })
-      );
+      if (dropTarget === undefined) {
+        setPlacementIndicator(undefined);
+      } else {
+        setPlacementIndicator(
+          computeIndicatorPlacement({
+            placement: dropTarget.placement,
+            element: dropTarget.element,
+          })
+        );
+      }
     },
   });
 

--- a/packages/design-system/src/components/primitives/dnd/sortable-list.stories.tsx
+++ b/packages/design-system/src/components/primitives/dnd/sortable-list.stories.tsx
@@ -94,12 +94,16 @@ export const SortableList = ({
     },
     onDropTargetChange(dropTarget) {
       setDropTarget(dropTarget);
-      setPlacementIndicator(
-        computeIndicatorPlacement({
-          placement: dropTarget.placement,
-          element: dropTarget.element,
-        })
-      );
+      if (dropTarget === undefined) {
+        setPlacementIndicator(undefined);
+      } else {
+        setPlacementIndicator(
+          computeIndicatorPlacement({
+            placement: dropTarget.placement,
+            element: dropTarget.element,
+          })
+        );
+      }
     },
   });
 


### PR DESCRIPTION
Here I allows to return undefined in swapDropTarget. This enables us to reset drop target when move cursor out of droppable elements.

For example before Body was always selected as drop target. Though this behavior prevent us from restricting parents for cases like Tabs>Tab and List>ListItem.

Also got rid from emulatePointerAlwaysInRootBounds which was used to workaround that fallback to Body. So now no longer necessary too.



https://user-images.githubusercontent.com/5635476/235142653-48b95ebe-9714-44c4-90d9-b69b930f2379.mov


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
