### PR TITLE
Create assets with patches

### DIFF
--- a/apps/builder/app/builder/shared/assets/use-assets.tsx
+++ b/apps/builder/app/builder/shared/assets/use-assets.tsx
@@ -109,14 +109,12 @@ export type UploadData = ActionData;
 const uploadAsset = async ({
   authToken,
   projectId,
-  assetId,
   file,
   onCompleted,
   onError,
 }: {
   authToken: undefined | string;
   projectId: string;
-  assetId: string;
   file: File;
   onCompleted: (data: UploadData) => void;
   onError: (error: string) => void;
@@ -124,7 +122,6 @@ const uploadAsset = async ({
   try {
     const metaFormData = new FormData();
     metaFormData.append("projectId", projectId);
-    metaFormData.append("assetId", assetId);
     metaFormData.append("type", file.type);
     // sanitizeS3Key here is just because of https://github.com/remix-run/remix/issues/4443
     // should be removed after fix
@@ -174,8 +171,8 @@ export const useUploadAsset = () => {
       return;
     }
 
-    // update store with new asset
-    setAsset(uploadedAsset);
+    // update store with new asset and set current id
+    setAsset({ ...uploadedAsset, id: assetId });
   };
 
   const uploadAssets = (type: AssetType, files: File[]) => {
@@ -195,7 +192,6 @@ export const useUploadAsset = () => {
       uploadAsset({
         authToken,
         projectId,
-        assetId,
         file: fileData.file,
         onCompleted: (data) => {
           URL.revokeObjectURL(fileData.objectURL);

--- a/apps/builder/app/builder/shared/assets/use-assets.tsx
+++ b/apps/builder/app/builder/shared/assets/use-assets.tsx
@@ -38,7 +38,7 @@ const setAsset = (asset: Asset) => {
 };
 
 type FileData = {
-  id: string;
+  assetId: string;
   type: AssetType;
   file: File;
   objectURL: string;
@@ -47,7 +47,7 @@ type FileData = {
 const getFilesData = (type: AssetType, files: File[]): FileData[] => {
   return files.map((file) => {
     return {
-      id: crypto.randomUUID(),
+      assetId: crypto.randomUUID(),
       type,
       file,
       objectURL: URL.createObjectURL(file),
@@ -62,10 +62,10 @@ const addUploadingFilesData = (filesData: FileData[]) => {
   uploadingFilesDataStore.set([...uploadingFilesData, ...filesData]);
 };
 
-const deleteUploadingFileData = (id: FileData["id"]) => {
+const deleteUploadingFileData = (id: FileData["assetId"]) => {
   const uploadingFilesData = uploadingFilesDataStore.get();
   uploadingFilesDataStore.set(
-    uploadingFilesData.filter((fileData) => fileData.id !== id)
+    uploadingFilesData.filter((fileData) => fileData.assetId !== id)
   );
 };
 
@@ -73,12 +73,12 @@ const assetContainersStore = computed(
   [assetsStore, uploadingFilesDataStore],
   (assets, uploadingFilesData) => {
     const uploadingAssets = new Map<PreviewAsset["id"], AssetContainer>();
-    for (const { id, type, file, objectURL } of uploadingFilesData) {
-      uploadingAssets.set(id, {
+    for (const { assetId, type, file, objectURL } of uploadingFilesData) {
+      uploadingAssets.set(assetId, {
         status: "uploading",
         objectURL: objectURL,
         asset: {
-          id,
+          id: assetId,
           type,
           format: file.type.split("/")[1],
           name: file.name,
@@ -185,10 +185,10 @@ export const useUploadAsset = () => {
     const filesData = getFilesData(type, files);
 
     addUploadingFilesData(filesData);
-    stubAssets(filesData.map((fileData) => fileData.id));
+    stubAssets(filesData.map((fileData) => fileData.assetId));
 
     for (const fileData of filesData) {
-      const assetId = fileData.id;
+      const assetId = fileData.assetId;
       uploadAsset({
         authToken,
         projectId,

--- a/apps/builder/app/routes/rest.assets.tsx
+++ b/apps/builder/app/routes/rest.assets.tsx
@@ -28,21 +28,14 @@ export const action = async (props: ActionArgs) => {
     if (request.method === "POST") {
       const formData = await request.formData();
       const projectId = formData.get("projectId") as string;
-      const assetId = formData.get("assetId") as string;
       const type = formData.get("type") as string;
       const filename = formData.get("filename") as string;
-      if (
-        projectId === null ||
-        assetId === null ||
-        type === null ||
-        filename === null
-      ) {
+      if (projectId === null || type === null || filename === null) {
         throw Error("Project id, asset id or filename are missing");
       }
       const name = await createUploadName(
         {
           projectId,
-          assetId,
           type,
           filename,
           maxAssetsPerProject: MaxAssets.parse(env.MAX_ASSETS_PER_PROJECT),

--- a/packages/asset-uploader/src/delete.ts
+++ b/packages/asset-uploader/src/delete.ts
@@ -6,7 +6,6 @@ import {
 } from "@webstudio-is/trpc-interface/index.server";
 import type { AssetClient } from "./client";
 import type { Asset } from "./schema";
-import { formatAsset } from "./utils/format-asset";
 
 export const deleteAssets = async (
   props: {
@@ -15,7 +14,7 @@ export const deleteAssets = async (
   },
   context: AppContext,
   client: AssetClient
-): Promise<Array<Asset>> => {
+) => {
   const canDelete = await authorizeProject.hasProjectPermit(
     { projectId: props.projectId, permit: "edit" },
     context
@@ -62,6 +61,4 @@ export const deleteAssets = async (
   for (const name of unusedFileNames) {
     await client.deleteFile(name);
   }
-
-  return assets.map((asset) => formatAsset(asset, asset.file));
 };

--- a/packages/asset-uploader/src/utils/format-asset.ts
+++ b/packages/asset-uploader/src/utils/format-asset.ts
@@ -9,7 +9,7 @@ import { type Asset, ImageMeta } from "../schema";
 // @todo remove once legacy fields are removed from schema
 type DbAssetWithoutOldFields = Omit<
   DbAsset,
-  "size" | "format" | "meta" | "status" | "description" | "createdAt"
+  "name" | "size" | "format" | "meta" | "status" | "description" | "createdAt"
 >;
 
 export const formatAsset = (


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1335

Successor of https://github.com/webstudio-is/webstudio-builder/pull/1376

Assets no longer created while uploading. Asset patch now tracks new assets to save in db.

## Code Review

- [ ] hi @rpominov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
- [ ] hi @istarkov, I need you to do
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
