### PR TITLE
Render placement indicator in portal

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/use-sortable.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/use-sortable.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from "react";
+import { createPortal } from "react-dom";
 import {
   type Placement,
   PlacementIndicator,
@@ -105,9 +106,12 @@ export const useSortable = <Item extends { id: string }>({
     },
   });
 
-  const placementIndicatorElement = placementIndicator ? (
-    <PlacementIndicator placement={placementIndicator} />
-  ) : undefined;
+  const placementIndicatorElement = placementIndicator
+    ? createPortal(
+        <PlacementIndicator placement={placementIndicator} />,
+        document.body
+      )
+    : undefined;
 
   const sortableRefCallback = (element: HTMLDivElement | null) => {
     useDropHandlers.rootRef(element);

--- a/apps/builder/app/builder/features/style-panel/style-source/use-sortable.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/use-sortable.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from "react";
+import { createPortal } from "react-dom";
 import {
   type Placement,
   PlacementIndicator,
@@ -119,9 +120,12 @@ export const useSortable = <Item extends { id: string }>({
     },
   });
 
-  const placementIndicatorElement = placementIndicator ? (
-    <PlacementIndicator placement={placementIndicator} />
-  ) : undefined;
+  const placementIndicatorElement = placementIndicator
+    ? createPortal(
+        <PlacementIndicator placement={placementIndicator} />,
+        document.body
+      )
+    : undefined;
 
   const sortableRefCallback = (element: HTMLDivElement | null) => {
     useDropHandlers.rootRef(element);


### PR DESCRIPTION
Need to render placement indicator in portal to avoid shifting because of position: relative on ancestors elements like ScrollView.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
