### PR TITLE
Support bold and normal font-weight

### DIFF
--- a/apps/builder/app/builder/features/style-panel/controls/font-weight/font-weight-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/font-weight/font-weight-control.tsx
@@ -49,6 +49,13 @@ const useLabels = (
   availableFontWeights: Array<FontWeightItem>,
   currentWeight: string
 ) => {
+  // support named aliases
+  if (currentWeight === "normal") {
+    currentWeight = "400";
+  }
+  if (currentWeight === "bold") {
+    currentWeight = "700";
+  }
   const labels = useMemo(
     () => availableFontWeights.map((option) => option.label),
     [availableFontWeights]

--- a/packages/css-data/bin/mdn-data.ts
+++ b/packages/css-data/bin/mdn-data.ts
@@ -65,16 +65,6 @@ const beautifyKeyword = (property: string, keyword: string) => {
   if (keyword === "currentcolor" || keyword === "invertOrCurrentColor") {
     return "currentColor";
   }
-  // builder style panel cannot interpret "normal" and "bold"
-  // always expected numeric value
-  if (property === "font-weight") {
-    if (keyword === "normal") {
-      return "400";
-    }
-    if (keyword === "bold") {
-      return "700";
-    }
-  }
   return keyword;
 };
 

--- a/packages/css-data/src/__generated__/keyword-values.ts
+++ b/packages/css-data/src/__generated__/keyword-values.ts
@@ -3836,8 +3836,8 @@ export const keywordValues = {
     "unset",
   ],
   fontWeight: [
-    "400",
-    "700",
+    "normal",
+    "bold",
     "bolder",
     "lighter",
     "initial",

--- a/packages/css-data/src/__generated__/properties.ts
+++ b/packages/css-data/src/__generated__/properties.ts
@@ -1445,7 +1445,7 @@ export const properties = {
     inherited: true,
     initial: {
       type: "keyword",
-      value: "400",
+      value: "normal",
     },
     popularity: 0.88598106,
     appliesTo: "allElements",

--- a/packages/css-data/src/html.ts
+++ b/packages/css-data/src/html.ts
@@ -48,9 +48,7 @@ const pl40px: Styles[number] = {
 
 const fontWeightBold: Styles[number] = {
   property: "fontWeight",
-  // in browsers defined as bold
-  // though builder accepts only numeric values
-  value: { type: "keyword", value: "700" },
+  value: { type: "keyword", value: "bold" },
 };
 
 const fontStyleItalic: Styles[number] = {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1535

Here instead of hacky preconverting to numeric font-weight value support "normal" and "bold" as input for font weight control.

Defaults can be checked on h1 and body.

## Code Review

- [ ] hi @rpominov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
