### PR TITLE
Reduce published site size

### DIFF
--- a/packages/image/src/index.ts
+++ b/packages/image/src/index.ts
@@ -4,15 +4,19 @@ export type { ImageLoader } from "./image-optimize";
 export * as loaders from "./image-loaders";
 import { props } from "./__generated__/image.props";
 
-// "loader" is our internal prop not intended to show up in the props panel
-const { loader, ...publicProps } = props;
+const getImageProps = (): Record<string, PropMeta> => {
+  // "loader" is our internal prop not intended to show up in the props panel
+  const { loader, ...publicProps } = props;
 
-export const imageProps: Record<string, PropMeta> = {
-  ...publicProps,
-  src: {
-    type: "string",
-    control: "file",
-    label: "Source",
-    required: false,
-  },
+  return {
+    ...publicProps,
+    src: {
+      type: "string",
+      control: "file",
+      label: "Source",
+      required: false,
+    },
+  };
 };
+
+export const imageProps = /*#__PURE__*/ getImageProps();

--- a/packages/sdk-size-test/package.json
+++ b/packages/sdk-size-test/package.json
@@ -15,7 +15,7 @@
     },
     {
       "path": "functions/*.js",
-      "limit": "240 kB",
+      "limit": "225 kB",
       "gzip": false
     }
   ],


### PR DESCRIPTION
Image prop were added to the bundle because of object rest and spread. Here I moved it to function and marked its execution as pure to cut 15kB.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @rpominov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
