### PR TITLE
Store component meta in atom

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
@@ -1,10 +1,8 @@
 import { useMemo } from "react";
+import { useStore } from "@nanostores/react";
 import { usePress } from "@react-aria/interactions";
 import {
-  type ComponentName,
   type WsComponentMeta,
-  getComponentMeta,
-  getComponentNames,
   componentCategories,
 } from "@webstudio-is/react-sdk";
 import {
@@ -26,18 +24,17 @@ import {
   useDraggable,
 } from "./use-draggable";
 import { MetaIcon } from "~/builder/shared/meta-icon";
+import { registeredComponentMetasStore } from "~/shared/nano-states";
 
-const getMetaMaps = () => {
-  const metaByComponentName: Map<ComponentName, WsComponentMeta> = new Map();
+const getMetaMaps = (metaByComponentName: Map<string, WsComponentMeta>) => {
   const metaByCategory: Map<
     WsComponentMeta["category"],
     Array<WsComponentMeta>
   > = new Map();
-  const componentNamesByMeta: Map<WsComponentMeta, ComponentName> = new Map();
+  const componentNamesByMeta: Map<WsComponentMeta, string> = new Map();
 
-  for (const name of getComponentNames()) {
-    const meta = getComponentMeta(name);
-    if (meta?.category === undefined) {
+  for (const [name, meta] of metaByComponentName) {
+    if (meta.category === undefined) {
       continue;
     }
     let categoryMetas = metaByCategory.get(meta.category);
@@ -58,9 +55,10 @@ type TabContentProps = {
 };
 
 export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
-  const { metaByComponentName, metaByCategory, componentNamesByMeta } = useMemo(
-    getMetaMaps,
-    []
+  const metaByComponentName = useStore(registeredComponentMetasStore);
+  const { metaByCategory, componentNamesByMeta } = useMemo(
+    () => getMetaMaps(metaByComponentName),
+    [metaByComponentName]
   );
   const { dragCard, handleInsert, draggableContainerRef } = useDraggable({
     publish,

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -1,15 +1,14 @@
 import { useMemo, useEffect } from "react";
 import { useStore } from "@nanostores/react";
 import { computed } from "nanostores";
-import {
-  type Params,
-  defaultPropsMetas,
-  registerComponentMetas,
-} from "@webstudio-is/react-sdk";
 import type { Instances, Page } from "@webstudio-is/project-build";
 import {
+  type Params,
+  defaultMetas,
+  defaultPropsMetas,
   createElementsTree,
   registerComponents,
+  registerComponentMetas as registerComponentMetasLegacy,
   customComponentMetas,
   customComponentPropsMetas,
   setParams,
@@ -33,6 +32,7 @@ import {
   instancesStore,
   useIsPreviewMode,
   selectedPageStore,
+  registerComponentMetas,
   registerComponentPropsMetas,
 } from "~/shared/nano-states";
 import { useDragAndDrop } from "./shared/use-drag-drop";
@@ -136,9 +136,11 @@ export const Canvas = ({
   const [isPreviewMode] = useIsPreviewMode();
 
   registerComponents(customComponents);
-  registerComponentMetas(customComponentMetas);
+  registerComponentMetasLegacy(customComponentMetas);
   useSyncInitializeOnce(() => {
+    registerComponentMetas(defaultMetas);
     registerComponentPropsMetas(defaultPropsMetas);
+    registerComponentMetas(customComponentMetas);
     registerComponentPropsMetas(customComponentPropsMetas);
   });
 

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -5,8 +5,6 @@ import { useStore } from "@nanostores/react";
 import type { Assets } from "@webstudio-is/asset-uploader";
 import {
   collapsedAttribute,
-  getComponentMeta,
-  getComponentNames,
   idAttribute,
   addGlobalRules,
   createImageValueTransformer,
@@ -23,6 +21,7 @@ import {
   assetsStore,
   breakpointsStore,
   isPreviewModeStore,
+  registeredComponentMetasStore,
   selectedInstanceSelectorStore,
   selectedStyleSourceSelectorStore,
 } from "~/shared/nano-states";
@@ -117,6 +116,7 @@ export const useManageDesignModeStyles = () => {
 export const GlobalStyles = () => {
   const breakpoints = useStore(breakpointsStore);
   const assets = useStore(assetsStore);
+  const metas = useStore(registeredComponentMetasStore);
 
   useIsomorphicLayoutEffect(() => {
     const sortedBreakpoints = Array.from(breakpoints.values()).sort(
@@ -140,9 +140,8 @@ export const GlobalStyles = () => {
 
   useIsomorphicLayoutEffect(() => {
     presetStylesEngine.clear();
-    for (const component of getComponentNames()) {
-      const meta = getComponentMeta(component);
-      const presetStyle = meta?.presetStyle;
+    for (const [component, meta] of metas) {
+      const presetStyle = meta.presetStyle;
       if (presetStyle === undefined) {
         continue;
       }
@@ -152,7 +151,7 @@ export const GlobalStyles = () => {
       }
     }
     presetStylesEngine.render();
-  }, []);
+  }, [metas]);
 
   return null;
 };

--- a/apps/builder/app/shared/nano-states/components-meta.ts
+++ b/apps/builder/app/shared/nano-states/components-meta.ts
@@ -1,5 +1,23 @@
 import { atom } from "nanostores";
-import type { WsComponentPropsMeta } from "@webstudio-is/react-sdk";
+import type {
+  WsComponentMeta,
+  WsComponentPropsMeta,
+} from "@webstudio-is/react-sdk";
+
+export const registeredComponentMetasStore = atom(
+  new Map<string, WsComponentMeta>()
+);
+
+export const registerComponentMetas = (
+  newMetas: Record<string, WsComponentMeta>
+) => {
+  const prevMetas = registeredComponentMetasStore.get();
+  const nextMetas = new Map(prevMetas);
+  for (const [componentName, meta] of Object.entries(newMetas)) {
+    nextMetas.set(componentName, meta);
+  }
+  registeredComponentMetasStore.set(nextMetas);
+};
 
 export const registeredComponentPropsMetasStore = atom(
   new Map<string, WsComponentPropsMeta>()
@@ -28,5 +46,6 @@ export const registerComponentPropsMetas = (
 };
 
 export const synchronizedComponentsMetaStores = [
+  ["registeredComponentMetas", registeredComponentMetasStore],
   ["registeredComponentPropsMetas", registeredComponentPropsMetasStore],
 ] as const;

--- a/packages/react-sdk/src/components/components-utils.ts
+++ b/packages/react-sdk/src/components/components-utils.ts
@@ -4,58 +4,6 @@ import { componentAttribute, idAttribute } from "../tree";
 
 export type ComponentName = keyof typeof components;
 
-/**
- * We need to define component names manually here, instead of using Object.keys(components)
- * Otherwise every component would be included in the bundle, even if it is not used
- *
- * @todo this list should not be hardcoded!
- */
-const componentNames = Object.keys({
-  Slot: 1,
-  Fragment: 1,
-  Box: 1,
-  Body: 1,
-  TextBlock: 1,
-  Heading: 1,
-  Paragraph: 1,
-  Link: 1,
-  LinkBlock: 1,
-  RichTextLink: 1,
-  Span: 1,
-  Bold: 1,
-  Italic: 1,
-  Superscript: 1,
-  Subscript: 1,
-  Button: 1,
-  Input: 1,
-  Form: 1,
-  Image: 1,
-  Blockquote: 1,
-  List: 1,
-  ListItem: 1,
-  Separator: 1,
-  Code: 1,
-  Label: 1,
-  SuccessMessage: 1,
-  ErrorMessage: 1,
-  Textarea: 1,
-  RadioButtonField: 1,
-  RadioButton: 1,
-  CheckboxField: 1,
-  Checkbox: 1,
-} satisfies { [K in keyof typeof components]: 1 }) as Array<
-  keyof typeof components
->;
-
-export const getComponentNames = (): ComponentName[] => {
-  const uniqueNames = new Set([
-    ...componentNames,
-    ...Object.keys(registeredComponents || {}),
-  ]);
-
-  return Array.from(uniqueNames) as ComponentName[];
-};
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyComponent = React.ForwardRefExoticComponent<
   Omit<

--- a/packages/react-sdk/src/css/css.ts
+++ b/packages/react-sdk/src/css/css.ts
@@ -1,8 +1,7 @@
 import { createCssEngine, type TransformValue } from "@webstudio-is/css-engine";
 import type { Asset, Assets } from "@webstudio-is/asset-uploader";
 import type { Build } from "@webstudio-is/project-build";
-import { getComponentNames } from "../components/components-utils";
-import { getComponentMeta } from "../components";
+import type { WsComponentMeta } from "../components/component-meta";
 import { idAttribute } from "../tree";
 import { addGlobalRules } from "./global-rules";
 import { getPresetStyleRules, getStyleRules } from "./style-rules";
@@ -12,6 +11,7 @@ type Data = {
   breakpoints?: Build["breakpoints"];
   styles?: Build["styles"];
   styleSourceSelections?: Build["styleSourceSelections"];
+  componentMetas: Map<string, WsComponentMeta>;
 };
 
 type CssOptions = {
@@ -61,9 +61,8 @@ export const generateCssText = (data: Data, options: CssOptions) => {
     engine.addMediaRule(breakpoint.id, breakpoint);
   }
 
-  for (const component of getComponentNames()) {
-    const meta = getComponentMeta(component);
-    const presetStyle = meta?.presetStyle;
+  for (const [component, meta] of data.componentMetas) {
+    const presetStyle = meta.presetStyle;
     if (presetStyle === undefined) {
       continue;
     }


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1545 https://github.com/webstudio-is/webstudio-builder/issues/1129

Here register all component metas to atom which is sychronized with builder.

Replaced getComponentNames with registered metas keys. We no longer need to maintain this list.

Old registration still there because there is a lot of usages of getComponentMeta.

## Code Review

- [ ] hi @rpominov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
