### PR TITLE
Add domains to publish

### DIFF
--- a/apps/builder/app/builder/features/topbar/domains.tsx
+++ b/apps/builder/app/builder/features/topbar/domains.tsx
@@ -67,10 +67,13 @@ const getCname = (domain: string) => {
   return cnameArray.join(".");
 };
 
-const getStatusText = (props: { projectDomain: Domain }) => {
-  const status = props.projectDomain.verified
-    ? (`VERIFIED_${props.projectDomain.domain.status}` as `VERIFIED_${DomainStatus}`)
+export const getStatus = (projectDomain: Domain) =>
+  projectDomain.verified
+    ? (`VERIFIED_${projectDomain.domain.status}` as const)
     : `UNVERIFIED`;
+
+const getStatusText = (props: { projectDomain: Domain }) => {
+  const status = getStatus(props.projectDomain);
 
   let isVerifiedActive = false;
   let text = "Something went wrong";

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -23,7 +23,7 @@ import { getPublishedUrl } from "~/shared/router-utils";
 import { theme } from "@webstudio-is/design-system";
 import { useAuthPermit } from "~/shared/nano-states";
 import { isFeatureEnabled } from "@webstudio-is/feature-flags";
-import { Domains } from "./domains";
+import { Domains, getStatus } from "./domains";
 import { CollapsibleDomainSection } from "./collapsible-domain-section";
 import {
   CheckCircleIcon,
@@ -207,7 +207,13 @@ const ChangeProjectDomain = (props: PublishButtonProps) => {
   );
 };
 
-const Publish = ({ projectId }: { projectId: Project["id"] }) => {
+const Publish = ({
+  projectId,
+  domains,
+}: {
+  projectId: Project["id"];
+  domains: string[];
+}) => {
   const {
     send: publish,
     state: publishState,
@@ -239,7 +245,7 @@ const Publish = ({ projectId }: { projectId: Project["id"] }) => {
         color="positive"
         disabled={publishState !== "idle"}
         onClick={() => {
-          publish({ projectId });
+          publish({ projectId, domains });
         }}
       >
         Publish
@@ -259,6 +265,16 @@ const Content = (props: PublishButtonProps) => {
   useEffect(() => {
     refreshDomainResult({ projectId: props.project.id });
   }, [refreshDomainResult, props.project.id]);
+
+  // In the future we would allow to select what domains to publish,
+  // now we just publish all verified and active domains
+  const domainsToPublish = domainsResult?.success
+    ? domainsResult.data
+        .filter(
+          (projectDomain) => getStatus(projectDomain) === "VERIFIED_ACTIVE"
+        )
+        .map((projectDomain) => projectDomain.domain.domain)
+    : [];
 
   return (
     <>
@@ -308,7 +324,7 @@ const Content = (props: PublishButtonProps) => {
         </>
       )}
 
-      <Publish projectId={props.project.id} />
+      <Publish projectId={props.project.id} domains={domainsToPublish} />
     </>
   );
 };

--- a/apps/builder/app/routes/rest.build.$buildId.tsx
+++ b/apps/builder/app/routes/rest.build.$buildId.tsx
@@ -21,7 +21,7 @@ export const loader = async ({
       throw json("Required project id", { status: 400 });
     }
 
-    const context = await createContext(request, "prod");
+    const context = await createContext(request);
 
     const pagesCanvasData = await loadProductionCanvasData(buildId, context);
 

--- a/packages/domain/src/db/domain.ts
+++ b/packages/domain/src/db/domain.ts
@@ -32,7 +32,7 @@ export const findMany = async (
 > => {
   // Only builder of the project can list domains
   const canList = await authorizeProject.hasProjectPermit(
-    { projectId: props.projectId, permit: "build" },
+    { projectId: props.projectId, permit: "view" },
     context
   );
 

--- a/packages/domain/src/index.server.ts
+++ b/packages/domain/src/index.server.ts
@@ -1,1 +1,2 @@
 export * from "./trpc";
+export * from "./db";

--- a/packages/domain/src/trpc/domain.ts
+++ b/packages/domain/src/trpc/domain.ts
@@ -25,14 +25,14 @@ export const domainRouter = router({
       }
     }),
   publish: procedure
-    .input(z.object({ projectId: z.string() }))
+    .input(z.object({ projectId: z.string(), domains: z.array(z.string()) }))
     .mutation(async ({ input, ctx }) => {
       try {
         const build = await createProductionBuild(
           {
             projectId: input.projectId,
             deployment: {
-              domains: [],
+              domains: input.domains,
             },
           },
           ctx

--- a/packages/project-build/src/db/build.ts
+++ b/packages/project-build/src/db/build.ts
@@ -188,6 +188,8 @@ export const cloneBuild = async (
   const data = {
     ...build,
     id: undefined,
+    createdAt: undefined,
+    updatedAt: undefined,
     deployment: props.deployment
       ? serializeDeployment(props.deployment)
       : undefined,

--- a/packages/trpc-interface/src/authorize/project.server.ts
+++ b/packages/trpc-interface/src/authorize/project.server.ts
@@ -47,7 +47,7 @@ export const hasProjectPermit = async (
     const namespace = "Project";
 
     // Allow load production build env i.e. "published" site
-    if (props.permit === "view" && context.authorization.buildEnv === "prod") {
+    if (props.permit === "view" && context.authorization.isServiceCall) {
       return true;
     }
 

--- a/packages/trpc-interface/src/context/context.server.ts
+++ b/packages/trpc-interface/src/context/context.server.ts
@@ -15,9 +15,9 @@ type AuthorizationContext = {
   authToken: string | undefined;
 
   /**
-   * buildEnv==="prod" only if we are loading project with production build
+   * Allow service 2 service communications to skip authorization for view calls
    */
-  buildEnv: "dev" | "prod";
+  isServiceCall: boolean;
 
   // Pass trpcClient through context as only main app can initialize it
   authorizeTrpc: TrpcInterfaceClient["authorize"];


### PR DESCRIPTION
## Description

At publish we would allow to check domains we want to publish. As of now we publish all project domains.

But already pass them from UI, so future move would be just UI changes, without touching API

- [x] - Fix "no access to project domains using service api call"

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
