### PR TITLE
Token deletion confirmation

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.tsx
@@ -6,9 +6,20 @@ import store from "immerhin";
 import {
   type Instance,
   type StyleSource,
+  type StyleSourceToken,
   type StyleSourceSelections,
   getStyleDeclKey,
 } from "@webstudio-is/project-build";
+import {
+  Flex,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogClose,
+  Button,
+  Text,
+  theme,
+} from "@webstudio-is/design-system";
 import { type ItemSource, StyleSourceInput } from "./style-source";
 import {
   availableStyleSourcesStore,
@@ -341,53 +352,118 @@ export const StyleSourcesSection = () => {
     undefined | StyleSource["id"]
   >(undefined);
 
+  const [tokenToDelete, setTokenToDelete] = useState<StyleSourceToken>();
+
   return (
-    <StyleSourceInput
-      items={items}
-      value={value}
-      selectedItemSelector={selectedOrLastStyleSourceSelector}
-      componentStates={componentStates}
-      onCreateItem={createStyleSource}
-      onSelectAutocompleteItem={({ id }) => {
-        addStyleSourceToInstace(id);
-      }}
-      onDuplicateItem={(id) => {
-        const newId = duplicateStyleSource(id);
-        if (newId !== undefined) {
-          setEditingItemId(newId);
+    <>
+      <StyleSourceInput
+        items={items}
+        value={value}
+        selectedItemSelector={selectedOrLastStyleSourceSelector}
+        componentStates={componentStates}
+        onCreateItem={createStyleSource}
+        onSelectAutocompleteItem={({ id }) => {
+          addStyleSourceToInstace(id);
+        }}
+        onDuplicateItem={(id) => {
+          const newId = duplicateStyleSource(id);
+          if (newId !== undefined) {
+            setEditingItemId(newId);
+          }
+        }}
+        onConvertToToken={(id) => {
+          convertLocalStyleSourceToToken(id);
+          setEditingItemId(id);
+        }}
+        onRemoveItem={(id) => {
+          removeStyleSourceFromInstance(id);
+        }}
+        onDeleteItem={(id) => {
+          const token = availableStyleSources.find(
+            (source) => source.id === id
+          );
+          if (token?.type === "token") {
+            setTokenToDelete(token);
+          }
+        }}
+        onSort={(items) => {
+          reorderStyleSources(items.map((item) => item.id));
+        }}
+        onSelectItem={(styleSourceSelector) => {
+          createLocalStyleSourceIfNotExists(styleSourceSelector.styleSourceId);
+          selectedStyleSourceSelectorStore.set(styleSourceSelector);
+        }}
+        // style source renaming
+        editingItemId={editingItemId}
+        onEditItem={(id) => {
+          setEditingItemId(id);
+          // prevent deselect after renaming
+          if (id !== undefined) {
+            selectedStyleSourceSelectorStore.set({
+              styleSourceId: id,
+            });
+          }
+        }}
+        onChangeItem={(item) => {
+          renameStyleSource(item.id, item.label);
+        }}
+      />
+      {tokenToDelete && (
+        <DeleteConfirmationDialog
+          onClose={() => {
+            setTokenToDelete(undefined);
+          }}
+          onConfirm={() => {
+            deleteStyleSource(tokenToDelete.id);
+          }}
+          token={tokenToDelete.name}
+        />
+      )}
+    </>
+  );
+};
+
+type DeleteConfirmationDialogProps = {
+  onClose: () => void;
+  onConfirm: () => void;
+  token: string;
+};
+
+const DeleteConfirmationDialog = ({
+  onClose,
+  onConfirm,
+  token,
+}: DeleteConfirmationDialogProps) => {
+  return (
+    <Dialog
+      open
+      onOpenChange={(isOpen) => {
+        if (isOpen === false) {
+          onClose();
         }
       }}
-      onConvertToToken={(id) => {
-        convertLocalStyleSourceToToken(id);
-        setEditingItemId(id);
-      }}
-      onRemoveItem={(id) => {
-        removeStyleSourceFromInstance(id);
-      }}
-      onDeleteItem={(id) => {
-        deleteStyleSource(id);
-      }}
-      onSort={(items) => {
-        reorderStyleSources(items.map((item) => item.id));
-      }}
-      onSelectItem={(styleSourceSelector) => {
-        createLocalStyleSourceIfNotExists(styleSourceSelector.styleSourceId);
-        selectedStyleSourceSelectorStore.set(styleSourceSelector);
-      }}
-      // style source renaming
-      editingItemId={editingItemId}
-      onEditItem={(id) => {
-        setEditingItemId(id);
-        // prevent deselect after renaming
-        if (id !== undefined) {
-          selectedStyleSourceSelectorStore.set({
-            styleSourceId: id,
-          });
-        }
-      }}
-      onChangeItem={(item) => {
-        renameStyleSource(item.id, item.label);
-      }}
-    />
+    >
+      <DialogContent>
+        <Flex gap="3" direction="column" css={{ padding: theme.spacing[9] }}>
+          <Text>{`Delete "${token}" token from the entire project including all of it's styles?`}</Text>
+          <Flex direction="rowReverse" gap="2">
+            <DialogClose asChild>
+              <Button
+                color="destructive"
+                onClick={() => {
+                  onConfirm();
+                }}
+              >
+                Yes, Delete
+              </Button>
+            </DialogClose>
+            <DialogClose asChild>
+              <Button color="ghost">Cancel</Button>
+            </DialogClose>
+          </Flex>
+        </Flex>
+        <DialogTitle>Delete confirmation</DialogTitle>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/apps/builder/app/builder/features/style-panel/style-source-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.tsx
@@ -445,7 +445,7 @@ const DeleteConfirmationDialog = ({
     >
       <DialogContent>
         <Flex gap="3" direction="column" css={{ padding: theme.spacing[9] }}>
-          <Text>{`Delete "${token}" token from the entire project including all of it's styles?`}</Text>
+          <Text>{`Delete "${token}" token from the project including all of its styles?`}</Text>
           <Flex direction="rowReverse" gap="2">
             <DialogClose asChild>
               <Button
@@ -454,7 +454,7 @@ const DeleteConfirmationDialog = ({
                   onConfirm();
                 }}
               >
-                Yes, Delete
+                Delete
               </Button>
             </DialogClose>
             <DialogClose asChild>

--- a/packages/project-build/src/schema/style-sources.ts
+++ b/packages/project-build/src/schema/style-sources.ts
@@ -8,6 +8,8 @@ const StyleSourceToken = z.object({
   name: z.string(),
 });
 
+export type StyleSourceToken = z.infer<typeof StyleSourceToken>;
+
 const StyleSourceLocal = z.object({
   type: z.literal("local"),
   id: StyleSourceId,


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio-builder/issues/1672

## Description

We need to show a confirmation dialog when user hits delete to explain what will happen

## Steps for reproduction

1. add a token
2. click delete

<img width="906" alt="Screenshot 2023-05-31 at 15 25 43" src="https://github.com/webstudio-is/webstudio-builder/assets/52824/eb7eb635-3c07-4bdc-bfdc-6e5cd7983d73">


## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
