### PR TITLE
Enforce node protocol

### DIFF
--- a/apps/builder/app/shared/asset-client.ts
+++ b/apps/builder/app/shared/asset-client.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import * as path from "node:path";
 import { MaxSize } from "@webstudio-is/asset-uploader";
 import {
   createFsClient,

--- a/packages/asset-uploader/src/utils/get-unique-filename.ts
+++ b/packages/asset-uploader/src/utils/get-unique-filename.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import * as path from "node:path";
 import { nanoid } from "nanoid";
 
 export const getUniqueFilename = (filename: string): string => {

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -32,11 +32,12 @@ module.exports = {
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": "off",
     "func-style": ["error", "expression", { allowArrowFunctions: true }],
-    "unicorn/filename-case": ["error", { case: "kebabCase" }],
     curly: 2,
     eqeqeq: ["error", "always", { null: "ignore" }],
     camelcase: [2, { properties: "never" }],
     radix: 2,
+    "unicorn/filename-case": ["error", { case: "kebabCase" }],
+    "unicorn/prefer-node-protocol": "error",
     "import/no-internal-modules": [
       "error",
       {

--- a/packages/generate-arg-types/src/cli.ts
+++ b/packages/generate-arg-types/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env tsx
 /* eslint-disable no-console */
 
-import path from "path";
+import * as path from "node:path";
 import { withCustomConfig } from "react-docgen-typescript";
 import fg from "fast-glob";
 import fs from "fs-extra";


### PR DESCRIPTION
Enable unicorn eslint rule to enforce `node:fs` like specifiers for node modules.

Previously `node:` prefix helped to find server code bundled in browser.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
