### PR TITLE
Fix copy paste of style sources

### DIFF
--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -29,7 +29,7 @@ import {
   insertStylesCopyMutable,
   insertStyleSourcesCopyMutable,
   insertStyleSourceSelectionsCopyMutable,
-  findSubtreeLocalStyleSources,
+  findLocalStyleSourcesWithinInstances,
   mergeNewBreakpointsMutable,
 } from "../tree-utils";
 import { deleteInstance } from "../instance-utils";
@@ -184,24 +184,16 @@ export const onPaste = (clipboardData: string) => {
         dropTarget
       );
 
-      // find all local style sources of copied instances
-      const newStyleSourceIds = findSubtreeLocalStyleSources(
-        new Set(copiedInstanceIds.values()),
-        new Map(
-          data.styleSources.map((styleSource) => [styleSource.id, styleSource])
-        ),
-        new Map(
-          data.styleSourceSelections.map((styleSourceSelection) => [
-            styleSourceSelection.instanceId,
-            styleSourceSelection,
-          ])
-        )
+      const localStyleSourceIds = findLocalStyleSourcesWithinInstances(
+        data.styleSources,
+        data.styleSourceSelections,
+        new Set(copiedInstanceIds.keys())
       );
 
       const copiedStyleSourceIds = insertStyleSourcesCopyMutable(
         styleSources,
         data.styleSources,
-        newStyleSourceIds
+        localStyleSourceIds
       );
 
       insertPropsCopyMutable(props, data.props, copiedInstanceIds);

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -15,7 +15,7 @@ import {
   type DroppableTarget,
   type InstanceSelector,
   createComponentInstance,
-  findSubtreeLocalStyleSources,
+  findLocalStyleSourcesWithinInstances,
   insertInstancesMutable,
   reparentInstanceMutable,
   getAncestorInstanceSelector,
@@ -124,14 +124,14 @@ export const deleteInstance = (instanceSelector: InstanceSelector) => {
         parentInstance = instances.get(grandparentInstanceId);
       }
 
-      const subtreeIds = findTreeInstanceIdsExcludingSlotDescendants(
+      const instanceIds = findTreeInstanceIdsExcludingSlotDescendants(
         instances,
         targetInstanceId
       );
-      const subtreeLocalStyleSourceIds = findSubtreeLocalStyleSources(
-        subtreeIds,
-        styleSources,
-        styleSourceSelections
+      const localStyleSourceIds = findLocalStyleSourcesWithinInstances(
+        styleSources.values(),
+        styleSourceSelections.values(),
+        instanceIds
       );
 
       // may not exist when delete root
@@ -142,23 +142,23 @@ export const deleteInstance = (instanceSelector: InstanceSelector) => {
         );
       }
 
-      for (const instanceId of subtreeIds) {
+      for (const instanceId of instanceIds) {
         instances.delete(instanceId);
       }
       // delete props and styles of deleted instance and its descendants
       for (const prop of props.values()) {
-        if (subtreeIds.has(prop.instanceId)) {
+        if (instanceIds.has(prop.instanceId)) {
           props.delete(prop.id);
         }
       }
-      for (const instanceId of subtreeIds) {
+      for (const instanceId of instanceIds) {
         styleSourceSelections.delete(instanceId);
       }
-      for (const styleSourceId of subtreeLocalStyleSourceIds) {
+      for (const styleSourceId of localStyleSourceIds) {
         styleSources.delete(styleSourceId);
       }
       for (const [styleDeclKey, styleDecl] of styles) {
-        if (subtreeLocalStyleSourceIds.has(styleDecl.styleSourceId)) {
+        if (localStyleSourceIds.has(styleDecl.styleSourceId)) {
           styles.delete(styleDeclKey);
         }
       }

--- a/apps/builder/app/shared/tree-utils.test.ts
+++ b/apps/builder/app/shared/tree-utils.test.ts
@@ -14,7 +14,7 @@ import {
   type InstanceSelector,
   cloneStyles,
   findClosestDroppableTarget,
-  findSubtreeLocalStyleSources,
+  findLocalStyleSourcesWithinInstances,
   getAncestorInstanceSelector,
   insertInstancesCopyMutable,
   insertInstancesMutable,
@@ -853,32 +853,28 @@ test("clone styles with appled new style source ids", () => {
   ]);
 });
 
-test("find subtree local style sources", () => {
-  const subtreeIds = new Set(["instance2", "instance4"]);
-  const styleSources = new Map([
-    ["local1", createStyleSource("local", "local1")],
-    ["local2", createStyleSource("local", "local2")],
-    ["token3", createStyleSource("token", "token3")],
-    ["local4", createStyleSource("local", "local4")],
-    ["token5", createStyleSource("token", "token5")],
-    ["local6", createStyleSource("local", "local6")],
-  ]);
-  const styleSourceSelections = new Map([
-    ["instance1", createStyleSourceSelection("instance1", ["local1"])],
-    ["instance2", createStyleSourceSelection("instance2", ["local2"])],
-    ["instance3", createStyleSourceSelection("instance3", ["token3"])],
-    [
-      "instance4",
-      createStyleSourceSelection("instance4", ["local4", "token5"]),
-    ],
-    ["instance5", createStyleSourceSelection("instance5", ["local6"])],
-  ]);
-
+test("find local style sources within instances", () => {
+  const instanceIds = new Set(["instance2", "instance4"]);
+  const styleSources = [
+    createStyleSource("local", "local1"),
+    createStyleSource("local", "local2"),
+    createStyleSource("token", "token3"),
+    createStyleSource("local", "local4"),
+    createStyleSource("token", "token5"),
+    createStyleSource("local", "local6"),
+  ];
+  const styleSourceSelections = [
+    createStyleSourceSelection("instance1", ["local1"]),
+    createStyleSourceSelection("instance2", ["local2"]),
+    createStyleSourceSelection("instance3", ["token3"]),
+    createStyleSourceSelection("instance4", ["local4", "token5"]),
+    createStyleSourceSelection("instance5", ["local6"]),
+  ];
   expect(
-    findSubtreeLocalStyleSources(
-      subtreeIds,
+    findLocalStyleSourcesWithinInstances(
       styleSources,
-      styleSourceSelections
+      styleSourceSelections,
+      instanceIds
     )
   ).toEqual(new Set(["local2", "local4"]));
 });

--- a/apps/builder/app/shared/tree-utils.ts
+++ b/apps/builder/app/shared/tree-utils.ts
@@ -15,6 +15,8 @@ import {
   StyleSources,
   StyleSourceSelection,
   StyleSourceSelections,
+  StyleSourceSelectionsList,
+  StyleSourcesList,
 } from "@webstudio-is/project-build";
 import {
   canAcceptComponent,
@@ -247,22 +249,24 @@ export const cloneStyles = (
   return clonedStyles;
 };
 
-export const findSubtreeLocalStyleSources = (
-  subtreeIds: Set<Instance["id"]>,
-  styleSources: StyleSources,
-  styleSourceSelections: StyleSourceSelections
+export const findLocalStyleSourcesWithinInstances = (
+  styleSources: IterableIterator<StyleSource> | StyleSourcesList,
+  styleSourceSelections:
+    | IterableIterator<StyleSourceSelection>
+    | StyleSourceSelectionsList,
+  instanceIds: Set<Instance["id"]>
 ) => {
   const localStyleSourceIds = new Set<StyleSource["id"]>();
-  for (const styleSource of styleSources.values()) {
+  for (const styleSource of styleSources) {
     if (styleSource.type === "local") {
       localStyleSourceIds.add(styleSource.id);
     }
   }
 
   const subtreeLocalStyleSourceIds = new Set<StyleSource["id"]>();
-  for (const { instanceId, values } of styleSourceSelections.values()) {
+  for (const { instanceId, values } of styleSourceSelections) {
     // skip selections outside of subtree
-    if (subtreeIds.has(instanceId) === false) {
+    if (instanceIds.has(instanceId) === false) {
       continue;
     }
     // find only local style sources on selections


### PR DESCRIPTION
Ref https://discord.com/channels/955905230107738152/955907841070346300/1103260031048241182

Here style sources were pasted without copying. Here I renamed the utility to clarify a little and provided proper list of instance ids.

## Code Review

- [ ] hi @rpominov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
