### PR TITLE
Drop link preset states

### DIFF
--- a/packages/css-data/src/html.ts
+++ b/packages/css-data/src/html.ts
@@ -451,6 +451,8 @@ export const a: Styles = [
     property: "color",
     value: { type: "rgb", r: 0, g: 0, b: 238, alpha: 1 },
   },
+  // active and visited states are not defined as usually overriden with stateless color
+  // and modeling var-like defaults is too complex
 ];
 
 /* lists */

--- a/packages/css-data/src/html.ts
+++ b/packages/css-data/src/html.ts
@@ -447,6 +447,10 @@ export const a: Styles = [
     property: "cursor",
     value: { type: "keyword", value: "pointer" },
   },
+  {
+    property: "color",
+    value: { type: "rgb", r: 0, g: 0, b: 238, alpha: 1 },
+  },
 ];
 
 /* lists */

--- a/packages/react-sdk/src/css/normalize.ts
+++ b/packages/react-sdk/src/css/normalize.ts
@@ -16,7 +16,7 @@
  */
 
 // webstudio custom opinionated presets
-import { borders, linkColors } from "./presets";
+import { borders } from "./presets";
 import type { EmbedTemplateStyleDecl } from "../embed-template";
 
 export type Styles = EmbedTemplateStyleDecl[];
@@ -63,7 +63,7 @@ export const i = baseStyle;
 
 export const img = baseStyle;
 
-export const a = [boxSizing, ...borders, ...linkColors];
+export const a = baseStyle;
 export const li = baseStyle;
 export const ul = baseStyle;
 export const ol = baseStyle;

--- a/packages/react-sdk/src/css/presets.ts
+++ b/packages/react-sdk/src/css/presets.ts
@@ -18,21 +18,3 @@ export const borders: Styles = [
     value: { type: "unit", value: 1, unit: "px" },
   },
 ];
-
-export const linkColors: Styles = [
-  {
-    property: "color",
-    value: { type: "rgb", r: 0, g: 0, b: 238, alpha: 1 },
-  },
-  {
-    state: ":active",
-    property: "color",
-    // chrome and safari use rgb(255, 0, 0)
-    value: { type: "rgb", r: 238, g: 0, b: 0, alpha: 1 },
-  },
-  {
-    state: ":visited",
-    property: "color",
-    value: { type: "rgb", r: 85, g: 26, b: 139, alpha: 1 },
-  },
-];


### PR DESCRIPTION
:active and :visited states on links have special behaviour. They are vendor defined until color on stateless link is defined. Similar to how vars work there is var with default. And when var is somewhere defined default is overriden.

Though using vars for this specific case is too complex here easier solution. We can just remove active and visited states on default styles. User may never see this inconsistency as usually would modify color on stateless link first and then go to active or visited states.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
