### PR TITLE
Fixed label's cursor & couple TS fixes

### DIFF
--- a/apps/builder/app/builder/features/props-panel/controls/combined.tsx
+++ b/apps/builder/app/builder/features/props-panel/controls/combined.tsx
@@ -159,9 +159,17 @@ export const renderControl = ({
         />
       );
     }
+
+    if (prop.type === "string[]") {
+      throw new Error(
+        `Cannot render a fallback control for prop "${rest.propName}" with type string[], because we don't know the available options for a multiselect control`
+      );
+    }
+
+    prop satisfies never;
   }
 
   throw new Error(
-    `Unsupported combination of prop and control: name=${rest.propName}, type=${prop?.type}, control=${meta.control}`
+    `Unsupported control type "${meta.control}" for prop "${rest.propName}"`
   );
 };

--- a/apps/builder/app/builder/features/props-panel/use-props-logic.ts
+++ b/apps/builder/app/builder/features/props-panel/use-props-logic.ts
@@ -68,12 +68,14 @@ const getDefaultMetaForType = (type: Prop["type"]): PropMeta => {
       return { type: "boolean", control: "boolean", required: false };
     case "asset":
       return { type: "string", control: "file", required: false };
+    case "page":
+      return { type: "string", control: "url", required: false };
     case "string[]":
       throw new Error(
         "A prop with type string[] must have a meta, we can't provide a default one because we need a list of options"
       );
     default:
-      throw new Error(`Usupported data type: ${type}`);
+      throw new Error(`Usupported data type: ${type satisfies never}`);
   }
 };
 

--- a/packages/design-system/src/components/label.tsx
+++ b/packages/design-system/src/components/label.tsx
@@ -17,6 +17,7 @@ const StyledLabel = styled(RadixLabel, {
   WebkitAppearance: "none",
   WebkitFontSmoothing: "antialiased",
   display: "block",
+  cursor: "default",
 
   boxSizing: "border-box",
   flexShrink: 0,


### PR DESCRIPTION
## Description

1. Fixed label's cursor: https://discord.com/channels/955905230107738152/1102616619219439676
2. Improved TS to make sure all prop types are always handled in props panel

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)


## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
