### PR TITLE
Fix width not set on prject change and breakpoints change

### DIFF
--- a/apps/builder/app/builder/features/breakpoints/use-set-initial-canvas-width.ts
+++ b/apps/builder/app/builder/features/breakpoints/use-set-initial-canvas-width.ts
@@ -1,9 +1,10 @@
 import { useStore } from "@nanostores/react";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect } from "react";
 import type { Breakpoint } from "@webstudio-is/project-build";
 import {
   useCanvasWidth,
   workspaceRectStore,
+  canvasWidthStore,
 } from "~/builder/shared/nano-states";
 import { breakpointsStore } from "~/shared/nano-states";
 import { findInitialWidth } from "./find-initial-width";
@@ -26,6 +27,7 @@ export const useSetInitialCanvasWidth = () => {
         breakpoint,
         workspaceRect.width
       );
+
       setCanvasWidth(width);
       return true;
     },
@@ -33,32 +35,52 @@ export const useSetInitialCanvasWidth = () => {
   );
 };
 
-export const useSetInitialCanvasWidthOnce = () => {
-  const isDone = useRef(false);
-  const [, setCanvasWidth] = useCanvasWidth();
-  const workspaceRect = useStore(workspaceRectStore);
-  const breakpoints = useStore(breakpointsStore);
-
-  // Set it initially once.
+/**
+ *  Update canvas width initially and on breakpoint change
+ **/
+export const useSetCanvasWidth = () => {
   useEffect(() => {
-    if (isDone.current || workspaceRect === undefined) {
-      return;
-    }
+    const update = () => {
+      const breakpoints = breakpointsStore.get();
+      const workspaceRect = workspaceRectStore.get();
+      if (workspaceRect === undefined || breakpoints.size === 0) {
+        return;
+      }
+      const breakpointValues = Array.from(breakpoints.values());
+      const baseBreakpoint = breakpointValues.find(isBaseBreakpoint);
 
-    isDone.current = true;
+      // When there is base breakpoint, we want to find the lowest possible size
+      // that is bigger than all max breakpoints and smaller than all min breakpoints.
+      if (baseBreakpoint) {
+        const width = findInitialWidth(
+          breakpointValues,
+          baseBreakpoint,
+          workspaceRect.width
+        );
 
-    const breakpointValues = Array.from(breakpoints.values());
-    const baseBreakpoint = breakpointValues.find(isBaseBreakpoint);
+        if (canvasWidthStore.get() !== width) {
+          canvasWidthStore.set(width);
+        }
+      }
+    };
 
-    // When there is base breakpoint, we want to find the lowest possible size
-    // that is bigger than all max breakpoints and smaller than all min breakpoints.
-    if (baseBreakpoint) {
-      const width = findInitialWidth(
-        breakpointValues,
-        baseBreakpoint,
-        workspaceRect.width
-      );
-      setCanvasWidth(width);
-    }
-  }, [breakpoints, setCanvasWidth, workspaceRect]);
+    const unsubscribeBreakpointStore = breakpointsStore.subscribe(update);
+    const unsubscribeRectStore =
+      workspaceRectStore.get() === undefined
+        ? workspaceRectStore.listen((workspaceRect) => {
+            if (workspaceRect === undefined) {
+              return;
+            }
+            unsubscribeRectStore();
+            update();
+          })
+        : () => {
+            /**/
+          };
+
+    return () => {
+      unsubscribeBreakpointStore();
+      unsubscribeRectStore();
+    };
+  }, []);
 };

--- a/apps/builder/app/builder/features/workspace/workspace.tsx
+++ b/apps/builder/app/builder/features/workspace/workspace.tsx
@@ -14,7 +14,7 @@ import { textEditingInstanceSelectorStore } from "~/shared/nano-states";
 import { CanvasTools } from "./canvas-tools";
 import { useMeasure } from "react-use";
 import { useEffect } from "react";
-import { useSetInitialCanvasWidthOnce } from "../breakpoints";
+import { useSetCanvasWidth } from "../breakpoints";
 
 const workspaceStyle = css({
   flexGrow: 1,
@@ -86,7 +86,7 @@ export const Workspace = ({
 }: WorkspaceProps) => {
   const canvasStyle = useCanvasStyle();
   const workspaceRef = useSetWorkspaceRect();
-  useSetInitialCanvasWidthOnce();
+  useSetCanvasWidth();
   const handleWorkspaceClick = () => {
     selectedInstanceSelectorStore.set(undefined);
     textEditingInstanceSelectorStore.set(undefined);


### PR DESCRIPTION
## Description

On project change breakpoints can be updated later than canvas with is calculated, so breakpoints from the previous project were used.

Here is the fix

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
