### PR TITLE
Replace meta.children with meta.template

### DIFF
--- a/apps/builder/app/shared/copy-paste/plugin-markdown.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-markdown.test.ts
@@ -6,14 +6,14 @@ const parseInstanceData = (data?: ReturnType<typeof parse>) => {
   if (data === undefined) {
     return;
   }
-  const { rootIds, instances, props } = data;
+  const { children, instances, props } = data;
   for (const instance of instances) {
     Instance.parse(instance);
   }
   for (const prop of props) {
     Prop.parse(prop);
   }
-  return { rootIds, instances, props };
+  return { children, instances, props };
 };
 
 const options = { generateId: () => "123" };
@@ -22,6 +22,12 @@ describe("Plugin Markdown", () => {
   test("paragraph", () => {
     expect(parseInstanceData(parse("xyz", options))).toMatchInlineSnapshot(`
       {
+        "children": [
+          {
+            "type": "id",
+            "value": "123",
+          },
+        ],
         "instances": [
           {
             "children": [
@@ -36,9 +42,6 @@ describe("Plugin Markdown", () => {
           },
         ],
         "props": [],
-        "rootIds": [
-          "123",
-        ],
       }
     `);
   });
@@ -47,6 +50,12 @@ describe("Plugin Markdown", () => {
     expect(parseInstanceData(parse("# heading", options)))
       .toMatchInlineSnapshot(`
       {
+        "children": [
+          {
+            "type": "id",
+            "value": "123",
+          },
+        ],
         "instances": [
           {
             "children": [
@@ -69,9 +78,6 @@ describe("Plugin Markdown", () => {
             "value": "h1",
           },
         ],
-        "rootIds": [
-          "123",
-        ],
       }
     `);
   });
@@ -80,6 +86,12 @@ describe("Plugin Markdown", () => {
     expect(parseInstanceData(parse("###### heading", options)))
       .toMatchInlineSnapshot(`
       {
+        "children": [
+          {
+            "type": "id",
+            "value": "123",
+          },
+        ],
         "instances": [
           {
             "children": [
@@ -102,9 +114,6 @@ describe("Plugin Markdown", () => {
             "value": "h6",
           },
         ],
-        "rootIds": [
-          "123",
-        ],
       }
     `);
   });
@@ -113,6 +122,12 @@ describe("Plugin Markdown", () => {
     expect(parseInstanceData(parse("__bold__", options)))
       .toMatchInlineSnapshot(`
       {
+        "children": [
+          {
+            "type": "id",
+            "value": "123",
+          },
+        ],
         "instances": [
           {
             "children": [
@@ -138,9 +153,6 @@ describe("Plugin Markdown", () => {
           },
         ],
         "props": [],
-        "rootIds": [
-          "123",
-        ],
       }
     `);
   });
@@ -149,6 +161,12 @@ describe("Plugin Markdown", () => {
     expect(parseInstanceData(parse("**bold**", options)))
       .toMatchInlineSnapshot(`
       {
+        "children": [
+          {
+            "type": "id",
+            "value": "123",
+          },
+        ],
         "instances": [
           {
             "children": [
@@ -174,9 +192,6 @@ describe("Plugin Markdown", () => {
           },
         ],
         "props": [],
-        "rootIds": [
-          "123",
-        ],
       }
     `);
   });
@@ -185,6 +200,12 @@ describe("Plugin Markdown", () => {
     expect(parseInstanceData(parse("_italic_", options)))
       .toMatchInlineSnapshot(`
       {
+        "children": [
+          {
+            "type": "id",
+            "value": "123",
+          },
+        ],
         "instances": [
           {
             "children": [
@@ -210,9 +231,6 @@ describe("Plugin Markdown", () => {
           },
         ],
         "props": [],
-        "rootIds": [
-          "123",
-        ],
       }
     `);
   });
@@ -221,6 +239,12 @@ describe("Plugin Markdown", () => {
     expect(parseInstanceData(parse("*italic*", options)))
       .toMatchInlineSnapshot(`
       {
+        "children": [
+          {
+            "type": "id",
+            "value": "123",
+          },
+        ],
         "instances": [
           {
             "children": [
@@ -246,9 +270,6 @@ describe("Plugin Markdown", () => {
           },
         ],
         "props": [],
-        "rootIds": [
-          "123",
-        ],
       }
     `);
   });
@@ -257,6 +278,12 @@ describe("Plugin Markdown", () => {
     expect(parseInstanceData(parse('[link](/uri "Title")', options)))
       .toMatchInlineSnapshot(`
       {
+        "children": [
+          {
+            "type": "id",
+            "value": "123",
+          },
+        ],
         "instances": [
           {
             "children": [
@@ -297,9 +324,6 @@ describe("Plugin Markdown", () => {
             "value": "Title",
           },
         ],
-        "rootIds": [
-          "123",
-        ],
       }
     `);
   });
@@ -308,6 +332,12 @@ describe("Plugin Markdown", () => {
     expect(parseInstanceData(parse('![foo](/url "title")', options)))
       .toMatchInlineSnapshot(`
       {
+        "children": [
+          {
+            "type": "id",
+            "value": "123",
+          },
+        ],
         "instances": [
           {
             "children": [],
@@ -350,9 +380,6 @@ describe("Plugin Markdown", () => {
             "value": "foo",
           },
         ],
-        "rootIds": [
-          "123",
-        ],
       }
     `);
   });
@@ -368,6 +395,12 @@ describe("Plugin Markdown", () => {
       )
     ).toMatchInlineSnapshot(`
       {
+        "children": [
+          {
+            "type": "id",
+            "value": "123",
+          },
+        ],
         "instances": [
           {
             "children": [
@@ -386,9 +419,6 @@ describe("Plugin Markdown", () => {
           },
         ],
         "props": [],
-        "rootIds": [
-          "123",
-        ],
       }
     `);
   });
@@ -404,6 +434,12 @@ describe("Plugin Markdown", () => {
       )
     ).toMatchInlineSnapshot(`
       {
+        "children": [
+          {
+            "type": "id",
+            "value": "123",
+          },
+        ],
         "instances": [
           {
             "children": [
@@ -419,9 +455,6 @@ describe("Plugin Markdown", () => {
           },
         ],
         "props": [],
-        "rootIds": [
-          "123",
-        ],
       }
     `);
   });
@@ -429,6 +462,12 @@ describe("Plugin Markdown", () => {
   test("blockquote", () => {
     expect(parseInstanceData(parse("> bar", options))).toMatchInlineSnapshot(`
       {
+        "children": [
+          {
+            "type": "id",
+            "value": "123",
+          },
+        ],
         "instances": [
           {
             "children": [
@@ -454,9 +493,6 @@ describe("Plugin Markdown", () => {
           },
         ],
         "props": [],
-        "rootIds": [
-          "123",
-        ],
       }
     `);
   });
@@ -464,6 +500,12 @@ describe("Plugin Markdown", () => {
   test("inline code", () => {
     expect(parseInstanceData(parse("`foo`", options))).toMatchInlineSnapshot(`
       {
+        "children": [
+          {
+            "type": "id",
+            "value": "123",
+          },
+        ],
         "instances": [
           {
             "children": [
@@ -497,9 +539,6 @@ describe("Plugin Markdown", () => {
             "value": true,
           },
         ],
-        "rootIds": [
-          "123",
-        ],
       }
     `);
   });
@@ -508,6 +547,12 @@ describe("Plugin Markdown", () => {
     expect(parseInstanceData(parse("```js meta\nfoo\n```", options)))
       .toMatchInlineSnapshot(`
       {
+        "children": [
+          {
+            "type": "id",
+            "value": "123",
+          },
+        ],
         "instances": [
           {
             "children": [
@@ -544,9 +589,6 @@ describe("Plugin Markdown", () => {
             "value": "meta",
           },
         ],
-        "rootIds": [
-          "123",
-        ],
       }
     `);
   });
@@ -554,6 +596,12 @@ describe("Plugin Markdown", () => {
   test("list unordered", () => {
     expect(parseInstanceData(parse("- one", options))).toMatchInlineSnapshot(`
       {
+        "children": [
+          {
+            "type": "id",
+            "value": "123",
+          },
+        ],
         "instances": [
           {
             "children": [
@@ -598,9 +646,6 @@ describe("Plugin Markdown", () => {
             "value": false,
           },
         ],
-        "rootIds": [
-          "123",
-        ],
       }
     `);
   });
@@ -608,6 +653,12 @@ describe("Plugin Markdown", () => {
   test("list ordered", () => {
     expect(parseInstanceData(parse("3. one", options))).toMatchInlineSnapshot(`
       {
+        "children": [
+          {
+            "type": "id",
+            "value": "123",
+          },
+        ],
         "instances": [
           {
             "children": [
@@ -659,9 +710,6 @@ describe("Plugin Markdown", () => {
             "value": 3,
           },
         ],
-        "rootIds": [
-          "123",
-        ],
       }
     `);
   });
@@ -669,6 +717,12 @@ describe("Plugin Markdown", () => {
   test("thematic break | separator", () => {
     expect(parseInstanceData(parse("---", options))).toMatchInlineSnapshot(`
       {
+        "children": [
+          {
+            "type": "id",
+            "value": "123",
+          },
+        ],
         "instances": [
           {
             "children": [],
@@ -678,9 +732,6 @@ describe("Plugin Markdown", () => {
           },
         ],
         "props": [],
-        "rootIds": [
-          "123",
-        ],
       }
     `);
   });

--- a/apps/builder/app/shared/copy-paste/plugin-markdown.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-markdown.ts
@@ -194,11 +194,7 @@ export const parse = (clipboardData: string, options?: Options) => {
   const instances: Instance[] = [];
   const props: Prop[] = [];
   const children = toInstanceData(instances, props, ast, options);
-  // assume text is not top level
-  const rootIds = children.flatMap((child) =>
-    child.type === "id" ? [child.value] : []
-  );
-  return { props, instances, rootIds };
+  return { props, instances, children };
 };
 
 export const onPaste = (clipboardData: string) => {
@@ -213,10 +209,12 @@ export const onPaste = (clipboardData: string) => {
   ];
   const instances = instancesStore.get();
   const dragComponents = [];
-  for (const instanceId of data.rootIds) {
-    const component = instances.get(instanceId)?.component;
-    if (component !== undefined) {
-      dragComponents.push(component);
+  for (const child of data.children) {
+    if (child.type === "id") {
+      const component = instances.get(child.value)?.component;
+      if (component !== undefined) {
+        dragComponents.push(component);
+      }
     }
   }
   const dropTarget = findClosestDroppableTarget(
@@ -228,7 +226,12 @@ export const onPaste = (clipboardData: string) => {
     return;
   }
   store.createTransaction([instancesStore, propsStore], (instances, props) => {
-    insertInstancesMutable(instances, data.instances, data.rootIds, dropTarget);
+    insertInstancesMutable(
+      instances,
+      data.instances,
+      data.children,
+      dropTarget
+    );
     for (const prop of data.props) {
       props.set(prop.id, prop);
     }

--- a/apps/builder/app/shared/tree-utils.test.ts
+++ b/apps/builder/app/shared/tree-utils.test.ts
@@ -238,7 +238,7 @@ test("insert instances tree into target", () => {
       createInstance("inserted1", "Box", [{ type: "id", value: "inserted2" }]),
       createInstance("inserted2", "Box", []),
     ],
-    ["inserted1"],
+    [{ type: "id", value: "inserted1" }],
     {
       parentSelector: ["box1", "root"],
       position: 1,
@@ -267,7 +267,7 @@ test("insert instances tree into target", () => {
       createInstance("inserted3", "Box", [{ type: "id", value: "inserted4" }]),
       createInstance("inserted4", "Box", []),
     ],
-    ["inserted3"],
+    [{ type: "id", value: "inserted3" }],
     {
       parentSelector: ["box1", "root"],
       position: "end",

--- a/packages/react-sdk/src/app/custom-components/form.ws.tsx
+++ b/packages/react-sdk/src/app/custom-components/form.ws.tsx
@@ -25,55 +25,63 @@ export const meta: WsComponentMeta = {
     { selector: "[data-state=error]", label: "Error" },
     { selector: "[data-state=success]", label: "Success" },
   ],
-  children: [
+  template: [
     {
       type: "instance",
-      component: "Label",
-      children: [{ type: "text", value: "Name" }],
-    },
-    {
-      type: "instance",
-      component: "Input",
-      props: [{ type: "string", name: "name", value: "name" }],
-      children: [],
-    },
-    {
-      type: "instance",
-      component: "Label",
-      children: [{ type: "text", value: "Email" }],
-    },
-    {
-      type: "instance",
-      component: "Input",
-      props: [{ type: "string", name: "name", value: "email" }],
-      children: [],
-    },
-    {
-      type: "instance",
-      component: "Button",
-      children: [{ type: "text", value: "Submit" }],
-    },
-    {
-      type: "instance",
-      component: "SuccessMessage",
+      component: "Form",
       children: [
         {
           type: "instance",
-          component: "TextBlock",
+          component: "Label",
+          children: [{ type: "text", value: "Name" }],
+        },
+        {
+          type: "instance",
+          component: "Input",
+          props: [{ type: "string", name: "name", value: "name" }],
+          children: [],
+        },
+        {
+          type: "instance",
+          component: "Label",
+          children: [{ type: "text", value: "Email" }],
+        },
+        {
+          type: "instance",
+          component: "Input",
+          props: [{ type: "string", name: "name", value: "email" }],
+          children: [],
+        },
+        {
+          type: "instance",
+          component: "Button",
+          children: [{ type: "text", value: "Submit" }],
+        },
+        {
+          type: "instance",
+          component: "SuccessMessage",
           children: [
-            { type: "text", value: "Thank you for getting in touch!" },
+            {
+              type: "instance",
+              component: "TextBlock",
+              children: [
+                { type: "text", value: "Thank you for getting in touch!" },
+              ],
+            },
           ],
         },
-      ],
-    },
-    {
-      type: "instance",
-      component: "ErrorMessage",
-      children: [
         {
           type: "instance",
-          component: "TextBlock",
-          children: [{ type: "text", value: "Sorry, something went wrong." }],
+          component: "ErrorMessage",
+          children: [
+            {
+              type: "instance",
+              component: "TextBlock",
+              children: [
+                { type: "text", value: "Sorry, something went wrong." },
+              ],
+            },
+          ],
         },
       ],
     },

--- a/packages/react-sdk/src/components/blockquote.ws.tsx
+++ b/packages/react-sdk/src/components/blockquote.ws.tsx
@@ -66,7 +66,13 @@ export const meta: WsComponentMeta = {
   icon: BlockquoteIcon,
   states: defaultStates,
   presetStyle,
-  children: [{ type: "text", value: "Blockquote you can edit" }],
+  template: [
+    {
+      type: "instance",
+      component: "Blockquote",
+      children: [{ type: "text", value: "Blockquote you can edit" }],
+    },
+  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/checkbox-field.ws.tsx
+++ b/packages/react-sdk/src/components/checkbox-field.ws.tsx
@@ -23,14 +23,20 @@ export const meta: WsComponentMeta = {
   icon: CheckboxCheckedIcon,
   states: defaultStates,
   presetStyle,
-  children: [
-    { type: "instance", component: "Checkbox", props: [], children: [] },
+  template: [
     {
       type: "instance",
-      component: "TextBlock",
-      label: "Checkbox Label",
-      props: [],
-      children: [{ type: "text", value: "Checkbox" }],
+      component: "CheckboxField",
+      children: [
+        { type: "instance", component: "Checkbox", children: [] },
+        {
+          type: "instance",
+          component: "TextBlock",
+          label: "Checkbox Label",
+          props: [],
+          children: [{ type: "text", value: "Checkbox" }],
+        },
+      ],
     },
   ],
 };

--- a/packages/react-sdk/src/components/code-text.ws.tsx
+++ b/packages/react-sdk/src/components/code-text.ws.tsx
@@ -42,7 +42,13 @@ export const meta: WsComponentMeta = {
   icon: CodeTextIcon,
   states: defaultStates,
   presetStyle,
-  children: [{ type: "text", value: "Code you can edit" }],
+  template: [
+    {
+      type: "instance",
+      component: "CodeText",
+      children: [{ type: "text", value: "Code you can edit" }],
+    },
+  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/component-meta.ts
+++ b/packages/react-sdk/src/components/component-meta.ts
@@ -60,7 +60,7 @@ const WsComponentMeta = z.object({
   icon: z.string(),
   presetStyle: z.optional(z.record(z.string(), EmbedTemplateStyleDecl)),
   states: z.optional(z.array(ComponentState)),
-  children: z.optional(WsEmbedTemplate),
+  template: z.optional(WsEmbedTemplate),
 });
 
 export type WsComponentMeta = Omit<

--- a/packages/react-sdk/src/components/form.ws.tsx
+++ b/packages/react-sdk/src/components/form.ws.tsx
@@ -23,33 +23,39 @@ export const meta: WsComponentMeta = {
   icon: FormIcon,
   states: defaultStates,
   presetStyle,
-  children: [
+  template: [
     {
       type: "instance",
-      component: "Label",
-      children: [{ type: "text", value: "Name" }],
-    },
-    {
-      type: "instance",
-      component: "Input",
-      props: [{ type: "string", name: "name", value: "name" }],
-      children: [],
-    },
-    {
-      type: "instance",
-      component: "Label",
-      children: [{ type: "text", value: "Email" }],
-    },
-    {
-      type: "instance",
-      component: "Input",
-      props: [{ type: "string", name: "name", value: "email" }],
-      children: [],
-    },
-    {
-      type: "instance",
-      component: "Button",
-      children: [{ type: "text", value: "Submit" }],
+      component: "Form",
+      children: [
+        {
+          type: "instance",
+          component: "Label",
+          children: [{ type: "text", value: "Name" }],
+        },
+        {
+          type: "instance",
+          component: "Input",
+          props: [{ type: "string", name: "name", value: "name" }],
+          children: [],
+        },
+        {
+          type: "instance",
+          component: "Label",
+          children: [{ type: "text", value: "Email" }],
+        },
+        {
+          type: "instance",
+          component: "Input",
+          props: [{ type: "string", name: "name", value: "email" }],
+          children: [],
+        },
+        {
+          type: "instance",
+          component: "Button",
+          children: [{ type: "text", value: "Submit" }],
+        },
+      ],
     },
   ],
 };

--- a/packages/react-sdk/src/components/heading.ws.tsx
+++ b/packages/react-sdk/src/components/heading.ws.tsx
@@ -26,9 +26,15 @@ export const meta: WsComponentMeta = {
   type: "rich-text",
   label: "Heading",
   icon: HeadingIcon,
-  children: [{ type: "text", value: "Heading you can edit" }],
   states: defaultStates,
   presetStyle,
+  template: [
+    {
+      type: "instance",
+      component: "Heading",
+      children: [{ type: "text", value: "Heading you can edit" }],
+    },
+  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/label.ws.tsx
+++ b/packages/react-sdk/src/components/label.ws.tsx
@@ -23,7 +23,13 @@ export const meta: WsComponentMeta = {
   icon: TextBlockIcon,
   states: defaultStates,
   presetStyle,
-  children: [{ type: "text", value: "Form Label" }],
+  template: [
+    {
+      type: "instance",
+      component: "Label",
+      children: [{ type: "text", value: "Form Label" }],
+    },
+  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/link.ws.tsx
+++ b/packages/react-sdk/src/components/link.ws.tsx
@@ -41,7 +41,13 @@ export const meta: WsComponentMeta = {
       label: "Current page",
     },
   ],
-  children: [{ type: "text", value: "Link text you can edit" }],
+  template: [
+    {
+      type: "instance",
+      component: "Link",
+      children: [{ type: "text", value: "Link text you can edit" }],
+    },
+  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/list-item.ws.tsx
+++ b/packages/react-sdk/src/components/list-item.ws.tsx
@@ -19,9 +19,15 @@ export const meta: WsComponentMeta = {
   acceptedParents: ["List"],
   label: "List Item",
   icon: ListItemIcon,
-  children: [{ type: "text", value: "List Item you can edit" }],
   states: defaultStates,
   presetStyle,
+  template: [
+    {
+      type: "instance",
+      component: "ListItem",
+      children: [{ type: "text", value: "List Item you can edit" }],
+    },
+  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/list.ws.tsx
+++ b/packages/react-sdk/src/components/list.ws.tsx
@@ -49,7 +49,6 @@ export const meta: WsComponentMeta = {
   icon: ListIcon,
   states: defaultStates,
   presetStyle,
-  children: [],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/paragraph.ws.tsx
+++ b/packages/react-sdk/src/components/paragraph.ws.tsx
@@ -18,9 +18,15 @@ export const meta: WsComponentMeta = {
   type: "rich-text",
   label: "Paragraph",
   icon: TextAlignLeftIcon,
-  children: [{ type: "text", value: "Pragraph you can edit" }],
   states: defaultStates,
   presetStyle,
+  template: [
+    {
+      type: "instance",
+      component: "Paragraph",
+      children: [{ type: "text", value: "Pragraph you can edit" }],
+    },
+  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/radio-button-field.ws.tsx
+++ b/packages/react-sdk/src/components/radio-button-field.ws.tsx
@@ -23,14 +23,20 @@ export const meta: WsComponentMeta = {
   icon: RadioCheckedIcon,
   states: defaultStates,
   presetStyle,
-  children: [
-    { type: "instance", component: "RadioButton", props: [], children: [] },
+  template: [
     {
       type: "instance",
-      component: "TextBlock",
-      label: "Radio Label",
-      props: [],
-      children: [{ type: "text", value: "Radio" }],
+      component: "RadioButtonField",
+      children: [
+        { type: "instance", component: "RadioButton", props: [], children: [] },
+        {
+          type: "instance",
+          component: "TextBlock",
+          label: "Radio Label",
+          props: [],
+          children: [{ type: "text", value: "Radio" }],
+        },
+      ],
     },
   ],
 };

--- a/packages/react-sdk/src/components/rich-text-link.ws.tsx
+++ b/packages/react-sdk/src/components/rich-text-link.ws.tsx
@@ -7,7 +7,7 @@ const { category, ...linkMetaRest } = linkMeta;
 export const meta: WsComponentMeta = {
   ...linkMetaRest,
   type: "rich-text-child",
-  children: [],
+  template: [],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/separator.ws.tsx
+++ b/packages/react-sdk/src/components/separator.ws.tsx
@@ -47,7 +47,6 @@ export const meta: WsComponentMeta = {
   icon: DashIcon,
   states: defaultStates,
   presetStyle,
-  children: [],
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/text-block.ws.tsx
+++ b/packages/react-sdk/src/components/text-block.ws.tsx
@@ -26,7 +26,13 @@ export const meta: WsComponentMeta = {
   icon: TextBlockIcon,
   states: defaultStates,
   presetStyle,
-  children: [{ type: "text", value: "Block of text you can edit" }],
+  template: [
+    {
+      type: "instance",
+      component: "TextBlock",
+      children: [{ type: "text", value: "Block of text you can edit" }],
+    },
+  ],
 };
 
 export const propsMeta: WsComponentPropsMeta = {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1569

Here we change template in meta to include current component instead of implicitly creating it.

This way we can provide insert composition of components instead of single one for example input+label. Or even wrap current component like label>input.

Another usecase is ability to set local styles and props for current component.

Note: review with hidden whitespaces

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @rpominov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
