### PR TITLE
Make css value suffix optional and preventable

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
@@ -294,6 +294,7 @@ export const ColorPicker = ({
     <CssValueInput
       styleSource={styleSource}
       prefix={prefix}
+      suffix={false}
       property={property}
       value={value}
       intermediateValue={intermediateValue}

--- a/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
@@ -294,7 +294,7 @@ export const ColorPicker = ({
     <CssValueInput
       styleSource={styleSource}
       prefix={prefix}
-      suffix={false}
+      showSuffix={false}
       property={property}
       value={value}
       intermediateValue={intermediateValue}

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -257,6 +257,7 @@ type CssValueInputProps = {
   onAbort: () => void;
   icon?: ReactNode;
   prefix?: ReactNode;
+  suffix?: ReactNode;
 };
 
 const initialValue: IntermediateStyleValue = {
@@ -317,6 +318,7 @@ const match = <Item,>(
 export const CssValueInput = ({
   icon,
   prefix,
+  suffix,
   styleSource,
   property,
   keywords = [],
@@ -574,15 +576,16 @@ export const CssValueInput = ({
   const isKeywordValue = value.type === "keyword" && hasItems;
   const suffixRef = useRef<HTMLDivElement | null>(null);
 
-  const suffix = (
-    <Box ref={suffixRef}>
-      {isUnitValue
-        ? unitSelectElement
-        : isKeywordValue
-        ? keywordButtonElement
-        : null}
-    </Box>
-  );
+  suffix =
+    suffix === false ? null : (
+      <Box ref={suffixRef}>
+        {isUnitValue
+          ? unitSelectElement
+          : isKeywordValue
+          ? keywordButtonElement
+          : null}
+      </Box>
+    );
 
   return (
     <Combobox>

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -257,7 +257,7 @@ type CssValueInputProps = {
   onAbort: () => void;
   icon?: ReactNode;
   prefix?: ReactNode;
-  suffix?: ReactNode;
+  showSuffix?: boolean;
 };
 
 const initialValue: IntermediateStyleValue = {
@@ -318,7 +318,7 @@ const match = <Item,>(
 export const CssValueInput = ({
   icon,
   prefix,
-  suffix,
+  showSuffix = true,
   styleSource,
   property,
   keywords = [],
@@ -576,8 +576,8 @@ export const CssValueInput = ({
   const isKeywordValue = value.type === "keyword" && hasItems;
   const suffixRef = useRef<HTMLDivElement | null>(null);
 
-  suffix =
-    suffix === false ? null : (
+  const suffix =
+    showSuffix === false ? null : (
       <Box ref={suffixRef}>
         {isUnitValue
           ? unitSelectElement


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio-builder/issues/1247
## Description

We want color controls to not have the suffix button

## Steps for reproduction

1. open style panel
2. see color controls have no suffix button

## Code Review

- [ ] hi @trysound, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
