### PR TITLE
Fix collapsed outline sometimes not visible

### DIFF
--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -60,8 +60,9 @@ export const helperStyles = [
   }`,
   // Using :where allows to prevent increasing specificity, so that helper is overwritten by user styles.
   `[${idAttribute}]:where([${collapsedAttribute}]:not(body)) {
-    outline: 1px dashed #555;
-    outline-offset: -0.5px;
+    outline: 1px dashed rgba(0,0,0,0.7);
+    outline-offset: -1px;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.7);
   }`,
   // Has no width, will collapse
   `[${idAttribute}]:where(:not(body)[${collapsedAttribute}="w"]) {


### PR DESCRIPTION
## Description

<img width="499" alt="image" src="https://user-images.githubusercontent.com/5077042/236811571-0f98099d-907a-47d4-8733-59dba654d26f.png">

Now on connected outlines, it will not be the thin border like before.
(But the thin border has an issue that in some cases it can become a solid line)

Imo this looks better vs thick 4px outlines at the webflow

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
