### PR TITLE
Restrict allowed parents with config in meta

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
@@ -158,10 +158,12 @@ export const useDraggable = ({
     const dropTarget = findClosestDroppableTarget(
       instancesStore.get(),
       // fallback to root as drop target
-      selectedInstanceSelectorStore.get() ?? [selectedPage.rootInstanceId]
+      selectedInstanceSelectorStore.get() ?? [selectedPage.rootInstanceId],
+      [component]
     );
-
-    insertNewComponentInstance(component, dropTarget);
+    if (dropTarget) {
+      insertNewComponentInstance(component, dropTarget);
+    }
   };
 
   return {

--- a/apps/builder/app/builder/shared/tree/index.tsx
+++ b/apps/builder/app/builder/shared/tree/index.tsx
@@ -56,7 +56,7 @@ export const InstanceTree = (
       )?.component;
     }
     return dragComponent;
-  }, [dragPayload]);
+  }, [dragPayload, instances]);
 
   const canLeaveParent = useCallback(
     (instanceId: Instance["id"]) => {

--- a/apps/builder/app/builder/shared/tree/index.tsx
+++ b/apps/builder/app/builder/shared/tree/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useStore } from "@nanostores/react";
 import {
   Tree,
@@ -9,10 +9,11 @@ import {
 } from "@webstudio-is/design-system";
 import type { Instance } from "@webstudio-is/project-build";
 import {
+  canAcceptComponent,
   getComponentMeta,
   type WsComponentMeta,
 } from "@webstudio-is/react-sdk";
-import { instancesStore } from "~/shared/nano-states";
+import { instancesStore, useDragAndDropState } from "~/shared/nano-states";
 
 const instanceRelatedProps = {
   renderItem(props: TreeItemRenderProps<Instance>) {
@@ -40,6 +41,22 @@ export const InstanceTree = (
   >
 ) => {
   const instances = useStore(instancesStore);
+  const [state] = useDragAndDropState();
+
+  const dragPayload = state.dragPayload;
+
+  const dragComponent = useMemo(() => {
+    let dragComponent: undefined | string;
+    if (dragPayload?.type === "insert") {
+      dragComponent = dragPayload.dragComponent;
+    }
+    if (dragPayload?.type === "reparent") {
+      dragComponent = instances.get(
+        dragPayload.dragInstanceSelector[0]
+      )?.component;
+    }
+    return dragComponent;
+  }, [dragPayload]);
 
   const canLeaveParent = useCallback(
     (instanceId: Instance["id"]) => {
@@ -56,13 +73,12 @@ export const InstanceTree = (
   const canAcceptChild = useCallback(
     (instanceId: Instance["id"]) => {
       const instance = instances.get(instanceId);
-      if (instance === undefined) {
+      if (instance === undefined || dragComponent === undefined) {
         return false;
       }
-      const meta = getComponentMeta(instance.component);
-      return meta?.type === "container";
+      return canAcceptComponent(instance.component, dragComponent);
     },
-    [instances]
+    [instances, dragComponent]
   );
 
   const getItemChildren = useCallback(

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -147,10 +147,15 @@ export const onPaste = (clipboardData: string) => {
   const instanceSelector = selectedInstanceSelectorStore.get() ?? [
     selectedPage.rootInstanceId,
   ];
+  const dragComponent = data.instances[0].component;
   const dropTarget = findClosestDroppableTarget(
     instancesStore.get(),
-    instanceSelector
+    instanceSelector,
+    [dragComponent]
   );
+  if (dropTarget === undefined) {
+    return;
+  }
   store.createTransaction(
     [
       breakpointsStore,

--- a/apps/builder/app/shared/copy-paste/plugin-markdown.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-markdown.ts
@@ -211,10 +211,22 @@ export const onPaste = (clipboardData: string) => {
   const instanceSelector = selectedInstanceSelectorStore.get() ?? [
     selectedPage.rootInstanceId,
   ];
+  const instances = instancesStore.get();
+  const dragComponents = [];
+  for (const instanceId of data.rootIds) {
+    const component = instances.get(instanceId)?.component;
+    if (component !== undefined) {
+      dragComponents.push(component);
+    }
+  }
   const dropTarget = findClosestDroppableTarget(
     instancesStore.get(),
-    instanceSelector
+    instanceSelector,
+    dragComponents
   );
+  if (dropTarget === undefined) {
+    return;
+  }
   store.createTransaction([instancesStore, propsStore], (instances, props) => {
     insertInstancesMutable(instances, data.instances, data.rootIds, dropTarget);
     for (const prop of data.props) {

--- a/apps/builder/app/shared/tree-utils.test.ts
+++ b/apps/builder/app/shared/tree-utils.test.ts
@@ -170,33 +170,51 @@ test("find closest droppable target", () => {
     createInstancePair("box3", "Box", [
       { type: "id", value: "box31" },
       { type: "id", value: "box32" },
-      { type: "id", value: "box33" },
+      { type: "id", value: "list33" },
     ]),
     createInstancePair("box31", "Box", []),
     createInstancePair("box32", "Box", []),
-    createInstancePair("box33", "Box", []),
+    createInstancePair("list33", "List", []),
   ]);
+
   expect(
-    findClosestDroppableTarget(instances, [
-      "bold",
-      "paragraph21",
-      "box2",
-      "root",
-    ])
+    findClosestDroppableTarget(
+      instances,
+      ["bold", "paragraph21", "box2", "root"],
+      ["Box"]
+    )
   ).toEqual({
     parentSelector: ["box2", "root"],
     position: 1,
   });
-  expect(findClosestDroppableTarget(instances, ["box3", "root"])).toEqual({
+  expect(
+    findClosestDroppableTarget(instances, ["box3", "root"], ["Box"])
+  ).toEqual({
     parentSelector: ["box3", "root"],
     position: "end",
   });
-  expect(findClosestDroppableTarget(instances, ["root"])).toEqual({
+  expect(findClosestDroppableTarget(instances, ["root"], ["Box"])).toEqual({
     parentSelector: ["root"],
     position: "end",
   });
-  expect(findClosestDroppableTarget(instances, ["box4", "root"])).toEqual({
-    parentSelector: ["root"],
+  expect(
+    findClosestDroppableTarget(instances, ["box4", "root"], ["Box"])
+  ).toEqual(undefined);
+  expect(
+    findClosestDroppableTarget(
+      instances,
+      ["box32", "box3", "root"],
+      ["Box", "ListItem"]
+    )
+  ).toEqual(undefined);
+  expect(
+    findClosestDroppableTarget(
+      instances,
+      ["list33", "box3", "root"],
+      ["Box", "ListItem"]
+    )
+  ).toEqual({
+    parentSelector: ["list33", "box3", "root"],
     position: "end",
   });
 });

--- a/packages/react-sdk/src/components/component-meta.ts
+++ b/packages/react-sdk/src/components/component-meta.ts
@@ -46,6 +46,7 @@ const WsComponentMeta = z.object({
     "rich-text",
     "rich-text-child",
   ]),
+  allowedParentComponents: z.optional(z.array(z.string())),
   label: z.string(),
   Icon: z.function(),
   presetStyle: z.optional(z.any()),

--- a/packages/react-sdk/src/components/component-meta.ts
+++ b/packages/react-sdk/src/components/component-meta.ts
@@ -46,7 +46,7 @@ const WsComponentMeta = z.object({
     "rich-text",
     "rich-text-child",
   ]),
-  allowedParentComponents: z.optional(z.array(z.string())),
+  acceptedParents: z.optional(z.array(z.string())),
   label: z.string(),
   Icon: z.function(),
   presetStyle: z.optional(z.any()),

--- a/packages/react-sdk/src/components/index.ts
+++ b/packages/react-sdk/src/components/index.ts
@@ -230,7 +230,7 @@ export const canAcceptComponent = (
     return false;
   }
   return (
-    childMeta.allowedParentComponents === undefined ||
-    childMeta.allowedParentComponents.includes(parentComponent)
+    childMeta.acceptedParents === undefined ||
+    childMeta.acceptedParents.includes(parentComponent)
   );
 };

--- a/packages/react-sdk/src/components/index.ts
+++ b/packages/react-sdk/src/components/index.ts
@@ -219,3 +219,18 @@ const computeInitialProps = (
   // order of initialProps must be preserved
   return [...initialProps, ...requiredProps];
 };
+
+export const canAcceptComponent = (
+  parentComponent: string,
+  childComponent: string
+) => {
+  const parentMeta = getComponentMeta(parentComponent);
+  const childMeta = getComponentMeta(childComponent);
+  if (parentMeta?.type !== "container" || childMeta === undefined) {
+    return false;
+  }
+  return (
+    childMeta.allowedParentComponents === undefined ||
+    childMeta.allowedParentComponents.includes(parentComponent)
+  );
+};

--- a/packages/react-sdk/src/components/list-item.ws.tsx
+++ b/packages/react-sdk/src/components/list-item.ws.tsx
@@ -15,7 +15,7 @@ const presetStyle = {
 export const meta: WsComponentMeta = {
   category: "typography",
   type: "rich-text",
-  allowedParentComponents: ["List"],
+  acceptedParents: ["List"],
   label: "List Item",
   Icon: ListItemIcon,
   children: [{ type: "text", value: "List Item you can edit" }],

--- a/packages/react-sdk/src/components/list-item.ws.tsx
+++ b/packages/react-sdk/src/components/list-item.ws.tsx
@@ -15,6 +15,7 @@ const presetStyle = {
 export const meta: WsComponentMeta = {
   category: "typography",
   type: "rich-text",
+  allowedParentComponents: ["List"],
   label: "List Item",
   Icon: ListItemIcon,
   children: [{ type: "text", value: "List Item you can edit" }],


### PR DESCRIPTION
Added `allowedParentComponents: string[]` option to meta which prevents dropping, inserting or pasting components into wrong parents. For example ListItem now can be placed only inside of List component.

This will unlock better experience with compound radix components.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
