### PR TITLE
Bring back initial props to remix image

### DIFF
--- a/packages/react-sdk/src/app/custom-components/index.ts
+++ b/packages/react-sdk/src/app/custom-components/index.ts
@@ -16,7 +16,10 @@ export const customComponents = {
 };
 
 export const customComponentPropsMetas: Record<string, WsComponentPropsMeta> = {
-  Image: { props: imageProps },
+  Image: {
+    props: imageProps,
+    initialProps: ["src", "width", "height", "alt", "loading"],
+  },
   Form: formPropsMeta,
 };
 


### PR DESCRIPTION
Remix image before inherited initial props from default image. Though the new simplified logic only replaces occurrences without merging.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
