### PR TITLE
Drop collapse/expand animation from tree

### DIFF
--- a/packages/design-system/src/components/tree/tree.stories.tsx
+++ b/packages/design-system/src/components/tree/tree.stories.tsx
@@ -6,7 +6,7 @@ import { Flex } from "../flex";
 import { TreeItemLabel, TreeItemBody } from "./tree-node";
 import type { ItemDropTarget, ItemSelector } from "./item-utils";
 
-export const StressTest = ({ animate }: { animate: boolean }) => {
+export const StressTest = () => {
   const [root, setRoot] = useState<Item>((): Item => {
     return {
       id: "root",
@@ -96,7 +96,6 @@ export const StressTest = ({ animate }: { animate: boolean }) => {
         isItemHidden={(itemSelector) =>
           findItemById(root, itemSelector[0])?.isHidden ?? false
         }
-        animate={animate}
         root={root}
         selectedItemSelector={selectedItemSelector}
         dragItemSelector={dragItemSelector}
@@ -125,5 +124,4 @@ export const StressTest = ({ animate }: { animate: boolean }) => {
 
 export default {
   component: Tree,
-  args: { animate: true },
 } as ComponentMeta<typeof Tree>;

--- a/packages/design-system/src/components/tree/tree.tsx
+++ b/packages/design-system/src/components/tree/tree.tsx
@@ -37,7 +37,6 @@ export type TreeProps<Data extends { id: string }> = {
 
   onSelect?: (itemSelector: ItemSelector) => void;
   onHover?: (itemSelector: undefined | ItemSelector) => void;
-  animate?: boolean;
   onDropTargetChange: (dropTarget: undefined | ItemDropTarget) => void;
   onDragItemChange: (itemSelector: ItemSelector) => void;
   onDragEnd: (event: {
@@ -54,7 +53,7 @@ const sharedDropOptions = {
     //   redefining children like this will screw up automatic childrenOrientation detection
     //   luckily we know the orientation and can define it manually below
     return Array.from(
-      element.querySelectorAll(":scope > div > [data-drop-target-id]")
+      element.querySelectorAll(":scope > [data-drop-target-id]")
     );
   },
   childrenOrientation: { type: "vertical", reverse: false },
@@ -72,7 +71,6 @@ export const Tree = <Data extends { id: string }>({
   renderItem,
   onSelect,
   onHover,
-  animate,
   onDropTargetChange,
   onDragItemChange,
   onDragEnd,
@@ -284,14 +282,15 @@ export const Tree = <Data extends { id: string }>({
           renderItem={renderItem}
           getItemChildren={getItemChildren}
           isItemHidden={isItemHidden}
-          animate={animate}
           onSelect={onSelect}
           onHover={onHover}
           selectedItemSelector={selectedItemSelector}
           itemData={root}
           getIsExpanded={getIsExpanded}
-          setIsExpanded={setIsExpanded}
-          onExpandTransitionEnd={dropHandlers.handleDomMutation}
+          setIsExpanded={(itemSelector, isExpanded) => {
+            setIsExpanded(itemSelector, isExpanded);
+            dropHandlers.handleDomMutation();
+          }}
           dropTargetItemSelector={shiftedDropTarget?.itemSelector}
         />
       </Box>


### PR DESCRIPTION
Collapse/expand animation is glitchy in safari and adds a lot of complexxity.

Neither webflow nor figma animate this. It makes sense to remove it.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @rpominov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
