### PR TITLE
Some fixes in props panel

### DIFF
--- a/apps/builder/app/builder/features/props-panel/controls/text.tsx
+++ b/apps/builder/app/builder/features/props-panel/controls/text.tsx
@@ -67,6 +67,11 @@ const AsTextarea = ({
           onChange={(event) => localValue.set(event.target.value)}
           onBlur={localValue.save}
           rows={rows ?? 1}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && event.metaKey) {
+              localValue.save();
+            }
+          }}
         />
       </Flex>
     </VerticalLayout>

--- a/apps/builder/app/builder/features/props-panel/props-panel.tsx
+++ b/apps/builder/app/builder/features/props-panel/props-panel.tsx
@@ -207,16 +207,19 @@ export const PropsPanel = (props: PropsPanelProps) => {
 
       <Separator />
 
-      <Row
-        css={{
-          paddingTop: theme.spacing[5],
-          paddingBottom: theme.spacing[5],
-        }}
-      >
-        {logic.initialProps.map((item) => renderProperty(props, item))}
-      </Row>
-
-      <Separator />
+      {logic.initialProps.length > 0 && (
+        <>
+          <Row
+            css={{
+              paddingTop: theme.spacing[5],
+              paddingBottom: theme.spacing[5],
+            }}
+          >
+            {logic.initialProps.map((item) => renderProperty(props, item))}
+          </Row>
+          <Separator />
+        </>
+      )}
 
       <CollapsibleSectionWithAddButton
         label="Properties"

--- a/apps/builder/app/builder/features/props-panel/use-props-logic.ts
+++ b/apps/builder/app/builder/features/props-panel/use-props-logic.ts
@@ -198,13 +198,6 @@ export const usePropsLogic = ({
     return { prop: saved, propName: name, meta: known };
   });
 
-  // can happen only if there is a bug
-  if (unprocessedSaved.size > 0) {
-    throw new Error(
-      `Expected all saved props to be processed, but there are ${unprocessedSaved.size} left`
-    );
-  }
-
   const handleAdd = (propName: string) => {
     const propMeta = unprocessedKnown.get(propName);
     if (propMeta === undefined) {


### PR DESCRIPTION
## Description

1. Removed a sanity check that started to give false positives (wasn't needed really in the first place)
2. Cmd+enter in textarea control now saves the value
3. Fixed layout of props panel in the case when there're no initial props

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
