### PR TITLE
core: Upgrading to node 18

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.test.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.test.ts
@@ -15,11 +15,6 @@ import type {
   StyleValue,
 } from "@webstudio-is/css-data";
 
-// @todo remove at node18
-globalThis.structuredClone = (value: unknown) => {
-  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
-};
-
 describe("setLayerProperty", () => {
   test("should work", () => {
     const styleInfo: StyleInfo = {};

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typescript": "5.0.3"
   },
   "engines": {
-    "node": "16",
+    "node": "18",
     "pnpm": "8.0",
     "yarn": "This project is configured to use pnpm"
   },


### PR DESCRIPTION
## Description

1. What is this PR about #1191 

Upgrades the builder node requirement to `node v18`, removed structuredClone as per the issue description. And the tests seem to work without any failure.

Let me know, if there ay things that needed to be taken care of during this upgrade.

## Code Review

- [x] hi @kof, I need you to do
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally
- [x] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
