### PR TITLE
Register props meta into store

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -21,6 +21,7 @@ import {
 import { usePublishShortcuts } from "./shared/shortcuts";
 import {
   projectStore,
+  registeredComponentPropsMetasStore,
   selectedPageIdStore,
   useIsPreviewMode,
   useSetAssets,
@@ -45,9 +46,7 @@ import { BlockingAlerts } from "./features/blocking-alerts";
 import { useStore } from "@nanostores/react";
 import {
   customComponentMetas,
-  customComponentPropsMetas,
   registerComponentMetas,
-  registerComponentPropsMetas,
 } from "@webstudio-is/react-sdk";
 
 registerContainers();
@@ -239,7 +238,6 @@ export type BuilderProps = {
 // @todo: Don't do this in builder
 // https://github.com/webstudio-is/webstudio-builder/issues/1545
 registerComponentMetas(customComponentMetas);
-registerComponentPropsMetas(customComponentPropsMetas);
 
 export const Builder = ({
   project,

--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -21,7 +21,6 @@ import {
 import { usePublishShortcuts } from "./shared/shortcuts";
 import {
   projectStore,
-  registeredComponentPropsMetasStore,
   selectedPageIdStore,
   useIsPreviewMode,
   useSetAssets,

--- a/apps/builder/app/builder/features/props-panel/props-panel.tsx
+++ b/apps/builder/app/builder/features/props-panel/props-panel.tsx
@@ -1,3 +1,4 @@
+import { useStore } from "@nanostores/react";
 import store from "immerhin";
 import type { Instance } from "@webstudio-is/project-build";
 import {
@@ -16,8 +17,16 @@ import {
   InputField,
   NestedInputButton,
 } from "@webstudio-is/design-system";
+import {
+  type WsComponentMeta,
+  getComponentMeta,
+} from "@webstudio-is/react-sdk";
 import type { Publish } from "~/shared/pubsub";
-import { propsStore, useInstanceProps } from "~/shared/nano-states";
+import {
+  propsStore,
+  registeredComponentPropsMetasStore,
+  useInstanceProps,
+} from "~/shared/nano-states";
 import { CollapsibleSectionWithAddButton } from "~/builder/shared/collapsible-section";
 import {
   useStyleData,
@@ -31,11 +40,6 @@ import {
 } from "./use-props-logic";
 import { getLabel } from "./shared";
 import { useState, type ReactNode } from "react";
-import {
-  getComponentPropsMeta,
-  getComponentMeta,
-  type WsComponentMeta,
-} from "@webstudio-is/react-sdk";
 import { getInstanceLabel } from "~/builder/shared/tree";
 import { MetaIcon } from "~/builder/shared/meta-icon";
 
@@ -247,7 +251,9 @@ export const PropsPanelContainer = ({
   publish: Publish;
   selectedInstance: Instance;
 }) => {
-  const propsMeta = getComponentPropsMeta(instance.component);
+  const propsMeta = useStore(registeredComponentPropsMetasStore).get(
+    instance.component
+  );
   if (propsMeta === undefined) {
     throw new Error(`Could not get meta for compoent "${instance.component}"`);
   }

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -1,13 +1,15 @@
 import { useMemo, useEffect } from "react";
 import { useStore } from "@nanostores/react";
 import { computed } from "nanostores";
-import type { Params } from "@webstudio-is/react-sdk";
+import {
+  type Params,
+  defaultPropsMetas,
+  registerComponentMetas,
+} from "@webstudio-is/react-sdk";
 import type { Instances, Page } from "@webstudio-is/project-build";
 import {
   createElementsTree,
   registerComponents,
-  registerComponentPropsMetas,
-  registerComponentMetas,
   customComponentMetas,
   customComponentPropsMetas,
   setParams,
@@ -31,9 +33,12 @@ import {
   instancesStore,
   useIsPreviewMode,
   selectedPageStore,
+  registerComponentPropsMetas,
+  registeredComponentPropsMetasStore,
 } from "~/shared/nano-states";
 import { useDragAndDrop } from "./shared/use-drag-drop";
 import { useCopyPaste } from "~/shared/copy-paste";
+import { useSyncInitializeOnce } from "~/shared/hook-utils";
 import { setDataCollapsed, subscribeCollapsedToPubSub } from "./collapsed";
 import { useWindowResizeDebounced } from "~/shared/dom-hooks";
 import { subscribeInstanceSelection } from "./instance-selection";
@@ -133,7 +138,10 @@ export const Canvas = ({
 
   registerComponents(customComponents);
   registerComponentMetas(customComponentMetas);
-  registerComponentPropsMetas(customComponentPropsMetas);
+  useSyncInitializeOnce(() => {
+    registerComponentPropsMetas(defaultPropsMetas);
+    registerComponentPropsMetas(customComponentPropsMetas);
+  });
 
   // e.g. toggling preview is still needed in both modes
   useCanvasShortcuts();

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -34,7 +34,6 @@ import {
   useIsPreviewMode,
   selectedPageStore,
   registerComponentPropsMetas,
-  registeredComponentPropsMetasStore,
 } from "~/shared/nano-states";
 import { useDragAndDrop } from "./shared/use-drag-drop";
 import { useCopyPaste } from "~/shared/copy-paste";

--- a/apps/builder/app/shared/nano-states/components-meta.ts
+++ b/apps/builder/app/shared/nano-states/components-meta.ts
@@ -1,0 +1,32 @@
+import { atom } from "nanostores";
+import type { WsComponentPropsMeta } from "@webstudio-is/react-sdk";
+
+export const registeredComponentPropsMetasStore = atom(
+  new Map<string, WsComponentPropsMeta>()
+);
+
+export const registerComponentPropsMetas = (
+  newPropsMetas: Record<string, WsComponentPropsMeta>
+) => {
+  const prevPropsMetas = registeredComponentPropsMetasStore.get();
+  const nextPropsMetas = new Map(prevPropsMetas);
+  for (const [componentName, propsMeta] of Object.entries(newPropsMetas)) {
+    const { initialProps = [], props } = propsMeta;
+    const requiredProps: string[] = [];
+    for (const [name, value] of Object.entries(props)) {
+      if (value.required && initialProps.includes(name) === false) {
+        requiredProps.push(name);
+      }
+    }
+    nextPropsMetas.set(componentName, {
+      // order of initialProps must be preserved
+      initialProps: [...initialProps, ...requiredProps],
+      props: propsMeta.props,
+    });
+  }
+  registeredComponentPropsMetasStore.set(nextPropsMetas);
+};
+
+export const synchronizedComponentsMetaStores = [
+  ["registeredComponentPropsMetas", registeredComponentPropsMetasStore],
+] as const;

--- a/apps/builder/app/shared/nano-states/index.ts
+++ b/apps/builder/app/shared/nano-states/index.ts
@@ -3,3 +3,4 @@ export * from "./breakpoints";
 export * from "./instances";
 export * from "./canvas";
 export * from "./pages";
+export * from "./components-meta";

--- a/packages/react-sdk/src/components/index.ts
+++ b/packages/react-sdk/src/components/index.ts
@@ -1,4 +1,3 @@
-import { PropMeta } from "@webstudio-is/generate-arg-types";
 import type { WsComponentMeta, WsComponentPropsMeta } from "./component-meta";
 import type { ComponentName } from "./components-utils";
 import { meta as SlotMeta } from "./slot.ws";
@@ -69,7 +68,7 @@ import { propsMeta as CheckboxFieldPropsMeta } from "./checkbox-field.ws";
 import { propsMeta as CheckboxPropsMeta } from "./checkbox.ws";
 
 // @todo this list should not be hardcoded!
-const defaultMetas: Record<string, WsComponentMeta> = {
+export const defaultMetas: Record<string, WsComponentMeta> = {
   Slot: SlotMeta,
   Fragment: FragmentMeta,
   Box: BoxMeta,
@@ -121,7 +120,7 @@ export const registerComponentMetas = (
 };
 
 // @todo this list should not be hardcoded!
-const defaultPropsMetasRaw = {
+export const defaultPropsMetas: Record<string, WsComponentPropsMeta> = {
   Slot: SlotMetaPropsMeta,
   Fragment: FragmentMetaPropsMeta,
   Box: BoxMetaPropsMeta,
@@ -154,44 +153,6 @@ const defaultPropsMetasRaw = {
   RadioButton: RadioButtonPropsMeta,
   CheckboxField: CheckboxFieldPropsMeta,
   Checkbox: CheckboxPropsMeta,
-} as const;
-
-const defaultPropsMetas: Record<string, WsComponentPropsMeta> =
-  defaultPropsMetasRaw;
-
-let registeredPropsMetas: Record<string, Partial<WsComponentPropsMeta>> = {};
-
-// we start as `undefined` because pre-computing will likely kill tree-shaking
-let currentPropsMetas: Record<string, WsComponentPropsMeta> | undefined =
-  undefined;
-
-export const getComponentPropsMeta = (
-  name: string
-): WsComponentPropsMeta | undefined => {
-  if (currentPropsMetas === undefined) {
-    currentPropsMetas = {};
-    for (const name of Object.keys(defaultPropsMetas)) {
-      const props = computeProps(
-        defaultPropsMetas[name],
-        registeredPropsMetas[name] ?? {}
-      );
-      const initialProps = computeInitialProps(
-        props,
-        defaultPropsMetas[name],
-        registeredPropsMetas[name] ?? {}
-      );
-      currentPropsMetas[name] = { props, initialProps };
-    }
-  }
-
-  return currentPropsMetas[name];
-};
-
-export const registerComponentPropsMetas = (
-  metas: Record<string, WsComponentPropsMeta>
-) => {
-  registeredPropsMetas = metas;
-  currentPropsMetas = undefined;
 };
 
 type RegisteredComponents = Partial<{
@@ -208,48 +169,6 @@ export let registeredComponents: RegisteredComponents | undefined;
  **/
 export const registerComponents = (components: RegisteredComponents) => {
   registeredComponents = components;
-};
-
-const computeProps = (
-  defaults: WsComponentPropsMeta,
-  overrides: Partial<WsComponentPropsMeta>
-) => {
-  if (overrides) {
-    const allNames = new Set([
-      ...Object.keys(defaults.props ?? {}),
-      ...Object.keys(overrides?.props ?? {}),
-    ]).values();
-
-    const result: WsComponentPropsMeta["props"] = {};
-    for (const name of allNames) {
-      result[name] = PropMeta.parse({
-        ...defaults.props[name],
-        ...overrides?.props?.[name],
-      });
-    }
-    return result;
-  }
-
-  return defaults.props;
-};
-
-const computeInitialProps = (
-  props: WsComponentPropsMeta["props"],
-  defaults: WsComponentPropsMeta,
-  overrides: Partial<WsComponentPropsMeta>
-): Array<string> => {
-  const initialProps = overrides?.initialProps ?? defaults?.initialProps ?? [];
-  const requiredProps = props
-    ? Object.entries(props)
-        .filter(
-          ([name, value]) =>
-            value?.required && initialProps.includes(name) === false
-        )
-        .map(([name]) => name)
-    : [];
-
-  // order of initialProps must be preserved
-  return [...initialProps, ...requiredProps];
 };
 
 export const canAcceptComponent = (


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1545 https://github.com/webstudio-is/webstudio-builder/issues/1129

Here moved props meta into store. Both default and custom meta should be registered as by default its empty.

Removed merging of overriden props with overrides because our cli still resolves all types in component.

Supported two-directional store initialization by checking if there was any .set calls. This let us send initial data from canvas.

## Code Review

- [ ] hi @rpominov, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
