### PR TITLE
Accept components map in renderers

### DIFF
--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -4,17 +4,17 @@ import { computed } from "nanostores";
 import type { Instances, Page } from "@webstudio-is/project-build";
 import {
   type Params,
+  type Components,
   defaultMetas,
   defaultPropsMetas,
   createElementsTree,
-  registerComponents,
   registerComponentMetas as registerComponentMetasLegacy,
   customComponentMetas,
   customComponentPropsMetas,
   setParams,
   customComponents,
-  type GetComponent,
 } from "@webstudio-is/react-sdk";
+import * as defaultComponents from "@webstudio-is/react-sdk/components";
 import { publish } from "~/shared/pubsub";
 import {
   handshakenStore,
@@ -63,7 +63,7 @@ const temporaryInstances: Instances = new Map([
   ],
 ]);
 
-const useElementsTree = (getComponent: GetComponent) => {
+const useElementsTree = (components: Components) => {
   const instances = useStore(instancesStore);
   const page = useStore(selectedPageStore);
   const rootInstanceId = page?.rootInstanceId;
@@ -102,9 +102,9 @@ const useElementsTree = (getComponent: GetComponent) => {
       assetsStore,
       pagesStore: pagesMapStore,
       Component: WebstudioComponentDev,
-      getComponent,
+      components,
     });
-  }, [instances, rootInstanceId, getComponent, pagesMapStore]);
+  }, [instances, rootInstanceId, components, pagesMapStore]);
 };
 
 const DesignMode = () => {
@@ -124,19 +124,17 @@ const DesignMode = () => {
 
 type CanvasProps = {
   params: Params;
-  getComponent: GetComponent;
 };
 
-export const Canvas = ({
-  params,
-  getComponent,
-}: CanvasProps): JSX.Element | null => {
+export const Canvas = ({ params }: CanvasProps): JSX.Element | null => {
   const handshaken = useStore(handshakenStore);
   setParams(params ?? null);
   useCanvasStore(publish);
   const [isPreviewMode] = useIsPreviewMode();
 
-  registerComponents(customComponents);
+  const components = new Map(
+    Object.entries({ ...defaultComponents, ...customComponents })
+  ) as Components;
   registerComponentMetasLegacy(customComponentMetas);
   useSyncInitializeOnce(() => {
     registerComponentMetas(defaultMetas);
@@ -166,7 +164,7 @@ export const Canvas = ({
 
   useEffect(subscribeCollapsedToPubSub, []);
 
-  const elements = useElementsTree(getComponent);
+  const elements = useElementsTree(components);
 
   return (
     <>

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -10,11 +10,12 @@ import {
   Instances,
 } from "@webstudio-is/project-build";
 import {
+  type AnyComponent,
+  type Components,
   renderWebstudioComponentChildren,
   idAttribute,
   componentAttribute,
 } from "@webstudio-is/react-sdk";
-import type { GetComponent } from "@webstudio-is/react-sdk";
 import {
   instancesStore,
   selectedInstanceRenderStateStore,
@@ -39,7 +40,7 @@ const ContentEditable = ({
   elementRef,
   ...props
 }: {
-  Component: NonNullable<ReturnType<GetComponent>>;
+  Component: AnyComponent;
   elementRef: { current: null | HTMLElement };
   [idAttribute]: Instance["id"];
   [componentAttribute]: Instance["component"];
@@ -94,14 +95,14 @@ type WebstudioComponentDevProps = {
   instance: Instance;
   instanceSelector: InstanceSelector;
   children: Array<JSX.Element | string>;
-  getComponent: GetComponent;
+  components: Components;
 };
 
 export const WebstudioComponentDev = ({
   instance,
   instanceSelector,
   children,
-  getComponent,
+  components,
 }: WebstudioComponentDevProps) => {
   const instanceId = instance.id;
   const instanceElementRef = useRef<HTMLElement>(null);
@@ -162,7 +163,7 @@ export const WebstudioComponentDev = ({
       ? { readOnly: true }
       : undefined;
 
-  const Component = getComponent(instance.component);
+  const Component = components.get(instance.component);
 
   if (Component === undefined) {
     return <></>;

--- a/apps/builder/app/routes/$.tsx
+++ b/apps/builder/app/routes/$.tsx
@@ -5,7 +5,7 @@ import {
   useLoaderData,
   useRouteError,
 } from "@remix-run/react";
-import { type Params, Root, getComponent } from "@webstudio-is/react-sdk";
+import { type Params, Root } from "@webstudio-is/react-sdk";
 import env from "~/env/env.public.server";
 import { sentryException } from "~/shared/sentry";
 import { Canvas } from "~/canvas";
@@ -52,7 +52,7 @@ export const ErrorBoundary = () => {
 
 const Outlet = () => {
   const { params } = useLoaderData<typeof loader>();
-  return <Canvas params={params} getComponent={getComponent} />;
+  return <Canvas params={params} />;
 };
 
 /**

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -66,6 +66,11 @@
       "source": "./src/index.ts",
       "import": "./lib/index.js",
       "require": "./lib/cjs/index.js"
+    },
+    "./components": {
+      "source": "./src/components/components.ts",
+      "import": "./lib/components/components.js",
+      "require": "./lib/cjs/components/components.js"
     }
   },
   "types": "lib/types/index.d.ts",

--- a/packages/react-sdk/src/components/components-utils.ts
+++ b/packages/react-sdk/src/components/components-utils.ts
@@ -1,11 +1,6 @@
-import * as components from "./components";
-import { registeredComponents } from "./index";
 import { componentAttribute, idAttribute } from "../tree";
 
-export type ComponentName = keyof typeof components;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyComponent = React.ForwardRefExoticComponent<
+export type AnyComponent = React.ForwardRefExoticComponent<
   Omit<
     React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>,
     "ref"
@@ -15,28 +10,4 @@ type AnyComponent = React.ForwardRefExoticComponent<
   } & React.RefAttributes<HTMLElement>
 >;
 
-/**
- * Now used only in builder app
- * @todo Consider using the same approach in the builder app as in the published apps . A dynamic import is needed
- */
-export const getComponent = (name: string): undefined | AnyComponent => {
-  return registeredComponents != null && name in registeredComponents
-    ? (registeredComponents[name as ComponentName] as never)
-    : (components[name as ComponentName] as never);
-};
-
-/**
- * The application imports only the components it uses, then pass them to createGetComponent i.e.
- * getComponent = createGetComponent({ Box, BlaBla })
- * <RootInstance data={data} getComponent={getComponent} />
- * see example /packages/sdk-size-test/app/routes/$.tsx
- **/
-export const createGetComponent = (comps: Partial<typeof components>) => {
-  return (name: string): undefined | AnyComponent => {
-    return registeredComponents != null && name in registeredComponents
-      ? (registeredComponents[name as ComponentName] as never)
-      : (comps[name as ComponentName] as never);
-  };
-};
-
-export type GetComponent = typeof getComponent;
+export type Components = Map<string, AnyComponent>;

--- a/packages/react-sdk/src/components/index.ts
+++ b/packages/react-sdk/src/components/index.ts
@@ -1,5 +1,4 @@
 import type { WsComponentMeta, WsComponentPropsMeta } from "./component-meta";
-import type { ComponentName } from "./components-utils";
 import { meta as SlotMeta } from "./slot.ws";
 import { meta as FragmentMeta } from "./fragment.ws";
 import { meta as HtmlEmbedMeta } from "./html-embed.ws";
@@ -157,22 +156,6 @@ export const defaultPropsMetas: Record<string, WsComponentPropsMeta> = {
   RadioButton: RadioButtonPropsMeta,
   CheckboxField: CheckboxFieldPropsMeta,
   Checkbox: CheckboxPropsMeta,
-};
-
-type RegisteredComponents = Partial<{
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  [name in ComponentName]: {};
-}>;
-
-export let registeredComponents: RegisteredComponents | undefined;
-
-/**
- *  @todo: Allow register any component.
- * Now we can register only existings Components, as all our type system would
- * break otherwise, see getComponent etc. So its overwriteComponent now
- **/
-export const registerComponents = (components: RegisteredComponents) => {
-  registeredComponents = components;
 };
 
 export const canAcceptComponent = (

--- a/packages/react-sdk/src/tree/create-elements-tree.tsx
+++ b/packages/react-sdk/src/tree/create-elements-tree.tsx
@@ -3,7 +3,7 @@ import type { ReadableAtom } from "nanostores";
 import { Scripts, ScrollRestoration } from "@remix-run/react";
 import type { Assets } from "@webstudio-is/asset-uploader";
 import type { Instance, Instances } from "@webstudio-is/project-build";
-import type { GetComponent } from "../components/components-utils";
+import type { Components } from "../components/components-utils";
 import { ReactSdkContext } from "../context";
 import type { Pages, PropsByInstanceId } from "../props";
 import type { WebstudioComponent } from "./webstudio-component";
@@ -18,7 +18,7 @@ export const createElementsTree = ({
   assetsStore,
   pagesStore,
   Component,
-  getComponent,
+  components,
 }: {
   renderer?: "canvas";
   instances: Instances;
@@ -27,7 +27,7 @@ export const createElementsTree = ({
   assetsStore: ReadableAtom<Assets>;
   pagesStore: ReadableAtom<Pages>;
   Component: (props: ComponentProps<typeof WebstudioComponent>) => JSX.Element;
-  getComponent: GetComponent;
+  components: Components;
 }) => {
   const rootInstance = instances.get(rootInstanceId);
   if (rootInstance === undefined) {
@@ -40,7 +40,7 @@ export const createElementsTree = ({
     instanceSelector: rootInstanceSelector,
     Component,
     children: rootInstance.children,
-    getComponent,
+    components,
   });
   const root = createInstanceElement({
     Component,
@@ -53,7 +53,7 @@ export const createElementsTree = ({
         <Scripts />
       </Fragment>,
     ],
-    getComponent,
+    components,
   });
   return (
     <ReactSdkContext.Provider
@@ -69,13 +69,13 @@ const createInstanceChildrenElements = ({
   instanceSelector,
   children,
   Component,
-  getComponent,
+  components,
 }: {
   instances: Instances;
   instanceSelector: InstanceSelector;
   children: Instance["children"];
   Component: (props: ComponentProps<typeof WebstudioComponent>) => JSX.Element;
-  getComponent: GetComponent;
+  components: Components;
 }) => {
   const elements = [];
   for (const child of children) {
@@ -93,14 +93,14 @@ const createInstanceChildrenElements = ({
       instanceSelector: childInstanceSelector,
       children: childInstance.children,
       Component,
-      getComponent,
+      components,
     });
     const element = createInstanceElement({
       instance: childInstance,
       instanceSelector: childInstanceSelector,
       Component,
       children,
-      getComponent,
+      components,
     });
     elements.push(element);
   }
@@ -112,20 +112,20 @@ const createInstanceElement = ({
   instance,
   instanceSelector,
   children = [],
-  getComponent,
+  components,
 }: {
   instance: Instance;
   instanceSelector: InstanceSelector;
   Component: (props: ComponentProps<typeof WebstudioComponent>) => JSX.Element;
   children?: Array<JSX.Element | string>;
-  getComponent: GetComponent;
+  components: Components;
 }) => {
   return (
     <Component
       key={instance.id}
       instance={instance}
       instanceSelector={instanceSelector}
-      getComponent={getComponent}
+      components={components}
     >
       {children}
     </Component>

--- a/packages/react-sdk/src/tree/root.ts
+++ b/packages/react-sdk/src/tree/root.ts
@@ -4,11 +4,9 @@ import type { Build, Page } from "@webstudio-is/project-build";
 import type { Asset } from "@webstudio-is/asset-uploader";
 import { createElementsTree } from "./create-elements-tree";
 import { WebstudioComponent } from "./webstudio-component";
-import { registerComponents } from "../components";
-import { customComponents as defaultCustomComponents } from "../app/custom-components";
 import { setParams, type Params } from "../app/params";
 import { getPropsByInstanceId } from "../props";
-import type { GetComponent } from "../components/components-utils";
+import type { Components } from "../components/components-utils";
 
 export type Data = {
   page: Page;
@@ -25,18 +23,15 @@ export type RootPropsData = Omit<Data, "build"> & {
 type RootProps = {
   data: RootPropsData;
   Component?: (props: ComponentProps<typeof WebstudioComponent>) => JSX.Element;
-  customComponents?: Parameters<typeof registerComponents>[0];
-  getComponent: GetComponent;
+  components: Components;
 };
 
 export const InstanceRoot = ({
   data,
   Component,
-  customComponents = defaultCustomComponents,
-  getComponent,
+  components,
 }: RootProps): JSX.Element | null => {
   setParams(data.params);
-  registerComponents(customComponents);
   return createElementsTree({
     instances: new Map(data.build.instances),
     rootInstanceId: data.page.rootInstanceId,
@@ -46,6 +41,6 @@ export const InstanceRoot = ({
     assetsStore: atom(new Map(data.assets.map((asset) => [asset.id, asset]))),
     pagesStore: atom(new Map(data.pages.map((page) => [page.id, page]))),
     Component: Component ?? WebstudioComponent,
-    getComponent,
+    components,
   });
 };

--- a/packages/react-sdk/src/tree/webstudio-component.tsx
+++ b/packages/react-sdk/src/tree/webstudio-component.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from "react";
 import type { Instance } from "@webstudio-is/project-build";
-import type { GetComponent } from "../components/components-utils";
+import type { Components } from "../components/components-utils";
 import { useInstanceProps } from "../props";
 
 const renderText = (text: string): Array<JSX.Element> => {
@@ -30,14 +30,14 @@ type WebstudioComponentProps = {
   instance: Instance;
   instanceSelector: Instance["id"][];
   children: Array<JSX.Element | string>;
-  getComponent: GetComponent;
+  components: Components;
 };
 
 export const WebstudioComponent = ({
   instance,
   instanceSelector,
   children,
-  getComponent,
+  components,
   ...rest
 }: WebstudioComponentProps) => {
   const instanceProps = useInstanceProps(instance.id);
@@ -47,7 +47,7 @@ export const WebstudioComponent = ({
     [idAttribute]: instance.id,
     [componentAttribute]: instance.component,
   };
-  const Component = getComponent(instance.component);
+  const Component = components.get(instance.component);
   if (Component === undefined) {
     return <></>;
   }

--- a/packages/sdk-size-test/app/page-components/page-main.ts
+++ b/packages/sdk-size-test/app/page-components/page-main.ts
@@ -1,3 +1,5 @@
-import { Box, Button, Body, createGetComponent } from "@webstudio-is/react-sdk";
+import { type Components, Box, Button, Body } from "@webstudio-is/react-sdk";
 
-export const getComponent = createGetComponent({ Box, Button, Body });
+export const components = new Map(
+  Object.entries({ Box, Button, Body })
+) as Components;

--- a/packages/sdk-size-test/app/routes/$.tsx
+++ b/packages/sdk-size-test/app/routes/$.tsx
@@ -1,10 +1,10 @@
 import { useLoaderData } from "@remix-run/react";
 import { InstanceRoot, Root } from "@webstudio-is/react-sdk";
-import { getComponent } from "../page-components/page-main";
+import { components } from "../page-components/page-main";
 
 export default function Index() {
   const data = useLoaderData<unknown>();
 
-  const Outlet = () => <InstanceRoot data={data} getComponent={getComponent} />;
+  const Outlet = () => <InstanceRoot data={data} components={components} />;
   return <Root Outlet={Outlet} />;
 }


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1129

Here refactored registered components away from global state in react-sdk package in favour of components map.

The map can be easily computed in runtime or generated for worker. Default and custom (remix) components registering is unified now and both libraries can be split into separate packages.

Temporary added "@webstudio/react-sdk/components" entry point to get a record of components.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
