### PR TITLE
Fix scroll on edit

### DIFF
--- a/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
+++ b/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
@@ -11,6 +11,7 @@ import {
   selectedInstanceIntanceToTagStore,
   selectedInstanceUnitSizesStore,
   selectedInstanceIsRenderedStore,
+  selectedInstanceSelectorStore,
 } from "~/shared/nano-states";
 import htmlTags, { type htmlTags as HtmlTags } from "html-tags";
 import { getAllElementsBoundingBox } from "~/shared/dom-utils";
@@ -18,6 +19,10 @@ import { subscribeScrollState } from "~/canvas/shared/scroll-state";
 import { selectedInstanceOutlineStore } from "~/shared/nano-states";
 import type { UnitSizes } from "~/builder/features/style-panel/shared/css-value-input/convert-units";
 import { setDataCollapsed } from "~/canvas/collapsed";
+import {
+  areInstanceSelectorsEqual,
+  type InstanceSelector,
+} from "~/shared/tree-utils";
 
 const isHtmlTag = (tag: string): tag is HtmlTags =>
   htmlTags.includes(tag as HtmlTags);
@@ -72,11 +77,13 @@ export const SelectedInstanceConnector = ({
   instance,
   instanceStyles,
   instanceProps,
+  instanceSelector,
 }: {
   instanceElementRef: { current: undefined | HTMLElement };
   instance: Instance;
   instanceStyles: StyleDecl[];
   instanceProps: undefined | Prop[];
+  instanceSelector: InstanceSelector;
 }) => {
   const instances = useStore(instancesStore);
 
@@ -185,11 +192,20 @@ export const SelectedInstanceConnector = ({
       unsubscribeScrollState();
       unsubscribeWindowResize();
       unsubscribeIsResizingCanvas();
-      selectedInstanceIsRenderedStore.set(false);
+
+      if (
+        areInstanceSelectorsEqual(
+          selectedInstanceSelectorStore.get(),
+          instanceSelector
+        ) === false
+      ) {
+        selectedInstanceIsRenderedStore.set(false);
+      }
     };
   }, [
     instanceElementRef,
     instance,
+    instanceSelector,
     instanceStyles,
     // instance props may change dom element
     instanceProps,

--- a/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
+++ b/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
@@ -193,6 +193,10 @@ export const SelectedInstanceConnector = ({
       unsubscribeWindowResize();
       unsubscribeIsResizingCanvas();
 
+      // Retain selectedInstanceIsRenderedStore state if instanceSelector stays the same.
+      // Occasionally, an immediate call to selectedInstanceIsRenderedStore.set(true) may not update StylePanel state
+      // within the same batch as the current effect unsubscribe (e.g., due to delayed postMessage). (and cause to lost scroll position)
+      // This rare issue is difficult to reproduce, occurring roughly once every 100 calls.
       if (
         areInstanceSelectorsEqual(
           selectedInstanceSelectorStore.get(),

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -175,6 +175,7 @@ export const WebstudioComponentDev = ({
         <SelectedInstanceConnector
           instanceElementRef={instanceElementRef}
           instance={instance}
+          instanceSelector={instanceSelector}
           instanceStyles={instanceStyles}
           instanceProps={instanceProps}
         />


### PR DESCRIPTION
## Description

The current approach relies on batching behavior.
Here is fast fix to not reset atom if global atom has not been changed

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
