### PR TITLE
Support remote label for next style sources

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
@@ -10,6 +10,7 @@ import {
   getCascadedBreakpointIds,
   getCascadedInfo,
   getInheritedInfo,
+  getNextSourceInfo,
   getPreviousSourceInfo,
 } from "./style-info";
 
@@ -268,6 +269,65 @@ test("compute styles from previous sources", () => {
           "type": "unit",
           "unit": "px",
           "value": 200,
+        },
+      },
+    }
+  `);
+});
+
+test("compute styles from next sources", () => {
+  const styleSourceSelections = new Map([
+    ["3", { instanceId: "3", values: ["1", "2", "3", "4"] }],
+  ]);
+  const selectedStyleSourceSelector = {
+    styleSourceId: "3",
+  };
+  const stylesByInstanceId = new Map<Instance["id"], StylesList>([
+    [
+      "3",
+      [
+        {
+          breakpointId: "bp",
+          styleSourceId: "1",
+          property: "width",
+          value: { type: "unit", value: 100, unit: "px" },
+        },
+        {
+          breakpointId: "bp",
+          styleSourceId: "2",
+          property: "width",
+          value: { type: "unit", value: 200, unit: "px" },
+        },
+        {
+          breakpointId: "bp",
+          styleSourceId: "3",
+          property: "width",
+          value: { type: "unit", value: 300, unit: "px" },
+        },
+        {
+          breakpointId: "bp",
+          styleSourceId: "4",
+          property: "width",
+          value: { type: "unit", value: 400, unit: "px" },
+        },
+      ],
+    ],
+  ]);
+  expect(
+    getNextSourceInfo(
+      styleSourceSelections,
+      stylesByInstanceId,
+      selectedInstanceSelector,
+      selectedStyleSourceSelector
+    )
+  ).toMatchInlineSnapshot(`
+    {
+      "width": {
+        "styleSourceId": "4",
+        "value": {
+          "type": "unit",
+          "unit": "px",
+          "value": 400,
         },
       },
     }

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
@@ -329,7 +329,7 @@ const renderMenuItems = (props: {
           return;
         }
         return (
-          <>
+          <Fragment key={currentCategory}>
             <DropdownMenuSeparator />
             <DropdownMenuLabel>
               {humanizeString(currentCategory)}
@@ -366,7 +366,7 @@ const renderMenuItems = (props: {
                 {label}
               </DropdownMenuItem>
             ))}
-          </>
+          </Fragment>
         );
       })}
     </>


### PR DESCRIPTION
Ref https://www.figma.com/file/xCBegXEWxROLqA1Y31z2Xo/%F0%9F%93%96-Webstudio-Design-Docs?type=design&node-id=1037-32728&t=HT5zNo0zhXDCpIX8-0

Here show next style sources as remote too. And add alert when next style source has same style as local so user see something overrides it.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
