### PR TITLE
Fix editing of background gradient resetted other properties of the curent layer

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.test.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.test.ts
@@ -228,10 +228,36 @@ describe("setLayerProperty", () => {
         ],
       },
     };
+
+    const cascadedPosition: NonNullable<
+      StyleInfo["backgroundPosition"]
+    >["cascaded"] = {
+      breakpointId: "mobile",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "unit",
+            value: 50,
+            unit: "%",
+          },
+          {
+            type: "unit",
+            value: 50,
+            unit: "%",
+          },
+        ],
+      },
+    };
+
     const styleInfo: StyleInfo = {
       backgroundImage: {
         cascaded,
         value: cascaded.value,
+      },
+      backgroundPosition: {
+        cascaded: cascadedPosition,
+        value: cascadedPosition.value,
       },
     };
 
@@ -289,6 +315,25 @@ describe("setLayerProperty", () => {
       }
     `);
 
+    // We should not reset existing properties to default values
+    expect(styleInfo.backgroundPosition?.value).toMatchInlineSnapshot(`
+      {
+        "type": "layers",
+        "value": [
+          {
+            "type": "unit",
+            "unit": "%",
+            "value": 50,
+          },
+          {
+            "type": "unit",
+            "unit": "%",
+            "value": 50,
+          },
+        ],
+      }
+    `);
+
     setProperty("backgroundImage")({
       type: "layers",
       value: [
@@ -318,6 +363,29 @@ describe("setLayerProperty", () => {
           {
             "type": "unparsed",
             "value": "linear-gradient(yellow, blue)",
+          },
+        ],
+      }
+    `);
+
+    expect(styleInfo.backgroundPosition?.value).toMatchInlineSnapshot(`
+      {
+        "type": "layers",
+        "value": [
+          {
+            "type": "unit",
+            "unit": "%",
+            "value": 50,
+          },
+          {
+            "type": "unit",
+            "unit": "%",
+            "value": 50,
+          },
+          {
+            "type": "unit",
+            "unit": "%",
+            "value": 0,
           },
         ],
       }

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.test.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.test.ts
@@ -238,7 +238,7 @@ describe("setLayerProperty", () => {
         value: [
           {
             type: "unit",
-            value: 50,
+            value: 10,
             unit: "%",
           },
           {
@@ -323,7 +323,7 @@ describe("setLayerProperty", () => {
           {
             "type": "unit",
             "unit": "%",
-            "value": 50,
+            "value": 10,
           },
           {
             "type": "unit",
@@ -375,7 +375,7 @@ describe("setLayerProperty", () => {
           {
             "type": "unit",
             "unit": "%",
-            "value": 50,
+            "value": 10,
           },
           {
             "type": "unit",

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-layers.ts
@@ -271,9 +271,12 @@ export const setLayerProperty =
         const insertItems =
           property === propertyName
             ? newValue.value
-            : Array.from(
-                Array(newValue.value.length),
-                () => layeredBackgroundPropsDefaults[property]
+            : Array.from(Array(newValue.value.length), (_, index) =>
+                // Do not override existing values with defaults for layerNum layer
+                index === 0
+                  ? newPropertyStyle.value[layerNum] ??
+                    layeredBackgroundPropsDefaults[property]
+                  : layeredBackgroundPropsDefaults[property]
               );
 
         newPropertyStyle.value.splice(layerNum, 1, ...insertItems);


### PR DESCRIPTION
## Description

Fix editing of background gradient resetted other properties of the curent layer

https://discord.com/channels/955905230107738152/955907841070346300/1105100883542409279


## Steps for reproduction


To reproduce set position center

![](https://cdn.discordapp.com/attachments/1105100883542409279/1105101084013367337/image.png)

Goto "Code", add space then click enter
All values are resetted


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
