### PR TITLE
Rename loadByProject to loadAssetsByProject

### DIFF
--- a/apps/builder/app/routes/builder.$projectId.tsx
+++ b/apps/builder/app/routes/builder.$projectId.tsx
@@ -4,7 +4,7 @@ import type { LoaderArgs } from "@remix-run/node";
 import { loadBuildByProjectId } from "@webstudio-is/project-build/index.server";
 import { db } from "@webstudio-is/project/index.server";
 import { authorizeProject } from "@webstudio-is/trpc-interface/index.server";
-import { loadByProject } from "@webstudio-is/asset-uploader/index.server";
+import { loadAssetsByProject } from "@webstudio-is/asset-uploader/index.server";
 import { createContext } from "~/shared/context.server";
 import { ErrorMessage } from "~/shared/error";
 import { sentryException } from "~/shared/sentry";
@@ -44,7 +44,7 @@ export const loader = async ({
   }
 
   const devBuild = await loadBuildByProjectId(project.id, "dev");
-  const assets = await loadByProject(project.id, context);
+  const assets = await loadAssetsByProject(project.id, context);
 
   const end = Date.now();
 

--- a/apps/builder/app/routes/rest.assets.tsx
+++ b/apps/builder/app/routes/rest.assets.tsx
@@ -1,7 +1,7 @@
 import type { ActionArgs, LoaderArgs } from "@remix-run/node";
 import { MaxAssets, type Asset } from "@webstudio-is/asset-uploader";
 import {
-  loadByProject,
+  loadAssetsByProject,
   createUploadName,
 } from "@webstudio-is/asset-uploader/index.server";
 import { sentryException } from "~/shared/sentry";
@@ -16,7 +16,7 @@ export const loader = async ({
     throw new Error("Project id undefined");
   }
   const context = await createContext(request);
-  return await loadByProject(params.projectId, context);
+  return await loadAssetsByProject(params.projectId, context);
 };
 
 export const action = async (props: ActionArgs) => {

--- a/apps/builder/app/shared/db/canvas.server.ts
+++ b/apps/builder/app/shared/db/canvas.server.ts
@@ -2,7 +2,7 @@ import type { Project } from "@webstudio-is/project";
 import type { Data } from "@webstudio-is/react-sdk";
 import { loadBuildByProjectId } from "@webstudio-is/project-build/index.server";
 import { db as projectDb } from "@webstudio-is/project/index.server";
-import { loadByProject } from "@webstudio-is/asset-uploader/index.server";
+import { loadAssetsByProject } from "@webstudio-is/asset-uploader/index.server";
 import type { AppContext } from "@webstudio-is/trpc-interface/index.server";
 import { findPageByIdOrPath } from "@webstudio-is/project-build";
 
@@ -78,7 +78,7 @@ export const loadCanvasData = async (
     throw new Error(`Page ${props.pageIdOrPath} not found`);
   }
 
-  const assets = await loadByProject(props.project.id, context);
+  const assets = await loadAssetsByProject(props.project.id, context);
 
   return {
     build,

--- a/packages/asset-uploader/src/db/load.ts
+++ b/packages/asset-uploader/src/db/load.ts
@@ -6,7 +6,7 @@ import {
 import type { Asset } from "../schema";
 import { formatAsset } from "../utils/format-asset";
 
-export const loadByProject = async (
+export const loadAssetsByProject = async (
   projectId: Project["id"],
   context: AppContext
 ): Promise<Asset[]> => {
@@ -21,32 +21,6 @@ export const loadByProject = async (
 
   const assets = await prisma.asset.findMany({
     where: { projectId, status: "UPLOADED" },
-    orderBy: {
-      createdAt: "desc",
-    },
-  });
-
-  return assets.map(formatAsset);
-};
-
-export const loadByIds = async (
-  props: {
-    ids: Array<Asset["id"]>;
-    projectId: Project["id"];
-  },
-  context: AppContext
-): Promise<Asset[]> => {
-  const canRead = await authorizeProject.hasProjectPermit(
-    { projectId: props.projectId, permit: "view" },
-    context
-  );
-
-  if (canRead === false) {
-    throw new Error("You don't have access to this project assets");
-  }
-
-  const assets = await prisma.asset.findMany({
-    where: { projectId: props.projectId, status: "UPLOADED" },
     orderBy: {
       createdAt: "desc",
     },

--- a/packages/asset-uploader/src/patch.ts
+++ b/packages/asset-uploader/src/patch.ts
@@ -6,7 +6,7 @@ import {
 } from "@webstudio-is/trpc-interface/index.server";
 import { type Asset, Assets } from "./schema";
 import { deleteAssets } from "./delete";
-import { loadByProject } from "./db/load";
+import { loadAssetsByProject } from "./db/load";
 import type { AssetClient } from "./client";
 
 export const patchAssets = async (
@@ -23,7 +23,7 @@ export const patchAssets = async (
     throw new Error("You don't have edit access to this project");
   }
 
-  const assetsList = await loadByProject(projectId, context);
+  const assetsList = await loadAssetsByProject(projectId, context);
   const assets = new Map<Asset["id"], Asset>();
   for (const asset of assetsList) {
     assets.set(asset.id, asset);


### PR DESCRIPTION
Found the name super confusing when started to work on builder. Here renamed and dropped unused loadByIds utility.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
