### PR TITLE
Add project domain validations

### DIFF
--- a/packages/domain/src/trpc/domain.ts
+++ b/packages/domain/src/trpc/domain.ts
@@ -98,6 +98,7 @@ export const domainRouter = router({
           },
           ctx
         );
+
         return { success: true } as const;
       } catch (error) {
         return {

--- a/packages/project/src/db/project-domain.ts
+++ b/packages/project/src/db/project-domain.ts
@@ -1,0 +1,79 @@
+import { customAlphabet } from "nanoid";
+import slugify from "slugify";
+
+const nanoid = customAlphabet("1234567890abcdefghijklmnopqrstuvwxyz");
+
+const slugifyOptions = { lower: true, strict: true };
+const MIN_DOMAIN_LENGTH = 10;
+
+// MIN_DOMAIN_LENGTH doesn't allow to use "assets" as a domain,
+// but in case it will be changed in the future, we reserve even short names
+const reservedDomains = [
+  // Reserved for SaaS support
+  "customer",
+  "customers",
+  "proxy-fallback",
+  // Reserved for local development
+  "local",
+  // Reserved for image transforms
+  "image-transform",
+  "image-transforms",
+  "images-transform",
+  "images-transforms",
+  // Assets
+  "assets",
+  "fonts",
+  "images",
+];
+
+// For the future use, reserve prefixes we can use for internal services
+const reservedPrefixes = ["wstd_sys_", "wstd-sys-"];
+
+export const validateProjectDomain = (
+  domainInput: string
+): { success: false; error: string } | { success: true; domain: string } => {
+  try {
+    const domain = slugify(domainInput, slugifyOptions);
+
+    if (domain.length < MIN_DOMAIN_LENGTH) {
+      return {
+        success: false,
+        error: `Minimum ${MIN_DOMAIN_LENGTH} characters required`,
+      } as const;
+    }
+
+    if (reservedDomains.includes(domain)) {
+      return {
+        success: false,
+        error: `Domain ${domain} is reserved`,
+      } as const;
+    }
+
+    if (reservedPrefixes.some((prefix) => domain.startsWith(prefix))) {
+      return {
+        success: false,
+        error: `Domain ${domain} is reserved`,
+      } as const;
+    }
+
+    return {
+      success: true,
+      domain,
+    };
+  } catch {
+    return {
+      success: false,
+      error: `Invalid domain ${domainInput}`,
+    };
+  }
+};
+
+export const generateDomain = (title: string) => {
+  const slugifiedTitle = slugify(title, slugifyOptions);
+  const domain = `${slugifiedTitle}-${nanoid(
+    // If user entered a long title already, we just add 5 chars generated id
+    // Otherwise we add the amount of chars to satisfy min length
+    Math.max(MIN_DOMAIN_LENGTH - slugifiedTitle.length - 1, 5)
+  )}`;
+  return domain;
+};

--- a/packages/project/src/db/project-domain.ts
+++ b/packages/project/src/db/project-domain.ts
@@ -39,21 +39,21 @@ export const validateProjectDomain = (
       return {
         success: false,
         error: `Minimum ${MIN_DOMAIN_LENGTH} characters required`,
-      } as const;
+      };
     }
 
     if (reservedDomains.includes(domain)) {
       return {
         success: false,
         error: `Domain ${domain} is reserved`,
-      } as const;
+      };
     }
 
     if (reservedPrefixes.some((prefix) => domain.startsWith(prefix))) {
       return {
         success: false,
         error: `Domain ${domain} is reserved`,
-      } as const;
+      };
     }
 
     return {

--- a/packages/project/src/index.ts
+++ b/packages/project/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./shared/schema";
 export type { ProjectRouter } from "./trpc";
+export { validateProjectDomain } from "./db/project-domain";


### PR DESCRIPTION
## Description

Services we need like `image-transform.wstd.io`, `local.wstd.io` 
can intersect with user-created domains. _in some cases that will cause disastrous results_

Do not allow to create domains we already use, and reserve `wstd-sys-` and `wstd_sys_` for future services we can create



## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
