### PR TITLE
Optimize patch endpoint

### DIFF
--- a/apps/builder/app/routes/rest.patch.ts
+++ b/apps/builder/app/routes/rest.patch.ts
@@ -1,19 +1,38 @@
 import type { ActionArgs } from "@remix-run/node";
 import type { SyncItem } from "immerhin";
-import type { Build } from "@webstudio-is/project-build";
+import { prisma } from "@webstudio-is/prisma-client";
 import {
-  patchBreakpoints,
-  patchProps,
-  patchStyles,
-  patchStyleSources,
-  patchStyleSourceSelections,
-  patchInstances,
-  patchPages,
+  type Build,
+  Breakpoints,
+  Instances,
+  Pages,
+  Props,
+  StyleSourceSelections,
+  StyleSources,
+  Styles,
+} from "@webstudio-is/project-build";
+import {
+  parsePages,
+  parseInstances,
+  parseStyleSourceSelections,
+  parseStyleSources,
+  parseStyles,
+  parseProps,
+  parseBreakpoints,
+  serializePages,
+  serializeBreakpoints,
+  serializeInstances,
+  serializeProps,
+  serializeStyleSources,
+  serializeStyleSourceSelections,
+  serializeStyles,
 } from "@webstudio-is/project-build/index.server";
 import { patchAssets } from "@webstudio-is/asset-uploader/index.server";
 import type { Project } from "@webstudio-is/project";
 import { createContext } from "~/shared/context.server";
 import { createAssetClient } from "~/shared/asset-client";
+import { authorizeProject } from "@webstudio-is/trpc-interface/index.server";
+import { applyPatches } from "immer";
 
 type PatchData = {
   transactions: Array<SyncItem>;
@@ -31,38 +50,154 @@ export const action = async ({ request }: ActionArgs) => {
   }
 
   const context = await createContext(request);
+  const canEdit = await authorizeProject.hasProjectPermit(
+    { projectId, permit: "edit" },
+    context
+  );
+  if (canEdit === false) {
+    throw Error("You don't have edit access to this project");
+  }
 
-  // @todo parallelize the updates
-  // currently not possible because we fetch the entire tree
-  // and parallelized updates will cause unpredictable side effects
+  const build = await prisma.build.findUnique({
+    where: { id_projectId: { projectId, id: buildId } },
+  });
+  if (build === null) {
+    throw Error(`Build ${buildId} not found`);
+  }
+
+  const buildData: {
+    pages?: Pages;
+    breakpoints?: Breakpoints;
+    instances?: Instances;
+    props?: Props;
+    styleSources?: StyleSources;
+    styleSourceSelections?: StyleSourceSelections;
+    styles?: Styles;
+  } = {};
+
+  const skipValidation = true;
+
   for await (const transaction of transactions) {
     for await (const change of transaction.changes) {
       const { namespace, patches } = change;
+      if (patches.length === 0) {
+        continue;
+      }
 
       if (namespace === "pages") {
-        await patchPages({ buildId, projectId }, patches, context);
-      } else if (namespace === "instances") {
-        await patchInstances({ buildId, projectId }, patches, context);
-      } else if (namespace === "styleSourceSelections") {
-        await patchStyleSourceSelections(
-          { buildId, projectId },
-          patches,
-          context
-        );
-      } else if (namespace === "styleSources") {
-        await patchStyleSources({ buildId, projectId }, patches, context);
-      } else if (namespace === "styles") {
-        await patchStyles({ buildId, projectId }, patches, context);
-      } else if (namespace === "props") {
-        await patchProps({ buildId, projectId }, patches, context);
-      } else if (namespace === "breakpoints") {
-        await patchBreakpoints({ buildId, projectId }, patches, context);
-      } else if (namespace === "assets") {
-        await patchAssets({ projectId }, patches, context, createAssetClient());
-      } else {
-        return { errors: `Unknown namespace "${namespace}"` };
+        // lazily parse build data before patching
+        const pages =
+          buildData.pages ?? parsePages(build.pages, skipValidation);
+        buildData.pages = applyPatches(pages, patches);
+        continue;
       }
+
+      if (namespace === "instances") {
+        const instances =
+          buildData.instances ??
+          parseInstances(build.instances, skipValidation);
+        buildData.instances = applyPatches(instances, patches);
+        continue;
+      }
+
+      if (namespace === "styleSourceSelections") {
+        const styleSourceSelections =
+          buildData.styleSourceSelections ??
+          parseStyleSourceSelections(
+            build.styleSourceSelections,
+            skipValidation
+          );
+        buildData.styleSourceSelections = applyPatches(
+          styleSourceSelections,
+          patches
+        );
+        continue;
+      }
+
+      if (namespace === "styleSources") {
+        const styleSources =
+          buildData.styleSources ??
+          parseStyleSources(build.styleSources, skipValidation);
+        buildData.styleSources = applyPatches(styleSources, patches);
+        continue;
+      }
+
+      if (namespace === "styles") {
+        const styles =
+          buildData.styles ?? parseStyles(build.styles, skipValidation);
+        buildData.styles = applyPatches(styles, patches);
+        continue;
+      }
+
+      if (namespace === "props") {
+        const props =
+          buildData.props ?? parseProps(build.props, skipValidation);
+        buildData.props = applyPatches(props, patches);
+        continue;
+      }
+
+      if (namespace === "breakpoints") {
+        const breakpoints =
+          buildData.breakpoints ??
+          parseBreakpoints(build.breakpoints, skipValidation);
+        buildData.breakpoints = applyPatches(breakpoints, patches);
+        continue;
+      }
+
+      if (namespace === "assets") {
+        // assets implements own patching
+        // @todo parallelize the updates
+        // currently not possible because we fetch the entire tree
+        // and parallelized updates will cause unpredictable side effects
+        await patchAssets({ projectId }, patches, context, createAssetClient());
+        continue;
+      }
+
+      return { errors: `Unknown namespace "${namespace}"` };
     }
   }
+
+  // save build data when all patches applied
+  const dbBuildData: Parameters<typeof prisma.build.update>[0]["data"] = {};
+  if (buildData.pages) {
+    // parse with zod before serialization to avoid saving invalid data
+    dbBuildData.pages = serializePages(Pages.parse(buildData.pages));
+  }
+  if (buildData.breakpoints) {
+    dbBuildData.breakpoints = serializeBreakpoints(
+      Breakpoints.parse(buildData.breakpoints)
+    );
+  }
+  if (buildData.instances) {
+    dbBuildData.instances = serializeInstances(
+      Instances.parse(buildData.instances)
+    );
+  }
+  if (buildData.props) {
+    dbBuildData.props = serializeProps(Props.parse(buildData.props));
+  }
+  if (buildData.styleSources) {
+    dbBuildData.styleSources = serializeStyleSources(
+      StyleSources.parse(buildData.styleSources)
+    );
+  }
+  if (buildData.styleSourceSelections) {
+    dbBuildData.styleSourceSelections = serializeStyleSourceSelections(
+      StyleSourceSelections.parse(buildData.styleSourceSelections)
+    );
+  }
+  if (buildData.styles) {
+    dbBuildData.styles = serializeStyles(Styles.parse(buildData.styles));
+  }
+  // check any build data is changed because only assets could change
+  if (Object.keys(dbBuildData).length > 0) {
+    await prisma.build.update({
+      data: dbBuildData,
+      where: {
+        id_projectId: { projectId, id: buildId },
+      },
+    });
+  }
+
   return { status: "ok" };
 };

--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -37,14 +37,11 @@
     "@webstudio-is/css-data": "workspace:^",
     "@webstudio-is/prisma-client": "workspace:^",
     "@webstudio-is/trpc-interface": "workspace:^",
-    "immer": "^9.0.12",
     "nanoid": "^3.2.0",
-    "uuid": "^9.0.0",
     "zod": "^3.19.1"
   },
   "devDependencies": {
     "@jest/globals": "^29.3.1",
-    "@types/uuid": "^8.3.4",
     "@webstudio-is/jest-config": "workspace:^",
     "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",

--- a/packages/project-build/src/db/breakpoints.ts
+++ b/packages/project-build/src/db/breakpoints.ts
@@ -1,11 +1,4 @@
 import { nanoid } from "nanoid";
-import { applyPatches, type Patch } from "immer";
-import { type Project, prisma } from "@webstudio-is/prisma-client";
-import {
-  authorizeProject,
-  type AppContext,
-} from "@webstudio-is/trpc-interface/index.server";
-import type { Build } from "../types";
 import {
   type Breakpoint,
   Breakpoints,
@@ -43,40 +36,5 @@ export const createInitialBreakpoints = (): [
         id,
       },
     ];
-  });
-};
-
-export const patchBreakpoints = async (
-  { buildId, projectId }: { buildId: Build["id"]; projectId: Project["id"] },
-  patches: Array<Patch>,
-  context: AppContext
-) => {
-  const canEdit = await authorizeProject.hasProjectPermit(
-    { projectId, permit: "edit" },
-    context
-  );
-  if (canEdit === false) {
-    throw new Error("You don't have edit access to this project");
-  }
-
-  const build = await prisma.build.findUnique({
-    where: {
-      id_projectId: { id: buildId, projectId },
-    },
-  });
-  if (build === null) {
-    return;
-  }
-
-  const breakpoints = parseBreakpoints(build.breakpoints);
-  const patchedBreakpoints = Breakpoints.parse(
-    applyPatches(breakpoints, patches)
-  );
-
-  await prisma.build.update({
-    where: {
-      id_projectId: { id: buildId, projectId },
-    },
-    data: { breakpoints: serializeBreakpoints(patchedBreakpoints) },
   });
 };

--- a/packages/project-build/src/db/instances.ts
+++ b/packages/project-build/src/db/instances.ts
@@ -1,9 +1,3 @@
-import { applyPatches, type Patch } from "immer";
-import { type Project, type Build, prisma } from "@webstudio-is/prisma-client";
-import {
-  authorizeProject,
-  type AppContext,
-} from "@webstudio-is/trpc-interface/index.server";
 import { Instances, InstancesList } from "../schema/instances";
 
 export const parseInstances = (
@@ -19,39 +13,4 @@ export const parseInstances = (
 export const serializeInstances = (instances: Instances) => {
   const instancesList: InstancesList = Array.from(instances.values());
   return JSON.stringify(instancesList);
-};
-
-export const patchInstances = async (
-  { buildId, projectId }: { buildId: Build["id"]; projectId: Project["id"] },
-  patches: Array<Patch>,
-  context: AppContext
-) => {
-  const canEdit = await authorizeProject.hasProjectPermit(
-    { projectId, permit: "edit" },
-    context
-  );
-
-  if (canEdit === false) {
-    throw new Error("You don't have edit access to this project");
-  }
-
-  const build = await prisma.build.findUnique({
-    where: {
-      id_projectId: { projectId, id: buildId },
-    },
-  });
-  if (build === null) {
-    return;
-  }
-  const instances = parseInstances(build.instances);
-  const patchedInstances = Instances.parse(applyPatches(instances, patches));
-
-  await prisma.build.update({
-    data: {
-      instances: serializeInstances(patchedInstances),
-    },
-    where: {
-      id_projectId: { projectId, id: buildId },
-    },
-  });
 };

--- a/packages/project-build/src/db/pages.ts
+++ b/packages/project-build/src/db/pages.ts
@@ -1,42 +1,14 @@
-import { applyPatches, type Patch } from "immer";
-import { type Project, type Build, prisma } from "@webstudio-is/prisma-client";
-import {
-  authorizeProject,
-  type AppContext,
-} from "@webstudio-is/trpc-interface/index.server";
 import { Pages } from "../schema/pages";
 
-export const patchPages = async (
-  { buildId, projectId }: { buildId: Build["id"]; projectId: Project["id"] },
-  patches: Array<Patch>,
-  context: AppContext
-) => {
-  const canEdit = await authorizeProject.hasProjectPermit(
-    { projectId, permit: "edit" },
-    context
-  );
+export const parsePages = (
+  pagesString: string,
+  skipValidation = false
+): Pages => {
+  return skipValidation
+    ? (JSON.parse(pagesString) as Pages)
+    : Pages.parse(JSON.parse(pagesString));
+};
 
-  if (canEdit === false) {
-    throw new Error("You don't have edit access to this project");
-  }
-
-  const build = await prisma.build.findUnique({
-    where: {
-      id_projectId: { projectId, id: buildId },
-    },
-  });
-  if (build === null) {
-    return;
-  }
-  const pages = Pages.parse(JSON.parse(build.pages));
-  const patchedPages = Pages.parse(applyPatches(pages, patches));
-
-  await prisma.build.update({
-    data: {
-      pages: JSON.stringify(patchedPages),
-    },
-    where: {
-      id_projectId: { projectId, id: buildId },
-    },
-  });
+export const serializePages = (pages: Pages) => {
+  return JSON.stringify(pages);
 };

--- a/packages/project-build/src/db/props.ts
+++ b/packages/project-build/src/db/props.ts
@@ -1,9 +1,3 @@
-import { applyPatches, type Patch } from "immer";
-import { type Project, type Build, prisma } from "@webstudio-is/prisma-client";
-import {
-  authorizeProject,
-  type AppContext,
-} from "@webstudio-is/trpc-interface/index.server";
 import { Props, PropsList } from "../schema/props";
 
 export const parseProps = (
@@ -19,39 +13,4 @@ export const parseProps = (
 export const serializeProps = (props: Props) => {
   const propsList: PropsList = Array.from(props.values());
   return JSON.stringify(propsList);
-};
-
-export const patchProps = async (
-  { buildId, projectId }: { buildId: Build["id"]; projectId: Project["id"] },
-  patches: Array<Patch>,
-  context: AppContext
-) => {
-  const canEdit = await authorizeProject.hasProjectPermit(
-    { projectId, permit: "edit" },
-    context
-  );
-
-  if (canEdit === false) {
-    throw new Error("You don't have edit access to this project");
-  }
-
-  const build = await prisma.build.findUnique({
-    where: {
-      id_projectId: { projectId, id: buildId },
-    },
-  });
-  if (build === null) {
-    return;
-  }
-  const props = parseProps(build.props);
-  const patchedProps = Props.parse(applyPatches(props, patches));
-
-  await prisma.build.update({
-    data: {
-      props: serializeProps(patchedProps),
-    },
-    where: {
-      id_projectId: { projectId, id: buildId },
-    },
-  });
 };

--- a/packages/project-build/src/db/style-source-selections.ts
+++ b/packages/project-build/src/db/style-source-selections.ts
@@ -1,9 +1,3 @@
-import { type Patch, applyPatches } from "immer";
-import { type Project, type Build, prisma } from "@webstudio-is/prisma-client";
-import {
-  authorizeProject,
-  type AppContext,
-} from "@webstudio-is/trpc-interface/index.server";
 import {
   StyleSourceSelectionsList,
   StyleSourceSelections,
@@ -29,47 +23,4 @@ export const serializeStyleSourceSelections = (
     styleSourceSelectionsMap.values()
   );
   return JSON.stringify(styleSourceSelectionsList);
-};
-
-export const patchStyleSourceSelections = async (
-  { buildId, projectId }: { buildId: Build["id"]; projectId: Project["id"] },
-  patches: Array<Patch>,
-  context: AppContext
-) => {
-  const canEdit = await authorizeProject.hasProjectPermit(
-    { projectId, permit: "edit" },
-    context
-  );
-
-  if (canEdit === false) {
-    throw new Error("You don't have edit access to this project");
-  }
-
-  const build = await prisma.build.findUnique({
-    where: {
-      id_projectId: { projectId, id: buildId },
-    },
-  });
-  if (build === null) {
-    return;
-  }
-
-  const styleSourceSelections = parseStyleSourceSelections(
-    build.styleSourceSelections
-  );
-
-  const patchedStyleSourceSelections = StyleSourceSelections.parse(
-    applyPatches(styleSourceSelections, patches)
-  );
-
-  await prisma.build.update({
-    data: {
-      styleSourceSelections: serializeStyleSourceSelections(
-        patchedStyleSourceSelections
-      ),
-    },
-    where: {
-      id_projectId: { projectId, id: buildId },
-    },
-  });
 };

--- a/packages/project-build/src/db/style-sources.ts
+++ b/packages/project-build/src/db/style-sources.ts
@@ -1,10 +1,3 @@
-import { type Patch, applyPatches } from "immer";
-import { type Project, prisma } from "@webstudio-is/prisma-client";
-import {
-  authorizeProject,
-  type AppContext,
-} from "@webstudio-is/trpc-interface/index.server";
-import type { Build } from "../types";
 import { StyleSourcesList, StyleSources } from "../schema/style-sources";
 
 export const parseStyleSources = (
@@ -22,43 +15,4 @@ export const serializeStyleSources = (styleSourcesMap: StyleSources) => {
     styleSourcesMap.values()
   );
   return JSON.stringify(styleSourcesList);
-};
-
-export const patchStyleSources = async (
-  { buildId, projectId }: { buildId: Build["id"]; projectId: Project["id"] },
-  patches: Array<Patch>,
-  context: AppContext
-) => {
-  const canEdit = await authorizeProject.hasProjectPermit(
-    { projectId, permit: "edit" },
-    context
-  );
-
-  if (canEdit === false) {
-    throw new Error("You don't have edit access to this project");
-  }
-
-  const build = await prisma.build.findUnique({
-    where: {
-      id_projectId: { projectId, id: buildId },
-    },
-  });
-  if (build === null) {
-    return;
-  }
-
-  const styleSources = parseStyleSources(build.styleSources);
-
-  const patchedStyleSources = StyleSources.parse(
-    applyPatches(styleSources, patches)
-  );
-
-  await prisma.build.update({
-    data: {
-      styleSources: serializeStyleSources(patchedStyleSources),
-    },
-    where: {
-      id_projectId: { projectId, id: buildId },
-    },
-  });
 };

--- a/packages/project-build/src/db/styles.ts
+++ b/packages/project-build/src/db/styles.ts
@@ -1,10 +1,3 @@
-import { type Patch, applyPatches } from "immer";
-import { type Project, prisma } from "@webstudio-is/prisma-client";
-import {
-  authorizeProject,
-  type AppContext,
-} from "@webstudio-is/trpc-interface/index.server";
-import type { Build } from "../types";
 import { Styles, StylesList, getStyleDeclKey } from "../schema/styles";
 
 export const parseStyles = (
@@ -21,41 +14,4 @@ export const parseStyles = (
 export const serializeStyles = (stylesMap: Styles) => {
   const stylesList: StylesList = Array.from(stylesMap.values());
   return JSON.stringify(stylesList);
-};
-
-export const patchStyles = async (
-  { buildId, projectId }: { buildId: Build["id"]; projectId: Project["id"] },
-  patches: Array<Patch>,
-  context: AppContext
-) => {
-  const canEdit = await authorizeProject.hasProjectPermit(
-    { projectId, permit: "edit" },
-    context
-  );
-
-  if (canEdit === false) {
-    throw new Error("You don't have edit access to this project");
-  }
-
-  const build = await prisma.build.findUnique({
-    where: {
-      id_projectId: { projectId, id: buildId },
-    },
-  });
-  if (build === null) {
-    return;
-  }
-
-  const styles = parseStyles(build.styles);
-
-  const patchedStyles = Styles.parse(applyPatches(styles, patches));
-
-  await prisma.build.update({
-    data: {
-      styles: serializeStyles(patchedStyles),
-    },
-    where: {
-      id_projectId: { projectId, id: buildId },
-    },
-  });
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1144,15 +1144,9 @@ importers:
       '@webstudio-is/trpc-interface':
         specifier: workspace:^
         version: link:../trpc-interface
-      immer:
-        specifier: ^9.0.12
-        version: 9.0.15
       nanoid:
         specifier: ^3.2.0
         version: 3.3.4
-      uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
       zod:
         specifier: ^3.19.1
         version: 3.19.1
@@ -1160,9 +1154,6 @@ importers:
       '@jest/globals':
         specifier: ^29.3.1
         version: 29.3.1
-      '@types/uuid':
-        specifier: ^8.3.4
-        version: 8.3.4
       '@webstudio-is/jest-config':
         specifier: workspace:^
         version: link:../jest-config


### PR DESCRIPTION
We batching transactions though each transaction and each namespaace in it loads build data, applies patches and writes to db. This makes patches do a lot of connections to db within single request.

Here each patch request loads and updates build only once and apply patches of all transactions to intermediary state.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
