### PR TITLE
Drop unused asset table fields

### DIFF
--- a/apps/builder/app/builder/features/props-panel/props-panel.stories.tsx
+++ b/apps/builder/app/builder/features/props-panel/props-panel.stories.tsx
@@ -97,7 +97,6 @@ const imageAsset = (name = "cat", format = "jpg"): Asset => ({
   type: "image",
   name: `${name}.${format}`,
   format: format,
-  location: "FS",
   size: 100000,
   createdAt: new Date().toISOString(),
   description: null,

--- a/apps/builder/app/builder/features/style-panel/controls/font-weight/is-supported-font-weight.test.ts
+++ b/apps/builder/app/builder/features/style-panel/controls/font-weight/is-supported-font-weight.test.ts
@@ -6,7 +6,6 @@ const createServerAsset = (meta: FontAsset["meta"]): FontAsset => ({
   id: "111",
   type: "font",
   name: "test",
-  location: "FS",
   projectId: "id",
   size: 2135,
   format: "ttf",

--- a/packages/asset-uploader/src/clients/fs/upload.ts
+++ b/packages/asset-uploader/src/clients/fs/upload.ts
@@ -1,6 +1,5 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
-import { Location } from "@webstudio-is/prisma-client";
 import { getAssetData } from "../../utils/get-asset-data";
 import { toUint8Array } from "../../utils/to-uint8-array";
 import { createSizeLimiter } from "../../utils/size-limiter";
@@ -31,7 +30,6 @@ export const uploadToFs = async ({
     type: type.startsWith("image") ? "image" : "font",
     size: data.byteLength,
     data,
-    location: Location.FS,
   });
 
   return assetData;

--- a/packages/asset-uploader/src/clients/s3/upload.ts
+++ b/packages/asset-uploader/src/clients/s3/upload.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import type { PutObjectCommandInput, S3Client } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
-import { Location } from "@webstudio-is/prisma-client";
 import { toUint8Array } from "../../utils/to-uint8-array";
 import { getAssetData } from "../../utils/get-asset-data";
 import { createSizeLimiter } from "../../utils/size-limiter";
@@ -59,7 +58,6 @@ export const uploadToS3 = async ({
     type: type.startsWith("image") ? "image" : "font",
     size: data.byteLength,
     data,
-    location: Location.REMOTE,
   });
 
   return assetData;

--- a/packages/asset-uploader/src/db/load.ts
+++ b/packages/asset-uploader/src/db/load.ts
@@ -27,8 +27,6 @@ export const loadAssetsByProject = async (
       file: true,
       id: true,
       projectId: true,
-      name: true,
-      location: true,
     },
     where: {
       projectId,
@@ -39,5 +37,11 @@ export const loadAssetsByProject = async (
     },
   });
 
-  return assets.map((asset) => formatAsset(asset, asset.file));
+  return assets.map((asset) =>
+    formatAsset({
+      assetId: asset.id,
+      projectId: asset.projectId,
+      file: asset.file,
+    })
+  );
 };

--- a/packages/asset-uploader/src/delete.ts
+++ b/packages/asset-uploader/src/delete.ts
@@ -30,7 +30,6 @@ export const deleteAssets = async (
       id: true,
       projectId: true,
       name: true,
-      location: true,
     },
     where: { id: { in: props.ids }, projectId: props.projectId },
   });

--- a/packages/asset-uploader/src/patch.ts
+++ b/packages/asset-uploader/src/patch.ts
@@ -77,12 +77,6 @@ export const patchAssets = async (
           id: asset.id,
           projectId,
           name: asset.name,
-          // @todo remove once legacy fields are removed from schema
-          location: asset.location,
-          size: asset.size,
-          format: asset.format,
-          meta: JSON.stringify(asset.meta),
-          status: "UPLOADED",
         })),
     });
   }

--- a/packages/asset-uploader/src/schema.ts
+++ b/packages/asset-uploader/src/schema.ts
@@ -17,9 +17,6 @@ export const MaxSize = z
 
 export const MaxAssets = z.string().default("50").transform(Number.parseFloat);
 
-export const Location = z.union([z.literal("FS"), z.literal("REMOTE")]);
-export type Location = z.infer<typeof Location>;
-
 const AssetId = z.string();
 
 const BaseAsset = z.object({
@@ -29,7 +26,6 @@ const BaseAsset = z.object({
   size: z.number(),
   name: z.string(),
   description: z.union([z.string(), z.null()]),
-  location: Location,
   createdAt: z.string(),
 });
 

--- a/packages/asset-uploader/src/upload.ts
+++ b/packages/asset-uploader/src/upload.ts
@@ -114,7 +114,7 @@ export const uploadFile = async (
       // global web streams types do not define ReadableStream as async iterable
       data as unknown as AsyncIterable<Uint8Array>
     );
-    const { meta, format, location, size } = assetData;
+    const { meta, format, size } = assetData;
     const dbFile = await prisma.file.update({
       where: {
         name,
@@ -126,14 +126,11 @@ export const uploadFile = async (
         status: "UPLOADED",
       },
     });
-    return formatAsset(
-      {
-        id: "",
-        projectId: dbFile.uploaderProjectId as string,
-        location,
-      },
-      dbFile
-    );
+    return formatAsset({
+      assetId: "",
+      projectId: dbFile.uploaderProjectId as string,
+      file: dbFile,
+    });
   } catch (error) {
     await prisma.file.delete({
       where: {

--- a/packages/asset-uploader/src/utils/format-asset.ts
+++ b/packages/asset-uploader/src/utils/format-asset.ts
@@ -1,30 +1,25 @@
-import type {
-  Asset as DbAsset,
-  File as DbFile,
-} from "@webstudio-is/prisma-client";
+import type { File as DbFile } from "@webstudio-is/prisma-client";
 import { type FontFormat, FONT_FORMATS } from "@webstudio-is/fonts";
 import { FontMeta } from "@webstudio-is/fonts";
 import { type Asset, ImageMeta } from "../schema";
 
-// @todo remove once legacy fields are removed from schema
-type DbAssetWithoutOldFields = Omit<
-  DbAsset,
-  "name" | "size" | "format" | "meta" | "status" | "description" | "createdAt"
->;
-
-export const formatAsset = (
-  asset: DbAssetWithoutOldFields,
-  file: DbFile
-): Asset => {
+export const formatAsset = ({
+  assetId,
+  projectId,
+  file,
+}: {
+  assetId: string;
+  projectId: string;
+  file: DbFile;
+}): Asset => {
   const isFont = FONT_FORMATS.has(file.format as FontFormat);
 
   if (isFont) {
     return {
-      id: asset.id,
+      id: assetId,
       name: file.name,
       description: file.description,
-      location: asset.location,
-      projectId: asset.projectId,
+      projectId,
       size: file.size,
       type: "font",
       createdAt: file.createdAt.toISOString(),
@@ -34,11 +29,10 @@ export const formatAsset = (
   }
 
   return {
-    id: asset.id,
+    id: assetId,
     name: file.name,
     description: file.description,
-    location: asset.location,
-    projectId: asset.projectId,
+    projectId,
     size: file.size,
     type: "image",
     format: file.format,

--- a/packages/asset-uploader/src/utils/get-asset-data.ts
+++ b/packages/asset-uploader/src/utils/get-asset-data.ts
@@ -2,11 +2,10 @@ import { z } from "zod";
 import sharp from "sharp";
 import { FontMeta } from "@webstudio-is/fonts";
 import { getFontData } from "@webstudio-is/fonts/index.server";
-import { Location, ImageMeta } from "../schema";
+import { ImageMeta } from "../schema";
 
 export const AssetData = z.object({
   size: z.number(),
-  location: Location,
   format: z.string(),
   meta: z.union([ImageMeta, FontMeta]),
 });
@@ -16,7 +15,6 @@ export type AssetData = z.infer<typeof AssetData>;
 type BaseAssetOptions = {
   size: number;
   data: Uint8Array;
-  location: Location;
 };
 
 type AssetOptions =
@@ -40,7 +38,6 @@ export const getAssetData = async (
 
     return {
       size: options.size,
-      location: options.location,
       format,
       meta: { width, height },
     };
@@ -50,7 +47,6 @@ export const getAssetData = async (
 
   return {
     size: options.size,
-    location: options.location,
     format,
     meta,
   };

--- a/packages/prisma-client/prisma/migrations/20230514234913_drop_unused_asset_fields/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20230514234913_drop_unused_asset_fields/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "Asset" DROP COLUMN "createdAt",
+DROP COLUMN "description",
+DROP COLUMN "format",
+DROP COLUMN "location",
+DROP COLUMN "meta",
+DROP COLUMN "size",
+DROP COLUMN "status";

--- a/packages/prisma-client/prisma/migrations/20230530155049_drop_unused_asset_fields/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20230530155049_drop_unused_asset_fields/migration.sql
@@ -6,3 +6,6 @@ DROP COLUMN "location",
 DROP COLUMN "meta",
 DROP COLUMN "size",
 DROP COLUMN "status";
+
+-- DropEnum
+DROP TYPE "Location";

--- a/packages/prisma-client/prisma/schema.prisma
+++ b/packages/prisma-client/prisma/schema.prisma
@@ -50,15 +50,6 @@ model Asset {
   projectId String
   file      File     @relation(fields: [name], references: [name])
   name      String
-  location  Location
-
-  // @todo remove these fields from schema and db after release
-  format      String
-  size        Int
-  description String?
-  createdAt   DateTime     @default(now())
-  meta        String       @default("{}")
-  status      UploadStatus @default(UPLOADED)
 
   @@id([id, projectId])
 }

--- a/packages/prisma-client/prisma/schema.prisma
+++ b/packages/prisma-client/prisma/schema.prisma
@@ -20,11 +20,6 @@ model Team {
   users User[]
 }
 
-enum Location {
-  FS
-  REMOTE
-}
-
 enum UploadStatus {
   UPLOADING
   UPLOADED

--- a/packages/prisma-client/src/types.ts
+++ b/packages/prisma-client/src/types.ts
@@ -1,4 +1,3 @@
-export { Location } from "./__generated__";
 export type {
   User,
   Build,

--- a/packages/react-sdk/src/props.test.ts
+++ b/packages/react-sdk/src/props.test.ts
@@ -31,7 +31,6 @@ describe("resolveUrlProp", () => {
     id: unique(),
     name: unique(),
     type: "image",
-    location: "REMOTE",
     projectId,
     format: "png",
     size: 100000,


### PR DESCRIPTION
Cleanup after refactoring. Now we can get rid of Asset.location because asset location is defined by environment. And remove fields moved to File table.

Should be merged after release.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
