### PR TITLE
Add padding to settings scroll area

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
@@ -18,8 +18,13 @@ export const SettingsPanel = () => {
   }
   const label = getComponentMeta(selectedInstance.component)?.label;
   return (
-    <ScrollArea css={{ px: theme.spacing[9] }}>
-      <Flex gap="1" direction="column" grow>
+    <ScrollArea>
+      <Flex
+        gap="1"
+        direction="column"
+        grow
+        css={{ px: theme.spacing[9], py: theme.spacing[9] }}
+      >
         <Label>Instance Name</Label>
         <InputField
           /* Key is required, otherwise when label is undefined, previous value stayed */


### PR DESCRIPTION
Outline was cut with overflow: scroll from scroll area. Here moved paddings inside and added bottom padding.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
