### PR TITLE
Fix types

### DIFF
--- a/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
+++ b/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
@@ -79,7 +79,7 @@ export const SelectedInstanceConnector = ({
   instanceProps,
   instanceSelector,
 }: {
-  instanceElementRef: { current: undefined | HTMLElement };
+  instanceElementRef: { current: null | HTMLElement };
   instance: Instance;
   instanceStyles: StyleDecl[];
   instanceProps: undefined | Prop[];
@@ -93,7 +93,7 @@ export const SelectedInstanceConnector = ({
     setDataCollapsed(instance.id, true);
 
     const element = instanceElementRef.current;
-    if (element === undefined) {
+    if (element == null) {
       return;
     }
     const showOutline = () => {

--- a/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
+++ b/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
@@ -93,7 +93,7 @@ export const SelectedInstanceConnector = ({
     setDataCollapsed(instance.id, true);
 
     const element = instanceElementRef.current;
-    if (element == null) {
+    if (element === null) {
       return;
     }
     const showOutline = () => {

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -40,6 +40,8 @@ const ContentEditable = ({
 }: {
   Component: NonNullable<ReturnType<GetComponent>>;
   elementRef: { current: null | HTMLElement };
+  [idAttribute]: Instance["id"];
+  [componentAttribute]: Instance["component"];
 }) => {
   const [editor] = useLexicalComposerContext();
 

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -39,14 +39,14 @@ const ContentEditable = ({
   ...props
 }: {
   Component: NonNullable<ReturnType<GetComponent>>;
-  elementRef: { current: undefined | HTMLElement };
+  elementRef: { current: null | HTMLElement };
 }) => {
   const [editor] = useLexicalComposerContext();
 
   const ref = useCallback(
     (rootElement: null | HTMLElement) => {
       editor.setRootElement(rootElement);
-      elementRef.current = rootElement ?? undefined;
+      elementRef.current = rootElement ?? null;
     },
     [editor, elementRef]
   );
@@ -101,7 +101,7 @@ export const WebstudioComponentDev = ({
   getComponent,
 }: WebstudioComponentDevProps) => {
   const instanceId = instance.id;
-  const instanceElementRef = useRef<HTMLElement>();
+  const instanceElementRef = useRef<HTMLElement>(null);
   const instanceStyles = useInstanceStyles(instanceId);
   useCssRules({ instanceId: instance.id, instanceStyles });
   const instances = useStore(instancesStore);

--- a/apps/builder/app/canvas/shared/use-pointer-outline.ts
+++ b/apps/builder/app/canvas/shared/use-pointer-outline.ts
@@ -18,6 +18,7 @@ export const usePointerOutline = () => {
     ref.current = div;
     return () => {
       document.body.removeChild(div);
+      ref.current = undefined;
     };
   }, []);
 

--- a/packages/react-sdk/src/components/components-utils.ts
+++ b/packages/react-sdk/src/components/components-utils.ts
@@ -1,4 +1,4 @@
-import type { forwardRef } from "react";
+import type { UnionToIntersection } from "type-fest";
 import * as components from "./components";
 import { registeredComponents } from "./index";
 
@@ -57,7 +57,9 @@ export const getComponentNames = (): ComponentName[] => {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyComponent = ReturnType<typeof forwardRef<any, any>>;
+type AnyComponent = UnionToIntersection<
+  (typeof components)[keyof typeof components]
+>;
 
 /**
  * Now used only in builder app
@@ -65,8 +67,8 @@ type AnyComponent = ReturnType<typeof forwardRef<any, any>>;
  */
 export const getComponent = (name: string): undefined | AnyComponent => {
   return registeredComponents != null && name in registeredComponents
-    ? (registeredComponents[name as ComponentName] as AnyComponent)
-    : components[name as ComponentName];
+    ? (registeredComponents[name as ComponentName] as never)
+    : (components[name as ComponentName] as never);
 };
 
 /**
@@ -78,8 +80,8 @@ export const getComponent = (name: string): undefined | AnyComponent => {
 export const createGetComponent = (comps: Partial<typeof components>) => {
   return (name: string): undefined | AnyComponent => {
     return registeredComponents != null && name in registeredComponents
-      ? (registeredComponents[name as ComponentName] as AnyComponent)
-      : comps[name as ComponentName];
+      ? (registeredComponents[name as ComponentName] as never)
+      : (comps[name as ComponentName] as never);
   };
 };
 

--- a/packages/react-sdk/src/components/components-utils.ts
+++ b/packages/react-sdk/src/components/components-utils.ts
@@ -1,6 +1,6 @@
-import type { UnionToIntersection } from "type-fest";
 import * as components from "./components";
 import { registeredComponents } from "./index";
+import { componentAttribute, idAttribute } from "../tree";
 
 export type ComponentName = keyof typeof components;
 
@@ -57,8 +57,14 @@ export const getComponentNames = (): ComponentName[] => {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyComponent = UnionToIntersection<
-  (typeof components)[keyof typeof components]
+type AnyComponent = React.ForwardRefExoticComponent<
+  Omit<
+    React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>,
+    "ref"
+  > & {
+    [componentAttribute]: string;
+    [idAttribute]: string;
+  } & React.RefAttributes<HTMLElement>
 >;
 
 /**


### PR DESCRIPTION
## Description

Makes AllComponent type better


Found null bug.

Enforced for all components 
```
    [componentAttribute]: instance.component,
    [idAttribute]: instance.id,
```
to be non-optional. 

cc @TrySound should fix your issue with Html component


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
