### PR TITLE
Fix sdk-components-react-remix types

### DIFF
--- a/packages/sdk-components-react-remix/index.d.ts
+++ b/packages/sdk-components-react-remix/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./lib/types/components";

--- a/packages/sdk-components-react-remix/metas.d.ts
+++ b/packages/sdk-components-react-remix/metas.d.ts
@@ -1,0 +1,1 @@
+export * from "./lib/types/metas";

--- a/packages/sdk-components-react-remix/package.json
+++ b/packages/sdk-components-react-remix/package.json
@@ -7,7 +7,6 @@
   "license": "MIT",
   "private": false,
   "type": "module",
-  "types": "lib/types/index.d.ts",
   "files": [
     "lib/*",
     "src/*"
@@ -16,16 +15,19 @@
   "exports": {
     ".": {
       "source": "./src/components.ts",
+      "types": "./lib/types/components.d.ts",
       "import": "./lib/components.js",
       "require": "./lib/cjs/components.js"
     },
     "./metas": {
       "source": "./src/metas.ts",
+      "types": "./lib/types/metas.d.ts",
       "import": "./lib/metas.js",
       "require": "./lib/cjs/metas.js"
     },
     "./props": {
       "source": "./src/props.ts",
+      "types": "./lib/types/props.d.ts",
       "import": "./lib/props.js",
       "require": "./lib/cjs/props.js"
     }

--- a/packages/sdk-components-react-remix/props.d.ts
+++ b/packages/sdk-components-react-remix/props.d.ts
@@ -1,0 +1,1 @@
+export * from "./lib/types/props";


### PR DESCRIPTION
Here added types in exports and .d.ts for legacy module resolution.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
