### PR TITLE
Fix breakpoints width and rendering

### DIFF
--- a/apps/builder/app/builder/features/breakpoints/use-set-initial-canvas-width.ts
+++ b/apps/builder/app/builder/features/breakpoints/use-set-initial-canvas-width.ts
@@ -51,7 +51,7 @@ export const useSetCanvasWidth = () => {
       const breakpointValues = Array.from(breakpoints.values());
       const selectedBreakpoint = selectedBreakpointStore.get();
 
-      // When there is base breakpoint, we want to find the lowest possible size
+      // When there is selected breakpoint, we want to find the lowest possible size
       // that is bigger than all max breakpoints and smaller than all min breakpoints.
       if (selectedBreakpoint) {
         const width = findInitialWidth(

--- a/apps/builder/app/builder/features/breakpoints/use-set-initial-canvas-width.ts
+++ b/apps/builder/app/builder/features/breakpoints/use-set-initial-canvas-width.ts
@@ -6,9 +6,11 @@ import {
   workspaceRectStore,
   canvasWidthStore,
 } from "~/builder/shared/nano-states";
-import { breakpointsStore } from "~/shared/nano-states";
+import {
+  breakpointsStore,
+  selectedBreakpointStore,
+} from "~/shared/nano-states";
 import { findInitialWidth } from "./find-initial-width";
-import { isBaseBreakpoint } from "~/shared/breakpoints";
 
 // Set canvas width based on workspace width, breakpoints and passed breakpoint id.
 export const useSetInitialCanvasWidth = () => {
@@ -47,14 +49,14 @@ export const useSetCanvasWidth = () => {
         return;
       }
       const breakpointValues = Array.from(breakpoints.values());
-      const baseBreakpoint = breakpointValues.find(isBaseBreakpoint);
+      const selectedBreakpoint = selectedBreakpointStore.get();
 
       // When there is base breakpoint, we want to find the lowest possible size
       // that is bigger than all max breakpoints and smaller than all min breakpoints.
-      if (baseBreakpoint) {
+      if (selectedBreakpoint) {
         const width = findInitialWidth(
           breakpointValues,
-          baseBreakpoint,
+          selectedBreakpoint,
           workspaceRect.width
         );
 
@@ -71,16 +73,14 @@ export const useSetCanvasWidth = () => {
             if (workspaceRect === undefined) {
               return;
             }
-            unsubscribeRectStore();
+            unsubscribeRectStore?.();
             update();
           })
-        : () => {
-            /**/
-          };
+        : undefined;
 
     return () => {
       unsubscribeBreakpointStore();
-      unsubscribeRectStore();
+      unsubscribeRectStore?.();
     };
   }, []);
 };

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -27,10 +27,11 @@ import {
   selectedStyleSourceSelectorStore,
 } from "~/shared/nano-states";
 import {
-  createCssEngine,
-  toValue,
   type StyleRule,
   type PlaintextRule,
+  createCssEngine,
+  toValue,
+  compareMedia,
 } from "@webstudio-is/css-engine";
 import { useSubscribe } from "~/shared/pubsub";
 
@@ -118,7 +119,10 @@ export const GlobalStyles = () => {
   const assets = useStore(assetsStore);
 
   useIsomorphicLayoutEffect(() => {
-    for (const breakpoint of breakpoints.values()) {
+    const sortedBreakpoints = Array.from(breakpoints.values()).sort(
+      compareMedia
+    );
+    for (const breakpoint of sortedBreakpoints) {
       userCssEngine.addMediaRule(breakpoint.id, breakpoint);
     }
     userCssEngine.render();


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/discussions/30

Here fixed width update which always relied on base breakpoint instead of selected one.

Another issue found and fixed is wrong order of rendered breakpoints.

## Code Review

- [ ] hi @rpominov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
