### PR TITLE
Sort components by order property in WsComponentMeta

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
@@ -38,7 +38,6 @@ export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
     () => getMetaMaps(metaByComponentName),
     [metaByComponentName]
   );
-  console.log({ metaByComponentName, metaByCategory, componentNamesByMeta });
   const { dragCard, handleInsert, draggableContainerRef } = useDraggable({
     publish,
     metaByComponentName,

--- a/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
@@ -25,29 +25,7 @@ import {
 } from "./use-draggable";
 import { MetaIcon } from "~/builder/shared/meta-icon";
 import { registeredComponentMetasStore } from "~/shared/nano-states";
-
-const getMetaMaps = (metaByComponentName: Map<string, WsComponentMeta>) => {
-  const metaByCategory: Map<
-    WsComponentMeta["category"],
-    Array<WsComponentMeta>
-  > = new Map();
-  const componentNamesByMeta: Map<WsComponentMeta, string> = new Map();
-
-  for (const [name, meta] of metaByComponentName) {
-    if (meta.category === undefined) {
-      continue;
-    }
-    let categoryMetas = metaByCategory.get(meta.category);
-    if (categoryMetas === undefined) {
-      categoryMetas = [];
-      metaByCategory.set(meta.category, categoryMetas);
-    }
-    categoryMetas.push(meta);
-    metaByComponentName.set(name, meta);
-    componentNamesByMeta.set(meta, name);
-  }
-  return { metaByComponentName, metaByCategory, componentNamesByMeta };
-};
+import { getMetaMaps } from "./get-meta-maps";
 
 type TabContentProps = {
   onSetActiveTab: (tabName: TabName) => void;
@@ -60,6 +38,7 @@ export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
     () => getMetaMaps(metaByComponentName),
     [metaByComponentName]
   );
+  console.log({ metaByComponentName, metaByCategory, componentNamesByMeta });
   const { dragCard, handleInsert, draggableContainerRef } = useDraggable({
     publish,
     metaByComponentName,

--- a/apps/builder/app/builder/features/sidebar-left/panels/components/get-meta-maps.test.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/get-meta-maps.test.ts
@@ -1,0 +1,71 @@
+import { type WsComponentMeta } from "@webstudio-is/react-sdk";
+import { describe, expect, test } from "@jest/globals";
+import { getMetaMaps } from "./get-meta-maps";
+
+const metaByComponentName: Map<string, WsComponentMeta> = new Map([
+  [
+    "Box",
+    {
+      category: "general",
+      label: "Box",
+      type: "container",
+      order: 0,
+      icon: "",
+    },
+  ],
+  [
+    "Box1",
+    {
+      category: "general",
+      label: "Box1",
+      type: "container",
+      order: 1,
+      icon: "",
+    },
+  ],
+]);
+
+describe("getMetaMaps", () => {
+  test("sorts meta by order", () => {
+    const { metaByCategory, componentNamesByMeta } =
+      getMetaMaps(metaByComponentName);
+    expect(metaByCategory).toMatchInlineSnapshot(`
+      Map {
+        "general" => [
+          {
+            "category": "general",
+            "icon": "",
+            "label": "Box",
+            "order": 0,
+            "type": "container",
+          },
+          {
+            "category": "general",
+            "icon": "",
+            "label": "Box1",
+            "order": 1,
+            "type": "container",
+          },
+        ],
+      }
+    `);
+    expect(componentNamesByMeta).toMatchInlineSnapshot(`
+      Map {
+        {
+          "category": "general",
+          "icon": "",
+          "label": "Box",
+          "order": 0,
+          "type": "container",
+        } => "Box",
+        {
+          "category": "general",
+          "icon": "",
+          "label": "Box1",
+          "order": 1,
+          "type": "container",
+        } => "Box1",
+      }
+    `);
+  });
+});

--- a/apps/builder/app/builder/features/sidebar-left/panels/components/get-meta-maps.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/get-meta-maps.ts
@@ -1,0 +1,36 @@
+import { type WsComponentMeta } from "@webstudio-is/react-sdk";
+
+export const getMetaMaps = (
+  metaByComponentName: Map<string, WsComponentMeta>
+) => {
+  const metaByCategory: Map<
+    WsComponentMeta["category"],
+    Array<WsComponentMeta>
+  > = new Map();
+  const componentNamesByMeta: Map<WsComponentMeta, string> = new Map();
+
+  for (const [name, meta] of metaByComponentName) {
+    if (meta.category === undefined) {
+      continue;
+    }
+    let categoryMetas = metaByCategory.get(meta.category);
+    if (categoryMetas === undefined) {
+      categoryMetas = [];
+      metaByCategory.set(meta.category, categoryMetas);
+    }
+    categoryMetas.push(meta);
+    metaByComponentName.set(name, meta);
+    componentNamesByMeta.set(meta, name);
+  }
+
+  for (const [, meta] of metaByCategory) {
+    meta.sort((metaA, metaB) => {
+      return (
+        (metaA.order ?? Number.MAX_SAFE_INTEGER) -
+        (metaB.order ?? Number.MAX_SAFE_INTEGER)
+      );
+    });
+  }
+
+  return { metaByCategory, componentNamesByMeta };
+};

--- a/apps/builder/app/builder/features/sidebar-left/panels/components/get-meta-maps.ts
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/get-meta-maps.ts
@@ -23,7 +23,7 @@ export const getMetaMaps = (
     componentNamesByMeta.set(meta, name);
   }
 
-  for (const [, meta] of metaByCategory) {
+  for (const meta of metaByCategory.values()) {
     meta.sort((metaA, metaB) => {
       return (
         (metaA.order ?? Number.MAX_SAFE_INTEGER) -

--- a/packages/react-sdk/src/app/custom-components/form.ws.tsx
+++ b/packages/react-sdk/src/app/custom-components/form.ws.tsx
@@ -21,6 +21,7 @@ export const meta: WsComponentMeta = {
   label: "Form",
   icon: FormIcon,
   presetStyle,
+  order: 0,
   states: [
     { selector: "[data-state=error]", label: "Error" },
     { selector: "[data-state=success]", label: "Success" },

--- a/packages/react-sdk/src/app/custom-components/index.ts
+++ b/packages/react-sdk/src/app/custom-components/index.ts
@@ -3,7 +3,10 @@ import { Link } from "./link";
 import { LinkBlock } from "./link-block";
 import { RichTextLink } from "./rich-text-link";
 import { Form } from "./form";
-import { meta as formMeta, propsMeta as formPropsMeta } from "./form.ws";
+import {
+  meta as formMeta,
+  propsMeta as formPropsMeta,
+} from "../../components/form.ws";
 
 export const customComponents = {
   Link,

--- a/packages/react-sdk/src/components/blockquote.ws.tsx
+++ b/packages/react-sdk/src/components/blockquote.ws.tsx
@@ -60,7 +60,7 @@ const presetStyle = {
 } satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
-  category: "typography",
+  category: "text",
   type: "rich-text",
   label: "Blockquote",
   icon: BlockquoteIcon,
@@ -73,6 +73,7 @@ export const meta: WsComponentMeta = {
       children: [{ type: "text", value: "Blockquote you can edit" }],
     },
   ],
+  order: 3,
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/box.ws.ts
+++ b/packages/react-sdk/src/components/box.ws.ts
@@ -43,6 +43,7 @@ export const meta: WsComponentMeta = {
   icon: BoxIcon,
   states: defaultStates,
   presetStyle,
+  order: 0,
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/button.ws.tsx
+++ b/packages/react-sdk/src/components/button.ws.tsx
@@ -25,6 +25,7 @@ export const meta: WsComponentMeta = {
     { selector: ":disabled", label: "Disabled" },
     { selector: ":enabled", label: "Enabled" },
   ],
+  order: 1,
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/checkbox.ws.tsx
+++ b/packages/react-sdk/src/components/checkbox.ws.tsx
@@ -24,6 +24,7 @@ export const meta: WsComponentMeta = {
   label: "Checkbox Input",
   icon: CheckboxCheckedIcon,
   presetStyle,
+  order: 6,
   states: [
     ...defaultStates,
     { selector: ":checked", label: "Checked" },

--- a/packages/react-sdk/src/components/code-text.ws.tsx
+++ b/packages/react-sdk/src/components/code-text.ws.tsx
@@ -49,6 +49,7 @@ export const meta: WsComponentMeta = {
       children: [{ type: "text", value: "Code you can edit" }],
     },
   ],
+  order: 7,
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/code-text.ws.tsx
+++ b/packages/react-sdk/src/components/code-text.ws.tsx
@@ -49,7 +49,7 @@ export const meta: WsComponentMeta = {
       children: [{ type: "text", value: "Code you can edit" }],
     },
   ],
-  order: 7,
+  order: 8,
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/component-meta.ts
+++ b/packages/react-sdk/src/components/component-meta.ts
@@ -41,7 +41,7 @@ export const defaultStates: ComponentState[] = [
   { selector: ":focus-within", label: "Focus Within" },
 ];
 
-const WsComponentMeta = z.object({
+export const WsComponentMeta = z.object({
   category: z.enum(componentCategories).optional(),
   // container - can accept other components with dnd
   // control - usually form controls like inputs, without children
@@ -63,6 +63,7 @@ const WsComponentMeta = z.object({
   presetStyle: z.optional(z.record(z.string(), EmbedTemplateStyleDecl)),
   states: z.optional(z.array(ComponentState)),
   template: z.optional(WsEmbedTemplate),
+  order: z.number().optional(),
 });
 
 export type WsComponentMeta = Omit<

--- a/packages/react-sdk/src/components/component-meta.ts
+++ b/packages/react-sdk/src/components/component-meta.ts
@@ -41,7 +41,7 @@ export const defaultStates: ComponentState[] = [
   { selector: ":focus-within", label: "Focus Within" },
 ];
 
-export const WsComponentMeta = z.object({
+const WsComponentMeta = z.object({
   category: z.enum(componentCategories).optional(),
   // container - can accept other components with dnd
   // control - usually form controls like inputs, without children

--- a/packages/react-sdk/src/components/component-meta.ts
+++ b/packages/react-sdk/src/components/component-meta.ts
@@ -18,7 +18,7 @@ export type WsComponentPropsMeta = z.infer<typeof WsComponentPropsMeta>;
 
 export const componentCategories = [
   "general",
-  "typography",
+  "text",
   "media",
   "forms",
 ] as const;

--- a/packages/react-sdk/src/components/form.ws.tsx
+++ b/packages/react-sdk/src/components/form.ws.tsx
@@ -23,6 +23,7 @@ export const meta: WsComponentMeta = {
   icon: FormIcon,
   states: defaultStates,
   presetStyle,
+  order: 0,
   template: [
     {
       type: "instance",

--- a/packages/react-sdk/src/components/heading.ws.tsx
+++ b/packages/react-sdk/src/components/heading.ws.tsx
@@ -22,7 +22,7 @@ const presetStyle = {
 } satisfies PresetStyle<HeadingTags>;
 
 export const meta: WsComponentMeta = {
-  category: "typography",
+  category: "text",
   type: "rich-text",
   label: "Heading",
   icon: HeadingIcon,
@@ -35,6 +35,7 @@ export const meta: WsComponentMeta = {
       children: [{ type: "text", value: "Heading you can edit" }],
     },
   ],
+  order: 1,
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/html-embed.ws.ts
+++ b/packages/react-sdk/src/components/html-embed.ws.ts
@@ -8,6 +8,7 @@ export const meta: WsComponentMeta = {
   label: "HTML Embed",
   icon: EmbedIcon,
   stylable: false,
+  order: 6,
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/html-embed.ws.ts
+++ b/packages/react-sdk/src/components/html-embed.ws.ts
@@ -8,7 +8,7 @@ export const meta: WsComponentMeta = {
   label: "HTML Embed",
   icon: EmbedIcon,
   stylable: false,
-  order: 6,
+  order: 7,
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/image.ws.tsx
+++ b/packages/react-sdk/src/components/image.ws.tsx
@@ -34,6 +34,7 @@ export const meta: WsComponentMeta = {
   icon: ImageIcon,
   states: defaultStates,
   presetStyle,
+  order: 0,
 };
 
 // "loader" is our internal prop not intended to show up in the props panel

--- a/packages/react-sdk/src/components/input.ws.tsx
+++ b/packages/react-sdk/src/components/input.ws.tsx
@@ -19,6 +19,7 @@ export const meta: WsComponentMeta = {
   label: "Text Input",
   icon: FormTextFieldIcon,
   presetStyle,
+  order: 3,
   states: [
     ...defaultStates,
     { selector: "::placeholder", label: "Placeholder" },

--- a/packages/react-sdk/src/components/label.ws.tsx
+++ b/packages/react-sdk/src/components/label.ws.tsx
@@ -23,6 +23,7 @@ export const meta: WsComponentMeta = {
   icon: TextBlockIcon,
   states: defaultStates,
   presetStyle,
+  order: 2,
   template: [
     {
       type: "instance",

--- a/packages/react-sdk/src/components/link-block.ws.tsx
+++ b/packages/react-sdk/src/components/link-block.ws.tsx
@@ -26,6 +26,7 @@ export const meta: WsComponentMeta = {
   icon: LinkBlockIcon,
   states: linkMeta.states,
   presetStyle,
+  order: 2,
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/link.ws.tsx
+++ b/packages/react-sdk/src/components/link.ws.tsx
@@ -29,6 +29,7 @@ export const meta: WsComponentMeta = {
   label: "Link Text",
   icon: LinkIcon,
   presetStyle,
+  order: 1,
   states: [
     ...defaultStates,
     {

--- a/packages/react-sdk/src/components/list-item.ws.tsx
+++ b/packages/react-sdk/src/components/list-item.ws.tsx
@@ -14,7 +14,7 @@ const presetStyle = {
 } satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
-  category: "typography",
+  category: "general",
   type: "rich-text",
   requiredAncestors: ["List"],
   label: "List Item",
@@ -28,6 +28,7 @@ export const meta: WsComponentMeta = {
       children: [{ type: "text", value: "List Item you can edit" }],
     },
   ],
+  order: 4,
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/list.ws.tsx
+++ b/packages/react-sdk/src/components/list.ws.tsx
@@ -43,12 +43,13 @@ const presetStyle = {
 } satisfies PresetStyle<ListTag>;
 
 export const meta: WsComponentMeta = {
-  category: "typography",
+  category: "general",
   type: "container",
   label: "List",
   icon: ListIcon,
   states: defaultStates,
   presetStyle,
+  order: 3,
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/paragraph.ws.tsx
+++ b/packages/react-sdk/src/components/paragraph.ws.tsx
@@ -14,7 +14,7 @@ const presetStyle = {
 } satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
-  category: "typography",
+  category: "text",
   type: "rich-text",
   label: "Paragraph",
   icon: TextAlignLeftIcon,
@@ -27,6 +27,7 @@ export const meta: WsComponentMeta = {
       children: [{ type: "text", value: "Pragraph you can edit" }],
     },
   ],
+  order: 2,
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/radio-button.ws.tsx
+++ b/packages/react-sdk/src/components/radio-button.ws.tsx
@@ -24,6 +24,7 @@ export const meta: WsComponentMeta = {
   label: "Radio Input",
   icon: RadioCheckedIcon,
   presetStyle,
+  order: 5,
   states: [
     ...defaultStates,
     { selector: ":checked", label: "Checked" },

--- a/packages/react-sdk/src/components/separator.ws.tsx
+++ b/packages/react-sdk/src/components/separator.ws.tsx
@@ -47,6 +47,7 @@ export const meta: WsComponentMeta = {
   icon: DashIcon,
   states: defaultStates,
   presetStyle,
+  order: 5,
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/slot.ws.ts
+++ b/packages/react-sdk/src/components/slot.ws.ts
@@ -7,6 +7,7 @@ export const meta: WsComponentMeta = {
   label: "Slot",
   icon: SlotComponentIcon,
   stylable: false,
+  order: 6,
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/text-block.ws.tsx
+++ b/packages/react-sdk/src/components/text-block.ws.tsx
@@ -20,7 +20,7 @@ const presetStyle = {
 } satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {
-  category: "typography",
+  category: "text",
   type: "rich-text",
   label: "Text Block",
   icon: TextBlockIcon,
@@ -33,6 +33,7 @@ export const meta: WsComponentMeta = {
       children: [{ type: "text", value: "Block of text you can edit" }],
     },
   ],
+  order: 0,
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/react-sdk/src/components/textarea.ws.tsx
+++ b/packages/react-sdk/src/components/textarea.ws.tsx
@@ -23,6 +23,7 @@ export const meta: WsComponentMeta = {
   label: "Text Area",
   icon: FormTextAreaIcon,
   presetStyle,
+  order: 4,
   states: [
     ...defaultStates,
     { selector: "::placeholder", label: "Placeholder" },


### PR DESCRIPTION
## Description

We want to be able to specify the order in which components are shown in the panel.

Right now the order property is not set where needed, because I am waiting for feedback from @taylornowotny 

## Steps for reproduction

1. Open add components panel
2. See components are in the right order

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @taylornowotny  , I need you to do
  - give some thought to both components that need to be first which we set specific order to (the rest will go as is)
  - recheck the categories, I feel like our split into categories is not intentional

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
