### PR TITLE
Compute remote style sources only for current breakpoint

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
@@ -239,6 +239,13 @@ test("compute styles from previous sources", () => {
           property: "width",
           value: { type: "unit", value: 200, unit: "px" },
         },
+        // prevent overriding by value from other breakpoint
+        {
+          breakpointId: "bp2",
+          styleSourceId: "2",
+          property: "width",
+          value: { type: "unit", value: 250, unit: "px" },
+        },
         {
           breakpointId: "bp",
           styleSourceId: "3",
@@ -259,7 +266,8 @@ test("compute styles from previous sources", () => {
       styleSourceSelections,
       stylesByInstanceId,
       selectedInstanceSelector,
-      selectedStyleSourceSelector
+      selectedStyleSourceSelector,
+      "bp"
     )
   ).toMatchInlineSnapshot(`
     {
@@ -310,6 +318,13 @@ test("compute styles from next sources", () => {
           property: "width",
           value: { type: "unit", value: 400, unit: "px" },
         },
+        // prevent overriding by value from other breakpoint
+        {
+          breakpointId: "bp2",
+          styleSourceId: "4",
+          property: "width",
+          value: { type: "unit", value: 450, unit: "px" },
+        },
       ],
     ],
   ]);
@@ -318,7 +333,8 @@ test("compute styles from next sources", () => {
       styleSourceSelections,
       stylesByInstanceId,
       selectedInstanceSelector,
-      selectedStyleSourceSelector
+      selectedStyleSourceSelector,
+      "bp"
     )
   ).toMatchInlineSnapshot(`
     {

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.ts
@@ -14,6 +14,7 @@ import {
   type Instances,
   type StyleDecl,
   type StyleSource as StyleSourceType,
+  Breakpoint,
 } from "@webstudio-is/project-build";
 import {
   type StyleSourceSelector,
@@ -303,7 +304,8 @@ export const getPreviousSourceInfo = (
   styleSourceSelections: StyleSourceSelections,
   stylesByInstanceId: Map<Instance["id"], StyleDecl[]>,
   selectedInstanceSelector: InstanceSelector,
-  selectedStyleSourceSelector: StyleSourceSelector
+  selectedStyleSourceSelector: StyleSourceSelector,
+  breakpointId: Breakpoint["id"]
 ) => {
   const previousSourceStyle: SourceProperties = {};
   const [selectedInstanceId] = selectedInstanceSelector;
@@ -319,7 +321,10 @@ export const getPreviousSourceInfo = (
   );
   // expect instance styles to be ordered
   for (const styleDecl of instanceStyles) {
-    if (previousSourceIds.includes(styleDecl.styleSourceId)) {
+    if (
+      styleDecl.breakpointId === breakpointId &&
+      previousSourceIds.includes(styleDecl.styleSourceId)
+    ) {
       previousSourceStyle[styleDecl.property] = {
         styleSourceId: styleDecl.styleSourceId,
         value: styleDecl.value,
@@ -333,7 +338,8 @@ export const getNextSourceInfo = (
   styleSourceSelections: StyleSourceSelections,
   stylesByInstanceId: Map<Instance["id"], StyleDecl[]>,
   selectedInstanceSelector: InstanceSelector,
-  selectedStyleSourceSelector: StyleSourceSelector
+  selectedStyleSourceSelector: StyleSourceSelector,
+  breakpointId: Breakpoint["id"]
 ) => {
   const nextSourceStyle: SourceProperties = {};
   const [selectedInstanceId] = selectedInstanceSelector;
@@ -349,7 +355,10 @@ export const getNextSourceInfo = (
   );
   // expect instance styles to be ordered
   for (const styleDecl of instanceStyles) {
-    if (nextSourceIds.includes(styleDecl.styleSourceId)) {
+    if (
+      styleDecl.breakpointId === breakpointId &&
+      nextSourceIds.includes(styleDecl.styleSourceId)
+    ) {
       nextSourceStyle[styleDecl.property] = {
         styleSourceId: styleDecl.styleSourceId,
         value: styleDecl.value,
@@ -442,7 +451,8 @@ export const useStyleInfo = () => {
   const previousSourceInfo = useMemo(() => {
     if (
       selectedInstanceSelector === undefined ||
-      selectedOrLastStyleSourceSelector === undefined
+      selectedOrLastStyleSourceSelector === undefined ||
+      selectedBreakpointId === undefined
     ) {
       return {};
     }
@@ -450,19 +460,22 @@ export const useStyleInfo = () => {
       styleSourceSelections,
       stylesByInstanceId,
       selectedInstanceSelector,
-      selectedOrLastStyleSourceSelector
+      selectedOrLastStyleSourceSelector,
+      selectedBreakpointId
     );
   }, [
     styleSourceSelections,
     stylesByInstanceId,
     selectedInstanceSelector,
     selectedOrLastStyleSourceSelector,
+    selectedBreakpointId,
   ]);
 
   const nextSourceInfo = useMemo(() => {
     if (
       selectedInstanceSelector === undefined ||
-      selectedOrLastStyleSourceSelector === undefined
+      selectedOrLastStyleSourceSelector === undefined ||
+      selectedBreakpointId === undefined
     ) {
       return {};
     }
@@ -470,13 +483,15 @@ export const useStyleInfo = () => {
       styleSourceSelections,
       stylesByInstanceId,
       selectedInstanceSelector,
-      selectedOrLastStyleSourceSelector
+      selectedOrLastStyleSourceSelector,
+      selectedBreakpointId
     );
   }, [
     styleSourceSelections,
     stylesByInstanceId,
     selectedInstanceSelector,
     selectedOrLastStyleSourceSelector,
+    selectedBreakpointId,
   ]);
 
   const presetStyle = useMemo(() => {


### PR DESCRIPTION
Ref https://discord.com/channels/955905230107738152/955907841070346300/1104446794211016744

Remote style sources should provide info only within current breakpoint. So when remote from other breakpoint we show cascaded remote instead.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
