### PR TITLE
Fix floating point math issue in scrub

### DIFF
--- a/packages/design-system/src/components/primitives/numeric-gesture-control.ts
+++ b/packages/design-system/src/components/primitives/numeric-gesture-control.ts
@@ -57,7 +57,8 @@ const getValueDefault = (
     maxValue = Number.MAX_SAFE_INTEGER,
   }: NumericScrubOptions
 ) => {
-  const value = state.value + movement;
+  // toFixed is needed to fix `1.3 - 1 = 0.30000000000000004`
+  const value = Number((state.value + movement).toFixed(2));
   if (value < minValue) {
     return minValue;
   }


### PR DESCRIPTION
## Description

Fix of the bug reported in https://discord.com/channels/955905230107738152/1102991527254446182:

1. Set value of any input that you can scrub to 1.3
2. Scrub to decrease it by 1 to 0.3
3. The value gets set 0.30000000000000004

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
 - [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)


## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
