### PR TITLE
Save project uploader when create file

### DIFF
--- a/packages/asset-uploader/src/upload.ts
+++ b/packages/asset-uploader/src/upload.ts
@@ -45,16 +45,12 @@ export const createUploadName = async (
       OR: [
         {
           status: "UPLOADED",
-          assets: {
-            some: { projectId },
-          },
+          uploaderProjectId: projectId,
         },
         {
           status: "UPLOADING",
           createdAt: { gt: new Date(Date.now() - UPLOADING_STALE_TIMEOUT) },
-          assets: {
-            some: { projectId },
-          },
+          uploaderProjectId: projectId,
         },
       ],
     },

--- a/packages/asset-uploader/src/upload.ts
+++ b/packages/asset-uploader/src/upload.ts
@@ -33,10 +33,6 @@ export const createUploadName = async (
       "You don't have access to create this project assets"
     );
   }
-  const { userId } = context.authorization;
-  if (userId === undefined) {
-    throw new Error("The user must be authenticated to create a project");
-  }
 
   /**
    * sometimes for example on request timeout we don't know what happened to the "UPLOADING" asset,
@@ -95,7 +91,7 @@ export const createUploadName = async (
           // store content type in related field
           format: type,
           size: 0,
-          userId,
+          uploaderProjectId: projectId,
         },
       },
       // @todo remove once legacy fields are removed from schema

--- a/packages/prisma-client/prisma/migrations/20230511173512_file-user/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20230511173512_file-user/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "File" ADD COLUMN     "userId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "File" ADD CONSTRAINT "File_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/prisma-client/prisma/migrations/20230511173512_file-user/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20230511173512_file-user/migration.sql
@@ -1,5 +1,0 @@
--- AlterTable
-ALTER TABLE "File" ADD COLUMN     "userId" TEXT;
-
--- AddForeignKey
-ALTER TABLE "File" ADD CONSTRAINT "File_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/prisma-client/prisma/migrations/20230515112405_file_uploader_project/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20230515112405_file_uploader_project/migration.sql
@@ -1,0 +1,9 @@
+-- DropForeignKey
+ALTER TABLE "File" DROP CONSTRAINT "File_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "File" DROP COLUMN "userId",
+ADD COLUMN     "uploaderProjectId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "File" ADD CONSTRAINT "File_uploaderProjectId_fkey" FOREIGN KEY ("uploaderProjectId") REFERENCES "Project"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/prisma-client/prisma/schema.prisma
+++ b/packages/prisma-client/prisma/schema.prisma
@@ -31,16 +31,16 @@ enum UploadStatus {
 }
 
 model File {
-  name        String       @id
-  format      String
-  size        Int
-  description String?
-  createdAt   DateTime     @default(now())
-  meta        String       @default("{}")
-  status      UploadStatus @default(UPLOADING)
-  user        User?        @relation(fields: [userId], references: [id])
-  userId      String?
-  assets      Asset[]
+  name              String       @id
+  format            String
+  size              Int
+  description       String?
+  createdAt         DateTime     @default(now())
+  meta              String       @default("{}")
+  status            UploadStatus @default(UPLOADING)
+  uploaderProject   Project?     @relation(fields: [uploaderProjectId], references: [id])
+  uploaderProjectId String?
+  assets            Asset[]
 }
 
 model Asset {
@@ -71,7 +71,6 @@ model User {
   team      Team?     @relation(fields: [teamId], references: [id])
   teamId    String?
   projects  Project[]
-  files     File[]
 }
 
 model Project {
@@ -83,6 +82,7 @@ model Project {
   userId    String?
   build     Build[]
   isDeleted Boolean  @default(false)
+  files     File[]
 
   @@unique([id, isDeleted])
   @@unique([domain, isDeleted])

--- a/packages/prisma-client/prisma/schema.prisma
+++ b/packages/prisma-client/prisma/schema.prisma
@@ -38,6 +38,8 @@ model File {
   createdAt   DateTime     @default(now())
   meta        String       @default("{}")
   status      UploadStatus @default(UPLOADING)
+  user        User?        @relation(fields: [userId], references: [id])
+  userId      String?
   assets      Asset[]
 }
 
@@ -69,6 +71,7 @@ model User {
   team      Team?     @relation(fields: [teamId], references: [id])
   teamId    String?
   projects  Project[]
+  files     File[]
 }
 
 model Project {


### PR DESCRIPTION
We need to be able to track users who uploads files to prevent misuse of our storage.
Here added File.uploaderProjectId in db. This way we can always find project owner.
Saving user is less ideal because often can be no user for example when share edit permission by token.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
