### PR TITLE
Changes to enable forms submission in saas

### DIFF
--- a/apps/builder/app/routes/rest.project.$projectId.tsx
+++ b/apps/builder/app/routes/rest.project.$projectId.tsx
@@ -9,7 +9,9 @@ import { getUserById, type User } from "~/shared/db/user.server";
 export const loader = async ({
   params,
   request,
-}: LoaderArgs): Promise<Data & { user?: { email: User["email"] } }> => {
+}: LoaderArgs): Promise<
+  Data & { user: { email: User["email"] } | undefined }
+> => {
   try {
     const projectId = params.projectId ?? undefined;
 

--- a/apps/builder/app/routes/rest.project.$projectId.tsx
+++ b/apps/builder/app/routes/rest.project.$projectId.tsx
@@ -1,13 +1,15 @@
 import { json, type LoaderArgs } from "@remix-run/node";
 import type { Data } from "@webstudio-is/react-sdk";
+import { db as projectDb } from "@webstudio-is/project/index.server";
 import { sentryException } from "~/shared/sentry";
 import { loadProductionCanvasData } from "~/shared/db";
 import { createContext } from "~/shared/context.server";
+import { getUserById, type User } from "~/shared/db/user.server";
 
 export const loader = async ({
   params,
   request,
-}: LoaderArgs): Promise<Data> => {
+}: LoaderArgs): Promise<Data & { user?: { email: User["email"] } }> => {
   try {
     const projectId = params.projectId ?? undefined;
 
@@ -22,7 +24,20 @@ export const loader = async ({
       context
     );
 
-    return pagesCanvasData;
+    const project = await projectDb.project.loadByParams(
+      { projectId },
+      context
+    );
+
+    const user =
+      project === null || project.userId === null
+        ? undefined
+        : await getUserById(project.userId);
+
+    return {
+      ...pagesCanvasData,
+      user: user ? { email: user.email } : undefined,
+    };
   } catch (error) {
     // If a Response is thrown, we're rethrowing it for Remix to handle.
     // https://remix.run/docs/en/v1/api/conventions#throwing-responses-in-loaders

--- a/packages/form-handlers-mailchannels-test/src/index.ts
+++ b/packages/form-handlers-mailchannels-test/src/index.ts
@@ -18,14 +18,14 @@ export default {
     formData.append("time", new Date().toLocaleString("en-US"));
 
     const result = await mailchannelsHandler({
-      formInto: {
+      formInfo: {
         formData,
         projectDomain: "example.com",
         projectId: "test-project",
         pageUrl: "https://example.com/some-page",
         email: to,
+        senderDomain: "webstudio.is",
       },
-      senderDomain: "webstudio.is",
     });
 
     if (result.success) {

--- a/packages/form-handlers-mailchannels-test/src/index.ts
+++ b/packages/form-handlers-mailchannels-test/src/index.ts
@@ -13,13 +13,19 @@ export default {
     }
 
     const formData = new FormData();
+    formData.append("ws--form-id", "test-form");
     formData.append("name", "Bob");
     formData.append("time", new Date().toLocaleString("en-US"));
 
     const result = await mailchannelsHandler({
-      senderEmail: "test@webstudio.is",
-      recipientEmail: to,
-      formData,
+      formInto: {
+        formData,
+        projectDomain: "example.com",
+        projectId: "test-project",
+        pageUrl: "https://example.com/some-page",
+        email: to,
+      },
+      senderDomain: "webstudio.is",
     });
 
     if (result.success) {

--- a/packages/form-handlers-mailchannels-test/src/index.ts
+++ b/packages/form-handlers-mailchannels-test/src/index.ts
@@ -20,11 +20,10 @@ export default {
     const result = await mailchannelsHandler({
       formInfo: {
         formData,
-        projectDomain: "example.com",
         projectId: "test-project",
         pageUrl: "https://example.com/some-page",
-        email: to,
-        senderDomain: "webstudio.is",
+        toEmail: to,
+        fromEmail: "test@webstudio.is",
       },
     });
 

--- a/packages/form-handlers/src/index.ts
+++ b/packages/form-handlers/src/index.ts
@@ -1,3 +1,8 @@
-export { formToEmail, type EmailInfo, type FormInfo } from "./shared";
+export {
+  formToEmail,
+  formIdFieldName,
+  type EmailInfo,
+  type FormInfo,
+} from "./shared";
 export { mailchannelsHandler } from "./mailchanels";
 export { n8nHandler } from "./n8n";

--- a/packages/form-handlers/src/index.ts
+++ b/packages/form-handlers/src/index.ts
@@ -1,3 +1,3 @@
-export { formDataToEmailContent } from "./shared";
+export { formToEmail, type EmailInfo, type FormInfo } from "./shared";
 export { mailchannelsHandler } from "./mailchanels";
 export { n8nHandler } from "./n8n";

--- a/packages/form-handlers/src/mailchanels.ts
+++ b/packages/form-handlers/src/mailchanels.ts
@@ -66,13 +66,11 @@ const sendEmail = async (payload: SendEmailPayload): Promise<Result> => {
 };
 
 export const mailchannelsHandler = async ({
-  formInto,
-  senderDomain,
+  formInfo,
 }: {
-  formInto: FormInfo;
-  senderDomain?: string;
+  formInfo: FormInfo;
 }) => {
-  const email = formToEmail(formInto, senderDomain);
+  const email = formToEmail(formInfo);
 
   return sendEmail({
     personalizations: [{ to: [{ email: email.to }] }],

--- a/packages/form-handlers/src/mailchanels.ts
+++ b/packages/form-handlers/src/mailchanels.ts
@@ -65,14 +65,18 @@ const sendEmail = async (
 
 export const mailchannelsHandler = async ({
   formData,
+  intro,
+  subject = "New form submission",
   recipientEmail,
   senderEmail,
 }: {
   formData: FormData;
+  intro?: string;
+  subject?: string;
   recipientEmail: string;
   senderEmail: string;
 }) => {
-  const { plainText, html, subject } = formDataToEmailContent({ formData });
+  const { plainText, html } = formDataToEmailContent({ formData, intro });
 
   return sendEmail({
     personalizations: [{ to: [{ email: recipientEmail }] }],

--- a/packages/form-handlers/src/n8n.ts
+++ b/packages/form-handlers/src/n8n.ts
@@ -2,19 +2,29 @@ import { formDataToEmailContent, getErrors, getResponseBody } from "./shared";
 
 export const n8nHandler = async ({
   formData,
+  intro,
+  subject = "New form submission",
+  unsubscribeUrl,
   recipientEmail,
   senderEmail,
   hookUrl,
   authentication,
 }: {
   formData: FormData;
+  intro?: string;
+  subject?: string;
+  unsubscribeUrl?: string;
   recipientEmail: string;
   senderEmail: string;
   hookUrl: string;
   // @todo: add support for other authentication types
   authentication?: { type: "basic"; username: string; password: string };
 }) => {
-  const { plainText, html, subject } = formDataToEmailContent({ formData });
+  const { plainText, html } = formDataToEmailContent({
+    formData,
+    intro,
+    unsubscribeUrl,
+  });
 
   const headers: HeadersInit = { "Content-Type": "application/json" };
 
@@ -51,6 +61,8 @@ export const n8nHandler = async ({
   if (
     response.status >= 200 &&
     response.status < 300 &&
+    // It's difficult to control status code at n8n side.
+    // Data is easier to control, so we use data to determine success.
     json?.success === true
   ) {
     return { success: true };

--- a/packages/form-handlers/src/n8n.ts
+++ b/packages/form-handlers/src/n8n.ts
@@ -35,9 +35,9 @@ export const n8nHandler = async ({
   const { username, password, urlWithoutAuth } = getAuth(hookUrl);
 
   if (username !== "" && password !== "") {
-    headers["Authorization"] = `Basic ${Buffer.from(
-      [username, password].join(":")
-    ).toString("base64")}`;
+    // using btoa() instead of Buffer.from().toString("base64")
+    // because Buffer is not available in Cloudflare workers
+    headers["Authorization"] = `Basic ${btoa([username, password].join(":"))}`;
   }
 
   const formId = getFormId(formInfo.formData);

--- a/packages/form-handlers/src/shared.ts
+++ b/packages/form-handlers/src/shared.ts
@@ -1,9 +1,11 @@
+// Input data common for all handlers
 export type FormInfo = {
   projectId: string;
   projectDomain: string;
   pageUrl: string;
   formData: FormData;
   email: string;
+  senderDomain?: string;
 };
 
 export type EmailInfo = {
@@ -28,10 +30,13 @@ export const getFormId = (formData: FormData) => {
   }
 };
 
-export const formToEmail = (
-  { formData, pageUrl, projectDomain, email }: FormInfo,
-  senderDomain = "webstudio.mail"
-): EmailInfo => {
+export const formToEmail = ({
+  formData,
+  pageUrl,
+  projectDomain,
+  email,
+  senderDomain = "webstudio.mail",
+}: FormInfo): EmailInfo => {
   let html = `<p>There has been a new submission of your form at <a href="${pageUrl}">${pageUrl}</a>:</p>`;
   let txt = `There has been a new submission of your form at ${pageUrl}:\n\n`;
 

--- a/packages/form-handlers/src/shared.ts
+++ b/packages/form-handlers/src/shared.ts
@@ -32,3 +32,37 @@ export const formDataToEmailContent = ({
     html: `<!DOCTYPE html><html><body><p>${prefix}</p><table><tbody>${htmlRows}</tbody></table></body></html>`,
   };
 };
+
+export const getResponseBody = async (
+  response: Response
+): Promise<{ text: string; json?: Record<string, unknown> }> => {
+  const text = await response.text();
+  try {
+    const json = JSON.parse(text);
+    return typeof json === "object" && json !== null
+      ? { json, text }
+      : { text };
+  } catch {
+    return { text: text === "" ? response.statusText : text };
+  }
+};
+
+export const getErrors = (
+  json: Record<string, unknown> | undefined
+): string[] | undefined => {
+  if (json === undefined) {
+    return;
+  }
+  if (typeof json.error === "string") {
+    return [json.error];
+  }
+  if (typeof json.message === "string") {
+    return [json.message];
+  }
+  if (
+    Array.isArray(json.errors) &&
+    json.errors.every((error) => typeof error === "string")
+  ) {
+    return json.errors;
+  }
+};

--- a/packages/form-handlers/src/shared.ts
+++ b/packages/form-handlers/src/shared.ts
@@ -1,3 +1,5 @@
+export const formIdFieldName = "ws--form-id";
+
 // Input data common for all handlers
 export type FormInfo = {
   projectId: string;
@@ -19,11 +21,11 @@ export type EmailInfo = {
 export type Result = { success: true } | { success: false; errors: string[] };
 
 export const getFormEntries = (formData: FormData) =>
-  [...formData.entries()].filter(([key]) => key.startsWith("ws--") === false);
+  [...formData.entries()].filter(([key]) => key !== formIdFieldName);
 
 export const getFormId = (formData: FormData) => {
   for (const [key, value] of formData.entries()) {
-    if (key === "ws--form-id") {
+    if (key === formIdFieldName) {
       return value;
     }
   }

--- a/packages/form-handlers/src/shared.ts
+++ b/packages/form-handlers/src/shared.ts
@@ -1,11 +1,10 @@
 // Input data common for all handlers
 export type FormInfo = {
   projectId: string;
-  projectDomain: string;
   pageUrl: string;
   formData: FormData;
-  email: string;
-  senderDomain?: string;
+  toEmail: string;
+  fromEmail: string;
 };
 
 export type EmailInfo = {
@@ -30,12 +29,19 @@ export const getFormId = (formData: FormData) => {
   }
 };
 
+const getDomain = (url: string) => {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return;
+  }
+};
+
 export const formToEmail = ({
   formData,
   pageUrl,
-  projectDomain,
-  email,
-  senderDomain = "webstudio.mail",
+  toEmail,
+  fromEmail,
 }: FormInfo): EmailInfo => {
   let html = `<p>There has been a new submission of your form at <a href="${pageUrl}">${pageUrl}</a>:</p>`;
   let txt = `There has been a new submission of your form at ${pageUrl}:\n\n`;
@@ -50,9 +56,9 @@ export const formToEmail = ({
   html += "</tbody></table>";
 
   return {
-    from: `${projectDomain}@${senderDomain}`,
-    to: email,
-    subject: `New form submission from ${projectDomain}`,
+    from: fromEmail,
+    to: toEmail,
+    subject: `New form submission from ${getDomain(pageUrl) ?? pageUrl}`,
     txt,
     html,
   };

--- a/packages/form-handlers/src/shared.ts
+++ b/packages/form-handlers/src/shared.ts
@@ -1,17 +1,13 @@
-export type EmailContent = {
-  plainText: string;
-  html: string;
-  subject: string;
-};
+export type EmailContent = { plainText: string; html: string };
 
 export const formDataToEmailContent = ({
   formData,
-  prefix = "There has been a new submission of your form:",
-  subject = "New form submission",
+  intro = "There has been a new submission of your form:",
+  unsubscribeUrl,
 }: {
   formData: FormData;
-  prefix?: string;
-  subject?: string;
+  intro?: string;
+  unsubscribeUrl?: string;
 }): EmailContent => {
   const entries = [...formData.entries()];
 
@@ -26,10 +22,17 @@ export const formDataToEmailContent = ({
     .map(([key, value]) => `${key}: ${value}`)
     .join("\n");
 
+  const unsubscribePlainText = unsubscribeUrl
+    ? `\n\nTo unsubscribe, click here: ${unsubscribeUrl}`
+    : "";
+
+  const unsubscribeHtml = unsubscribeUrl
+    ? `<p>To unsubscribe, click <a href="${unsubscribeUrl}">here</a>.</p>`
+    : "";
+
   return {
-    subject,
-    plainText: `${prefix}\n\n${plainTextRows}`,
-    html: `<!DOCTYPE html><html><body><p>${prefix}</p><table><tbody>${htmlRows}</tbody></table></body></html>`,
+    plainText: `${intro}\n\n${plainTextRows}${unsubscribePlainText}`,
+    html: `<!DOCTYPE html><html><body><p>${intro}</p><table><tbody>${htmlRows}</tbody></table>${unsubscribeHtml}</body></html>`,
   };
 };
 

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -52,6 +52,7 @@
     "@webstudio-is/image": "workspace:^",
     "@webstudio-is/prisma-client": "workspace:^",
     "@webstudio-is/project-build": "workspace:^",
+    "@webstudio-is/form-handlers": "workspace:^",
     "detect-font": "^0.1.5",
     "html-tags": "^3.2.0",
     "nanoevents": "^7.0.1",

--- a/packages/react-sdk/src/app/custom-components/__generated__/form.props.ts
+++ b/packages/react-sdk/src/app/custom-components/__generated__/form.props.ts
@@ -5,10 +5,8 @@ export const props: Record<string, PropMeta> = {
   style: { required: false, control: "text", type: "string" },
   title: { required: false, control: "text", type: "string" },
   acceptCharset: { required: false, control: "text", type: "string" },
-  action: { required: false, control: "text", type: "string" },
   autoComplete: { required: false, control: "text", type: "string" },
   encType: { required: false, control: "text", type: "string" },
-  method: { required: false, control: "text", type: "string" },
   name: { required: false, control: "text", type: "string" },
   noValidate: { required: false, control: "boolean", type: "boolean" },
   target: { required: false, control: "text", type: "string" },
@@ -452,6 +450,7 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "radio",
     type: "string",
+    defaultValue: "initial",
     options: ["initial", "success", "error"],
   },
 };

--- a/packages/react-sdk/src/app/custom-components/form.tsx
+++ b/packages/react-sdk/src/app/custom-components/form.tsx
@@ -97,7 +97,7 @@ export const Form = forwardRef<
 
   return (
     <fetcher.Form {...props} method="post" data-state={state} ref={ref}>
-      <input type="hidden" name="ws-form-id" value={instanceId} />
+      <input type="hidden" name="ws--form-id" value={instanceId} />
       {state === "success"
         ? onlySuccessMessage(children)
         : state === "error"

--- a/packages/react-sdk/src/app/custom-components/form.tsx
+++ b/packages/react-sdk/src/app/custom-components/form.tsx
@@ -7,6 +7,7 @@ import {
   type ElementRef,
   type ComponentProps,
 } from "react";
+import { getInstanceIdFromComponentProps } from "../../props";
 
 export const defaultTag = "form";
 
@@ -92,8 +93,11 @@ export const Form = forwardRef<
         : "error"
       : initialState;
 
+  const instanceId = getInstanceIdFromComponentProps(props);
+
   return (
     <fetcher.Form {...props} method="post" data-state={state} ref={ref}>
+      <input type="hidden" name="ws-form-id" value={instanceId} />
       {state === "success"
         ? onlySuccessMessage(children)
         : state === "error"

--- a/packages/react-sdk/src/app/custom-components/form.tsx
+++ b/packages/react-sdk/src/app/custom-components/form.tsx
@@ -1,4 +1,5 @@
 import { useFetcher } from "@remix-run/react";
+import { formIdFieldName } from "@webstudio-is/form-handlers";
 import {
   Children,
   cloneElement,
@@ -97,7 +98,7 @@ export const Form = forwardRef<
 
   return (
     <fetcher.Form {...props} method="post" data-state={state} ref={ref}>
-      <input type="hidden" name="ws--form-id" value={instanceId} />
+      <input type="hidden" name={formIdFieldName} value={instanceId} />
       {state === "success"
         ? onlySuccessMessage(children)
         : state === "error"

--- a/packages/react-sdk/src/app/custom-components/form.tsx
+++ b/packages/react-sdk/src/app/custom-components/form.tsx
@@ -1,3 +1,4 @@
+import { useFetcher } from "@remix-run/react";
 import {
   Children,
   cloneElement,
@@ -78,17 +79,28 @@ const withoutMessages = (children: ReactNode) =>
 
 export const Form = forwardRef<
   ElementRef<typeof defaultTag>,
-  ComponentProps<typeof defaultTag> & {
+  Omit<ComponentProps<typeof defaultTag>, "method" | "action"> & {
     initialState?: "initial" | "success" | "error";
   }
->(({ children, initialState = "initial", ...props }, ref) => (
-  <form {...props} data-state={initialState} ref={ref}>
-    {initialState === "success"
-      ? onlySuccessMessage(children)
-      : initialState === "error"
-      ? onlyErrorMessage(children)
-      : withoutMessages(children)}
-  </form>
-));
+>(({ children, initialState = "initial", ...props }, ref) => {
+  const fetcher = useFetcher();
+
+  const state =
+    fetcher.type === "done"
+      ? fetcher.data?.success === true
+        ? "success"
+        : "error"
+      : initialState;
+
+  return (
+    <fetcher.Form {...props} method="post" data-state={state} ref={ref}>
+      {state === "success"
+        ? onlySuccessMessage(children)
+        : state === "error"
+        ? onlyErrorMessage(children)
+        : withoutMessages(children)}
+    </fetcher.Form>
+  );
+});
 
 Form.displayName = "Form";

--- a/packages/sdk-size-test/package.json
+++ b/packages/sdk-size-test/package.json
@@ -15,7 +15,7 @@
     },
     {
       "path": "functions/*.js",
-      "limit": "240 kB",
+      "limit": "242 kB",
       "gzip": false
     }
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1190,6 +1190,9 @@ importers:
       '@webstudio-is/fonts':
         specifier: workspace:^
         version: link:../fonts
+      '@webstudio-is/form-handlers':
+        specifier: workspace:^
+        version: link:../form-handlers
       '@webstudio-is/generate-arg-types':
         specifier: workspace:^
         version: link:../generate-arg-types


### PR DESCRIPTION
Part of #84 
Should be deployed together with https://github.com/webstudio-is/webstudio-saas/pull/148

## Description

1. Exposed `User.email` in the data we send to saas
2. Used Remix's form in the Form component
3. Refactoring in `form-handlers`

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)


## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
