### PR TITLE
Store content type before upload

### DIFF
--- a/apps/builder/app/builder/shared/assets/use-assets.tsx
+++ b/apps/builder/app/builder/shared/assets/use-assets.tsx
@@ -110,7 +110,6 @@ const uploadAsset = async ({
   authToken,
   projectId,
   assetId,
-  type,
   file,
   onCompleted,
   onError,
@@ -118,7 +117,6 @@ const uploadAsset = async ({
   authToken: undefined | string;
   projectId: string;
   assetId: string;
-  type: string;
   file: File;
   onCompleted: (data: UploadData) => void;
   onError: (error: string) => void;
@@ -127,6 +125,7 @@ const uploadAsset = async ({
     const metaFormData = new FormData();
     metaFormData.append("projectId", projectId);
     metaFormData.append("assetId", assetId);
+    metaFormData.append("type", file.type);
     // sanitizeS3Key here is just because of https://github.com/remix-run/remix/issues/4443
     // should be removed after fix
     metaFormData.append("filename", sanitizeS3Key(file.name));
@@ -141,7 +140,7 @@ const uploadAsset = async ({
     }
 
     const uploadFormData = new FormData();
-    uploadFormData.append(type, file, metaData.name);
+    uploadFormData.append("file", file, metaData.name);
     const uploadResponse = await fetch(
       restAssetsUploadPath({ name: metaData.name }),
       {
@@ -200,7 +199,6 @@ export const useUploadAsset = () => {
         projectId,
         assetId,
         file: fileData.file,
-        type,
         onCompleted: (data) => {
           URL.revokeObjectURL(fileData.objectURL);
           deleteUploadingFileData(assetId);

--- a/apps/builder/app/routes/rest.assets.tsx
+++ b/apps/builder/app/routes/rest.assets.tsx
@@ -29,14 +29,21 @@ export const action = async (props: ActionArgs) => {
       const formData = await request.formData();
       const projectId = formData.get("projectId") as string;
       const assetId = formData.get("assetId") as string;
+      const type = formData.get("type") as string;
       const filename = formData.get("filename") as string;
-      if (projectId === null || assetId === null || filename === null) {
+      if (
+        projectId === null ||
+        assetId === null ||
+        type === null ||
+        filename === null
+      ) {
         throw Error("Project id, asset id or filename are missing");
       }
       const name = await createUploadName(
         {
           projectId,
           assetId,
+          type,
           filename,
           maxAssetsPerProject: MaxAssets.parse(env.MAX_ASSETS_PER_PROJECT),
         },

--- a/packages/asset-uploader/src/client.ts
+++ b/packages/asset-uploader/src/client.ts
@@ -1,6 +1,10 @@
 import type { AssetData } from "./utils/get-asset-data";
 
 export type AssetClient = {
-  uploadFile: (request: Request) => Promise<AssetData>;
+  uploadFile: (
+    name: string,
+    type: string,
+    request: Request
+  ) => Promise<AssetData>;
   deleteFile: (name: string) => Promise<void>;
 };

--- a/packages/asset-uploader/src/clients/fs/fs.ts
+++ b/packages/asset-uploader/src/clients/fs/fs.ts
@@ -9,8 +9,10 @@ type FsClientOptions = {
 
 export const createFsClient = (options: FsClientOptions): AssetClient => {
   return {
-    uploadFile: (request) =>
+    uploadFile: (name, type, request) =>
       uploadToFs({
+        name,
+        type,
         request,
         maxSize: options.maxUploadSize,
         fileDirectory: options.fileDirectory,

--- a/packages/asset-uploader/src/clients/s3/s3.ts
+++ b/packages/asset-uploader/src/clients/s3/s3.ts
@@ -23,9 +23,11 @@ export const createS3Client = (options: S3ClientOptions): AssetClient => {
     },
   });
 
-  const uploadFile: AssetClient["uploadFile"] = async (request) => {
+  const uploadFile: AssetClient["uploadFile"] = async (name, type, request) => {
     return await uploadToS3({
       client,
+      name,
+      type,
       request,
       maxSize: options.maxUploadSize,
       bucket: options.bucket,

--- a/packages/asset-uploader/src/upload.ts
+++ b/packages/asset-uploader/src/upload.ts
@@ -12,6 +12,7 @@ import { formatAsset } from "./utils/format-asset";
 type UploadData = {
   projectId: string;
   assetId: string;
+  type: string;
   filename: string;
   maxAssetsPerProject: number;
 };
@@ -22,7 +23,7 @@ export const createUploadName = async (
   data: UploadData,
   context: AppContext
 ) => {
-  const { projectId, maxAssetsPerProject, assetId, filename } = data;
+  const { projectId, maxAssetsPerProject, assetId, type, filename } = data;
   const canEdit = await authorizeProject.hasProjectPermit(
     { projectId, permit: "edit" },
     context
@@ -85,13 +86,14 @@ export const createUploadName = async (
         create: {
           name,
           status: "UPLOADING",
-          format: "unknown",
+          // store content type in relative field
+          format: type,
           size: 0,
         },
       },
       // @todo remove once legacy fields are removed from schema
       status: "UPLOADING",
-      format: "unknown",
+      format: type,
       size: 0,
     },
   });
@@ -103,6 +105,11 @@ export const uploadFile = async (
   client: AssetClient
 ) => {
   const asset = await prisma.asset.findFirst({
+    select: {
+      id: true,
+      projectId: true,
+      file: true,
+    },
     where: {
       name,
       file: {
@@ -116,7 +123,7 @@ export const uploadFile = async (
   }
 
   try {
-    const assetData = await client.uploadFile(request);
+    const assetData = await client.uploadFile(name, asset.file.format, request);
     const { meta, format, location, size } = assetData;
     const dbAsset = await prisma.asset.update({
       select: {

--- a/packages/asset-uploader/src/upload.ts
+++ b/packages/asset-uploader/src/upload.ts
@@ -86,7 +86,7 @@ export const createUploadName = async (
         create: {
           name,
           status: "UPLOADING",
-          // store content type in relative field
+          // store content type in related field
           format: type,
           size: 0,
         },


### PR DESCRIPTION
Content type is important when detect image or font parser and required (or recommended?) for uploading to s3.

Here temporary saved it in File.format and reuse in upload. Later overriden with parsed format.

This is a preparation to uploading only blob without additional information.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
