### PR TITLE
Use meta stored in atom in builder and canvas

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -43,10 +43,6 @@ import { useSearchParams } from "@remix-run/react";
 import { useSyncInitializeOnce } from "~/shared/hook-utils";
 import { BlockingAlerts } from "./features/blocking-alerts";
 import { useStore } from "@nanostores/react";
-import {
-  customComponentMetas,
-  registerComponentMetas,
-} from "@webstudio-is/react-sdk";
 
 registerContainers();
 
@@ -233,10 +229,6 @@ export type BuilderProps = {
   authToken?: string;
   authPermit: AuthPermit;
 };
-
-// @todo: Don't do this in builder
-// https://github.com/webstudio-is/webstudio-builder/issues/1545
-registerComponentMetas(customComponentMetas);
 
 export const Builder = ({
   project,

--- a/apps/builder/app/builder/features/inspector/inspector.tsx
+++ b/apps/builder/app/builder/features/inspector/inspector.tsx
@@ -1,7 +1,6 @@
 import { useRef, useState } from "react";
 import { useStore } from "@nanostores/react";
 import type { Instance } from "@webstudio-is/project-build";
-import { getComponentMeta } from "@webstudio-is/react-sdk";
 import {
   theme,
   PanelTabs,
@@ -19,7 +18,11 @@ import type { Publish } from "~/shared/pubsub";
 import { StylePanel } from "~/builder/features/style-panel";
 import { PropsPanelContainer } from "~/builder/features/props-panel";
 import { FloatingPanelProvider } from "~/builder/shared/floating-panel";
-import { selectedInstanceStore, isDraggingStore } from "~/shared/nano-states";
+import {
+  selectedInstanceStore,
+  isDraggingStore,
+  registeredComponentMetasStore,
+} from "~/shared/nano-states";
 import { SettingsPanel } from "../settings-panel";
 import { NavigatorTree } from "~/builder/shared/navigator-tree";
 import type { Settings } from "~/builder/shared/client-settings";
@@ -27,7 +30,8 @@ import { MetaIcon } from "~/builder/shared/meta-icon";
 import { getInstanceLabel } from "~/builder/shared/tree";
 
 const InstanceInfo = ({ instance }: { instance: Instance }) => {
-  const componentMeta = getComponentMeta(instance.component);
+  const metas = useStore(registeredComponentMetasStore);
+  const componentMeta = metas.get(instance.component);
   if (componentMeta === undefined) {
     return null;
   }

--- a/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
@@ -1,16 +1,19 @@
 import { useStore } from "@nanostores/react";
 import { Flex, Label, theme, InputField } from "@webstudio-is/design-system";
-import { getComponentMeta } from "@webstudio-is/react-sdk";
-import { selectedInstanceStore } from "~/shared/nano-states";
+import {
+  registeredComponentMetasStore,
+  selectedInstanceStore,
+} from "~/shared/nano-states";
 import { useSettingsLogic } from "./use-settings-logic";
 
 export const SettingsPanel = () => {
   const { setLabel, handleBlur, handleKeyDown } = useSettingsLogic();
   const selectedInstance = useStore(selectedInstanceStore);
+  const metas = useStore(registeredComponentMetasStore);
   if (selectedInstance === undefined) {
     return null;
   }
-  const label = getComponentMeta(selectedInstance.component)?.label;
+  const label = metas.get(selectedInstance.component)?.label;
   return (
     <Flex
       gap="1"

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@jest/globals";
+import { defaultMetas } from "@webstudio-is/react-sdk";
 import type {
   Breakpoints,
   Instance,
@@ -13,6 +14,8 @@ import {
   getNextSourceInfo,
   getPreviousSourceInfo,
 } from "./style-info";
+
+const metas = new Map(Object.entries(defaultMetas));
 
 const breakpoints: Breakpoints = new Map([
   ["1", { id: "1", label: "1", minWidth: 0 }],
@@ -162,6 +165,7 @@ test("compute inherited styles", () => {
   expect(
     getInheritedInfo(
       instances,
+      metas,
       inheritingStylesByInstanceId,
       selectedInstanceSelector,
       new Map([

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useStore } from "@nanostores/react";
+import type { htmlTags as HtmlTags } from "html-tags";
 import {
   html,
   type Style,
@@ -16,6 +17,7 @@ import {
   type StyleSource as StyleSourceType,
   Breakpoint,
 } from "@webstudio-is/project-build";
+import { compareMedia } from "@webstudio-is/css-engine";
 import {
   type StyleSourceSelector,
   instancesStore,
@@ -26,12 +28,11 @@ import {
   selectedOrLastStyleSourceSelectorStore,
   breakpointsStore,
   styleSourceSelectionsStore,
+  registeredComponentMetasStore,
 } from "~/shared/nano-states";
 import { selectedBreakpointStore } from "~/shared/nano-states";
 import type { InstanceSelector } from "~/shared/tree-utils";
-import { getComponentMeta } from "@webstudio-is/react-sdk";
-import type { htmlTags as HtmlTags } from "html-tags";
-import { compareMedia } from "@webstudio-is/css-engine";
+import type { WsComponentMeta } from "@webstudio-is/react-sdk";
 
 type CascadedValueInfo = {
   breakpointId: string;
@@ -242,11 +243,10 @@ export const getInstanceComponent = (
 };
 
 export const getPresetStyleRule = (
-  component: string,
+  meta: undefined | WsComponentMeta,
   tagName: HtmlTags,
   styleSourceSelector?: StyleSourceSelector
 ) => {
-  const meta = getComponentMeta(component);
   const presetStyles = meta?.presetStyle?.[tagName];
   if (presetStyles === undefined) {
     return;
@@ -270,6 +270,7 @@ export const getPresetStyleRule = (
  */
 export const getInheritedInfo = (
   instances: Instances,
+  metas: Map<string, WsComponentMeta>,
   stylesByInstanceId: Map<Instance["id"], StyleDecl[]>,
   instanceSelector: InstanceSelector,
   selectedInstanceIntanceToTag: Map<Instance["id"], HtmlTags>,
@@ -292,7 +293,7 @@ export const getInheritedInfo = (
     const component = getInstanceComponent(instances, instanceId);
     const presetStyle =
       tagName !== undefined && component !== undefined
-        ? getComponentMeta(component)?.presetStyle?.[tagName]
+        ? metas.get(component)?.presetStyle?.[tagName]
         : undefined;
     if (presetStyle) {
       for (const styleDecl of presetStyle) {
@@ -417,6 +418,7 @@ export const useStyleInfo = () => {
   );
 
   const instances = useStore(instancesStore);
+  const metas = useStore(registeredComponentMetasStore);
   const { stylesByInstanceId, stylesByStyleSourceId } =
     useStore(stylesIndexStore);
   const styleSourceSelections = useStore(styleSourceSelectionsStore);
@@ -454,6 +456,7 @@ export const useStyleInfo = () => {
     }
     return getInheritedInfo(
       instances,
+      metas,
       stylesByInstanceId,
       selectedInstanceSelector,
       selectedInstanceIntanceToTag,
@@ -462,6 +465,7 @@ export const useStyleInfo = () => {
     );
   }, [
     instances,
+    metas,
     stylesByInstanceId,
     cascadedBreakpointIds,
     selectedBreakpointId,
@@ -540,12 +544,13 @@ export const useStyleInfo = () => {
       return;
     }
     return getPresetStyleRule(
-      component,
+      metas.get(component),
       tagName,
       selectedOrLastStyleSourceSelector
     );
   }, [
     instances,
+    metas,
     selectedInstanceSelector,
     selectedInstanceIntanceToTag,
     selectedOrLastStyleSourceSelector,
@@ -638,6 +643,7 @@ export const useInstanceStyleData = (
   instanceSelector: InstanceSelector | undefined
 ) => {
   const instances = useStore(instancesStore);
+  const metas = useStore(registeredComponentMetasStore);
   const { stylesByInstanceId } = useStore(stylesIndexStore);
   const breakpoints = useStore(breakpointsStore);
   const selectedBreakpoint = useStore(selectedBreakpointStore);
@@ -660,8 +666,8 @@ export const useInstanceStyleData = (
     if (tagName === undefined || component === undefined) {
       return;
     }
-    return getPresetStyleRule(component, tagName);
-  }, [instances, instanceSelector, selectedInstanceIntanceToTag]);
+    return getPresetStyleRule(metas.get(component), tagName);
+  }, [instances, metas, instanceSelector, selectedInstanceIntanceToTag]);
 
   const cascadedBreakpointIds = useMemo(
     () => getCascadedBreakpointIds(breakpoints, selectedBreakpointId),
@@ -693,6 +699,7 @@ export const useInstanceStyleData = (
     }
     return getInheritedInfo(
       instances,
+      metas,
       stylesByInstanceId,
       instanceSelector,
       selectedInstanceIntanceToTag,
@@ -701,6 +708,7 @@ export const useInstanceStyleData = (
     );
   }, [
     instances,
+    metas,
     stylesByInstanceId,
     cascadedBreakpointIds,
     selectedBreakpointId,

--- a/apps/builder/app/builder/features/style-panel/style-source-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.tsx
@@ -9,10 +9,10 @@ import {
   type StyleSourceSelections,
   getStyleDeclKey,
 } from "@webstudio-is/project-build";
-import { getComponentMeta } from "@webstudio-is/react-sdk";
 import { type ItemSource, StyleSourceInput } from "./style-source";
 import {
   availableStyleSourcesStore,
+  registeredComponentMetasStore,
   selectedInstanceSelectorStore,
   selectedInstanceStatesByStyleSourceIdStore,
   selectedInstanceStore,
@@ -285,12 +285,12 @@ const renameStyleSource = (id: StyleSource["id"], label: string) => {
 };
 
 const componentStatesStore = computed(
-  [selectedInstanceStore],
-  (selectedInstance) => {
+  [selectedInstanceStore, registeredComponentMetasStore],
+  (selectedInstance, registeredComponentMetas) => {
     if (selectedInstance === undefined) {
       return;
     }
-    return getComponentMeta(selectedInstance.component)?.states;
+    return registeredComponentMetas.get(selectedInstance.component)?.states;
   }
 );
 

--- a/apps/builder/app/builder/features/workspace/canvas-tools/outline/label.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/outline/label.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useState } from "react";
+import { useStore } from "@nanostores/react";
 import { styled, type Rect } from "@webstudio-is/design-system";
 import type { Instance } from "@webstudio-is/project-build";
-import { getComponentMeta } from "@webstudio-is/react-sdk";
 import { theme } from "@webstudio-is/design-system";
 import { getInstanceLabel } from "~/builder/shared/tree";
 import { MetaIcon } from "~/builder/shared/meta-icon";
+import { registeredComponentMetasStore } from "~/shared/nano-states";
 
 type LabelPosition = "top" | "inside" | "bottom";
 type LabelRefCallback = (element: HTMLElement | null) => void;
@@ -80,7 +81,8 @@ type LabelProps = {
 
 export const Label = ({ instance, instanceRect }: LabelProps) => {
   const [labelRef, position] = useLabelPosition(instanceRect);
-  const meta = getComponentMeta(instance?.component);
+  const metas = useStore(registeredComponentMetasStore);
+  const meta = metas.get(instance.component);
   if (meta === undefined) {
     return <></>;
   }

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -8,7 +8,6 @@ import {
   defaultMetas,
   defaultPropsMetas,
   createElementsTree,
-  registerComponentMetas as registerComponentMetasLegacy,
   customComponentMetas,
   customComponentPropsMetas,
   setParams,
@@ -135,7 +134,6 @@ export const Canvas = ({ params }: CanvasProps): JSX.Element | null => {
   const components = new Map(
     Object.entries({ ...defaultComponents, ...customComponents })
   ) as Components;
-  registerComponentMetasLegacy(customComponentMetas);
   useSyncInitializeOnce(() => {
     registerComponentMetas(defaultMetas);
     registerComponentPropsMetas(defaultPropsMetas);

--- a/apps/builder/app/canvas/collapsed.ts
+++ b/apps/builder/app/canvas/collapsed.ts
@@ -8,6 +8,7 @@ import {
 import {
   breakpointsStore,
   instancesStore,
+  registeredComponentMetasStore,
   stylesIndexStore,
 } from "~/shared/nano-states";
 import { selectedBreakpointStore } from "~/shared/nano-states";
@@ -46,6 +47,7 @@ const replacedHtmlElements = ["IFRAME", "VIDEO", "EMBED", "IMG"];
 const skipElementsSet = new Set([...voidHtmlElements, ...replacedHtmlElements]);
 
 const getInstanceSize = (instanceId: string, tagName: HtmlTags | undefined) => {
+  const metas = registeredComponentMetasStore.get();
   const breakpoints = breakpointsStore.get();
   const selectedBreakpoint = selectedBreakpointStore.get();
   const { stylesByInstanceId } = stylesIndexStore.get();
@@ -67,7 +69,7 @@ const getInstanceSize = (instanceId: string, tagName: HtmlTags | undefined) => {
   const component = getInstanceComponent(instances, instanceId);
   const presetStyle =
     tagName !== undefined && component !== undefined
-      ? getPresetStyleRule(component, tagName)
+      ? getPresetStyleRule(metas.get(component), tagName)
       : undefined;
 
   const cascadedStyle = getCascadedInfo(stylesByInstanceId, instanceId, [

--- a/apps/builder/app/canvas/instance-selection.ts
+++ b/apps/builder/app/canvas/instance-selection.ts
@@ -1,7 +1,7 @@
-import { getComponentMeta } from "@webstudio-is/react-sdk";
 import { getInstanceSelectorFromElement } from "~/shared/dom-utils";
 import {
   instancesStore,
+  registeredComponentMetasStore,
   selectedInstanceSelectorStore,
   selectedStyleSourceSelectorStore,
 } from "~/shared/nano-states";
@@ -22,11 +22,12 @@ const findClosestRichTextInstanceSelector = (
   instanceSelector: InstanceSelector
 ) => {
   const instances = instancesStore.get();
+  const metas = registeredComponentMetasStore.get();
   for (const instanceId of instanceSelector) {
     const instance = instances.get(instanceId);
     if (
       instance !== undefined &&
-      getComponentMeta(instance.component)?.type === "rich-text"
+      metas.get(instance.component)?.type === "rich-text"
     ) {
       return getAncestorInstanceSelector(instanceSelector, instanceId);
     }

--- a/apps/builder/app/canvas/shared/use-drag-drop.ts
+++ b/apps/builder/app/canvas/shared/use-drag-drop.ts
@@ -9,7 +9,6 @@ import {
   useDrop,
   computeIndicatorPlacement,
 } from "@webstudio-is/design-system";
-import { getComponentMeta } from "@webstudio-is/react-sdk";
 import {
   instancesStore,
   registeredComponentMetasStore,
@@ -62,11 +61,12 @@ const findClosestRichTextInstanceSelector = (
   instanceSelector: InstanceSelector
 ) => {
   const instances = instancesStore.get();
+  const metas = registeredComponentMetasStore.get();
   for (const instanceId of instanceSelector) {
     const instance = instances.get(instanceId);
     if (
       instance !== undefined &&
-      getComponentMeta(instance.component)?.type === "rich-text"
+      metas.get(instance.component)?.type === "rich-text"
     ) {
       return getAncestorInstanceSelector(instanceSelector, instanceId);
     }

--- a/apps/builder/app/shared/nano-states/instances.ts
+++ b/apps/builder/app/shared/nano-states/instances.ts
@@ -1,9 +1,9 @@
 import { atom, computed } from "nanostores";
-import { getComponentMeta } from "@webstudio-is/react-sdk";
 import type { Instance, Instances } from "@webstudio-is/project-build";
 import type { InstanceSelector } from "../tree-utils";
 import { getElementByInstanceSelector } from "../dom-utils";
 import { useSyncInitializeOnce } from "../hook-utils";
+import { registeredComponentMetasStore } from "./components-meta";
 
 export const isResizingCanvasStore = atom(false);
 
@@ -25,7 +25,8 @@ export const enterEditingMode = (event?: KeyboardEvent) => {
     return;
   }
 
-  const meta = getComponentMeta(selectedInstance.component);
+  const metas = registeredComponentMetasStore.get();
+  const meta = metas.get(selectedInstance.component);
   if (meta?.type !== "rich-text") {
     return;
   }

--- a/packages/react-sdk/src/components/index.ts
+++ b/packages/react-sdk/src/components/index.ts
@@ -105,22 +105,6 @@ export const defaultMetas: Record<string, WsComponentMeta> = {
   Checkbox: CheckboxMeta,
 };
 
-let currentMetas = defaultMetas;
-
-export const getComponentMeta = (name: string): WsComponentMeta | undefined => {
-  return currentMetas[name];
-};
-
-export const registerComponentMetas = (
-  overrides: Record<string, Partial<WsComponentMeta>>
-) => {
-  const result: typeof currentMetas = {};
-  for (const name of Object.keys(defaultMetas)) {
-    result[name] = { ...defaultMetas[name], ...overrides[name] };
-  }
-  currentMetas = result;
-};
-
 // @todo this list should not be hardcoded!
 export const defaultPropsMetas: Record<string, WsComponentPropsMeta> = {
   Slot: SlotMetaPropsMeta,


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1545

All complex use cases already switched to get meta from arguments and from atom.

Here migrated the last cases and dropped legacy meta register in react-sdk package. Now we ready to split components into separate packages.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
