### PR TITLE
Show stateless styles when state is selected

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/style-info.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.ts
@@ -141,6 +141,15 @@ const getSelectedStyle = (
     return style;
   }
   for (const styleDecl of instanceStyles) {
+    // @todo consider making stateless styles remote when state is selected
+    if (
+      styleDecl.breakpointId === breakpointId &&
+      styleDecl.state === undefined
+    ) {
+      style[styleDecl.property] = styleDecl.value;
+    }
+  }
+  for (const styleDecl of instanceStyles) {
     if (
       styleDecl.breakpointId === breakpointId &&
       styleDecl.state === styleSourceSelector.state
@@ -225,6 +234,10 @@ export const getPresetStyleRule = (
   }
   const presetStyle: Style = {};
   for (const styleDecl of presetStyles) {
+    // @todo consider making stateless styles remote when state is selected
+    if (styleDecl.state === undefined) {
+      presetStyle[styleDecl.property] = styleDecl.value;
+    }
     if (styleDecl.state === styleSourceSelector?.state) {
       presetStyle[styleDecl.property] = styleDecl.value;
     }


### PR DESCRIPTION
Ref https://discord.com/channels/955905230107738152/955907841070346300/1104517307478319257

Ideally make these values remote but as a fast fix made them local.

## Code Review

- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
