### PR TITLE
Fix scroll reset in style panel

### DIFF
--- a/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
+++ b/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
@@ -188,6 +188,8 @@ export const SelectedInstanceConnector = ({
       unsubscribeScrollState();
       unsubscribeWindowResize();
       unsubscribeIsResizingCanvas();
+
+      // see webstudio-component.tsx for where it's set to `false`
       selectedInstanceIsRenderedStore.set(undefined);
     };
   }, [

--- a/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
+++ b/apps/builder/app/canvas/features/webstudio-component/selected-instance-connector.ts
@@ -11,7 +11,6 @@ import {
   selectedInstanceIntanceToTagStore,
   selectedInstanceUnitSizesStore,
   selectedInstanceIsRenderedStore,
-  selectedInstanceSelectorStore,
 } from "~/shared/nano-states";
 import htmlTags, { type htmlTags as HtmlTags } from "html-tags";
 import { getAllElementsBoundingBox } from "~/shared/dom-utils";
@@ -19,10 +18,7 @@ import { subscribeScrollState } from "~/canvas/shared/scroll-state";
 import { selectedInstanceOutlineStore } from "~/shared/nano-states";
 import type { UnitSizes } from "~/builder/features/style-panel/shared/css-value-input/convert-units";
 import { setDataCollapsed } from "~/canvas/collapsed";
-import {
-  areInstanceSelectorsEqual,
-  type InstanceSelector,
-} from "~/shared/tree-utils";
+import { type InstanceSelector } from "~/shared/tree-utils";
 
 const isHtmlTag = (tag: string): tag is HtmlTags =>
   htmlTags.includes(tag as HtmlTags);
@@ -192,19 +188,7 @@ export const SelectedInstanceConnector = ({
       unsubscribeScrollState();
       unsubscribeWindowResize();
       unsubscribeIsResizingCanvas();
-
-      // Retain selectedInstanceIsRenderedStore state if instanceSelector stays the same.
-      // Occasionally, an immediate call to selectedInstanceIsRenderedStore.set(true) may not update StylePanel state
-      // within the same batch as the current effect unsubscribe (e.g., due to delayed postMessage). (and cause to lost scroll position)
-      // This rare issue is difficult to reproduce, occurring roughly once every 100 calls.
-      if (
-        areInstanceSelectorsEqual(
-          selectedInstanceSelectorStore.get(),
-          instanceSelector
-        ) === false
-      ) {
-        selectedInstanceIsRenderedStore.set(false);
-      }
+      selectedInstanceIsRenderedStore.set(undefined);
     };
   }, [
     instanceElementRef,

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -144,12 +144,11 @@ export const WebstudioComponentDev = ({
   }, [isSelected]);
 
   useEffect(() => {
-    // `length === 1` means this is root
+    // 1 means root
     if (instanceSelector.length === 1) {
-      // By the time root is rendered, the new selected instance should be rendered too,
-      // and `selectedInstanceIsRendered` should be set to `true`.
-      // If it's still `undefined`, it means selected instance is not on the canvas,
-      // so we set it to `false` here.
+      // If by the time root is rendered,
+      // no selected instance renders and sets `selectedInstanceIsRendered` to `true`,
+      // then it's clear that selected instance will not render at all, so we set it to `false`
       if (selectedInstanceIsRenderedStore.get() === undefined) {
         selectedInstanceIsRenderedStore.set(false);
       }

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -143,6 +143,8 @@ export const WebstudioComponentDev = ({
     }
   }, [isSelected]);
 
+  // this assumes presence of `useStore(selectedInstanceSelectorStore)` above
+  // we rely on root re-rendering after selected instance changes
   useEffect(() => {
     // 1 means root
     if (instanceSelector.length === 1) {

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -17,6 +17,7 @@ import {
 import type { GetComponent } from "@webstudio-is/react-sdk";
 import {
   instancesStore,
+  selectedInstanceIsRenderedStore,
   selectedInstanceSelectorStore,
   selectedStyleSourceSelectorStore,
   useInstanceProps,
@@ -141,6 +142,19 @@ export const WebstudioComponentDev = ({
       });
     }
   }, [isSelected]);
+
+  useEffect(() => {
+    // `length === 1` means this is root
+    if (instanceSelector.length === 1) {
+      // By the time root is rendered, the new selected instance should be rendered too,
+      // and `selectedInstanceIsRendered` should be set to `true`.
+      // If it's still `undefined`, it means selected instance is not on the canvas,
+      // so we set it to `false` here.
+      if (selectedInstanceIsRenderedStore.get() === undefined) {
+        selectedInstanceIsRenderedStore.set(false);
+      }
+    }
+  });
 
   const readonlyProps =
     instance.component === "Input" || instance.component === "Textarea"

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -233,8 +233,13 @@ export const selectedInstanceIntanceToTagStore = atom<
   undefined | Map<Instance["id"], HtmlTags>
 >();
 
-/** Whether or the selected instance is rendered on canvas */
-export const selectedInstanceIsRenderedStore = atom<boolean>(false);
+/**
+ * Whether or the selected instance is rendered on canvas
+ * `true` — rendered
+ * `false` — not rendered
+ * `undefined` — set to `undefined` in the brief moment when selected instance changes
+ **/
+export const selectedInstanceIsRenderedStore = atom<boolean | undefined>(false);
 
 export const selectedInstanceStatesByStyleSourceIdStore = computed(
   [stylesStore, styleSourceSelectionsStore, selectedInstanceSelectorStore],

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -234,10 +234,10 @@ export const selectedInstanceIntanceToTagStore = atom<
 >();
 
 /**
- * Whether or the selected instance is rendered on canvas
- * `true` — rendered
- * `false` — not rendered
- * `undefined` — set to `undefined` in the brief moment when selected instance changes
+ * Whether or not the selected instance is rendered on canvas:
+ * `true` — rendered;
+ * `false` — not rendered;
+ * `undefined` — when selected instance unmounts and we don't know yet whether a new one will mount.
  **/
 export const selectedInstanceIsRenderedStore = atom<boolean | undefined>(false);
 

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -237,7 +237,7 @@ export const selectedInstanceIntanceToTagStore = atom<
  * Whether or not the selected instance is rendered on canvas:
  * `true` — rendered;
  * `false` — not rendered;
- * `undefined` — when selected instance unmounts and we don't know yet whether a new one will mount.
+ * `undefined` — selected instance unmounted and we don't know yet whether a new one will mount.
  **/
 export const selectedInstanceIsRenderedStore = atom<boolean | undefined>(false);
 


### PR DESCRIPTION
## Description

1. Closes #1617

Before this PR `selectedInstanceIsRendered` behaved like this:

Switching to instance that **is** on canvas: `true -> false -> true`
Switching to instance that **is not** on canvas: `true -> false`

Issue: we can't tell apart brief `false` in the first case, and final `false` in the second

After this PR:

Switching to instance that **is** on canvas: `true -> undefined -> true`
Switching to instance that **is not** on canvas: `true -> undefined -> false`

Now we can distinguish temporary `undefined` from permanent `false` and don't hide style panel during `undefined`

## Steps for reproduction

Case 1:

1. Select a Box instance
2. Scroll style panel
3. Select another Box instance
4. Scroll should not reset

Case 2:

1. Select a Box instance
2. Select a Success Message instance in a Form
3. Style panel should show "Select an instance on the canvas" message 

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
