### PR TITLE
Specify types with exports condition

### DIFF
--- a/packages/asset-uploader/package.json
+++ b/packages/asset-uploader/package.json
@@ -40,14 +40,15 @@
     ".": {
       "source": "./src/index.ts",
       "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/types/index.d.ts"
     },
     "./index.server": {
       "source": "./src/index.server.ts",
-      "import": "./lib/index.server.js"
+      "import": "./lib/index.server.js",
+      "types": "./lib/types/index.server.d.ts"
     }
   },
-  "types": "lib/types/index.d.ts",
   "files": [
     "lib/*",
     "src/*",

--- a/packages/authorization-token/package.json
+++ b/packages/authorization-token/package.json
@@ -31,14 +31,15 @@
     ".": {
       "source": "./src/index.ts",
       "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/types/index.d.ts"
     },
     "./index.server": {
       "source": "./src/index.server.ts",
-      "import": "./lib/index.server.js"
+      "import": "./lib/index.server.js",
+      "types": "./lib/types/index.server.d.ts"
     }
   },
-  "types": "lib/types/index.d.ts",
   "files": [
     "lib/*",
     "src/*",

--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -35,9 +35,9 @@
   "exports": {
     "source": "./src/index.ts",
     "import": "./lib/index.js",
-    "require": "./lib/cjs/index.js"
+    "require": "./lib/cjs/index.js",
+    "types": "./lib/types/index.d.ts"
   },
-  "types": "lib/types/index.d.ts",
   "files": [
     "lib/*",
     "src/*",

--- a/packages/css-engine/package.json
+++ b/packages/css-engine/package.json
@@ -38,9 +38,9 @@
   },
   "exports": {
     "source": "./src/index.ts",
-    "import": "./lib/index.js"
+    "import": "./lib/index.js",
+    "types": "./lib/types/index.d.ts"
   },
-  "types": "lib/types/index.d.ts",
   "files": [
     "lib/*",
     "src/*",

--- a/packages/css-vars/package.json
+++ b/packages/css-vars/package.json
@@ -18,13 +18,12 @@
     "@webstudio-is/tsconfig": "workspace:^",
     "typescript": "5.0.3"
   },
-  "module": "./lib/index.js",
   "exports": {
     "source": "./src/index.ts",
     "import": "./lib/index.js",
-    "require": "./lib/cjs/index.js"
+    "require": "./lib/cjs/index.js",
+    "types": "./lib/types/index.d.ts"
   },
-  "types": "lib/types/index.d.ts",
   "files": [
     "lib/*",
     "src/*",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -31,14 +31,15 @@
     ".": {
       "source": "./src/index.ts",
       "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/types/index.d.ts"
     },
     "./index.server": {
       "source": "./src/index.server.ts",
-      "import": "./lib/index.server.js"
+      "import": "./lib/index.server.js",
+      "types": "./lib/types/index.server.d.ts"
     }
   },
-  "types": "lib/types/index.d.ts",
   "files": [
     "lib/*",
     "src/*",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -85,9 +85,9 @@
   },
   "exports": {
     "source": "./src/index.ts",
-    "import": "./lib/index.js"
+    "import": "./lib/index.js",
+    "types": "./lib/types/index.d.ts"
   },
-  "types": "lib/types/index.d.ts",
   "files": [
     "lib/*",
     "src/*",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -33,14 +33,15 @@
     ".": {
       "source": "./src/index.ts",
       "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/types/index.d.ts"
     },
     "./index.server": {
       "source": "./src/index.server.ts",
-      "import": "./lib/index.server.js"
+      "import": "./lib/index.server.js",
+      "types": "./lib/types/index.server.d.ts"
     }
   },
-  "types": "lib/types/index.d.ts",
   "files": [
     "lib/*",
     "src/*",

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -20,9 +20,9 @@
   },
   "exports": {
     "source": "./src/index.ts",
-    "import": "./lib/index.js"
+    "import": "./lib/index.js",
+    "types": "./lib/types/index.d.ts"
   },
-  "types": "lib/types/index.d.ts",
   "files": [
     "lib/*",
     "src/*",

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -31,19 +31,19 @@
   "peerDependencies": {
     "zod": "^3.19.1"
   },
-  "module": "./lib/index.js",
   "exports": {
     ".": {
       "source": "./src/index.ts",
       "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/types/index.d.ts"
     },
     "./index.server": {
       "source": "./src/index.server.ts",
-      "import": "./lib/index.server.js"
+      "import": "./lib/index.server.js",
+      "types": "./lib/types/index.server.d.ts"
     }
   },
-  "types": "lib/types/index.d.ts",
   "files": [
     "lib/*",
     "src/*",

--- a/packages/form-handlers/package.json
+++ b/packages/form-handlers/package.json
@@ -29,10 +29,10 @@
     ".": {
       "source": "./src/index.ts",
       "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/types/index.d.ts"
     }
   },
-  "types": "lib/types/index.d.ts",
   "files": [
     "lib/*",
     "src/*",

--- a/packages/form-handlers/package.json
+++ b/packages/form-handlers/package.json
@@ -26,12 +26,10 @@
     "typescript": "5.0.3"
   },
   "exports": {
-    ".": {
-      "source": "./src/index.ts",
-      "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js",
-      "types": "./lib/types/index.d.ts"
-    }
+    "source": "./src/index.ts",
+    "import": "./lib/index.js",
+    "require": "./lib/cjs/index.js",
+    "types": "./lib/types/index.d.ts"
   },
   "files": [
     "lib/*",

--- a/packages/generate-arg-types/package.json
+++ b/packages/generate-arg-types/package.json
@@ -37,9 +37,9 @@
   },
   "exports": {
     "source": "./src/index.ts",
-    "import": "./lib/index.js"
+    "import": "./lib/index.js",
+    "types": "./lib/types/index.d.ts"
   },
-  "types": "lib/types/index.d.ts",
   "license": "MIT",
   "private": false,
   "sideEffects": false

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -30,9 +30,9 @@
   },
   "exports": {
     "source": "./src/index.ts",
-    "import": "./lib/index.js"
+    "import": "./lib/index.js",
+    "types": "./lib/types/index.d.ts"
   },
-  "types": "lib/types/index.d.ts",
   "files": [
     "lib/*",
     "src/*",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -36,20 +36,20 @@
   "dependencies": {
     "@webstudio-is/css-vars": "workspace:^"
   },
-  "module": "./lib/index.js",
   "exports": {
     ".": {
       "source": "./src/index.ts",
       "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/types/index.d.ts"
     },
     "./svg": {
       "source": "./src/__generated__/svg/index.ts",
       "import": "./lib/__generated__/svg/index.js",
-      "require": "./lib/cjs/__generated__/svg/index.js"
+      "require": "./lib/cjs/__generated__/svg/index.js",
+      "types": "./lib/types/__generated__/svg/index.d.ts"
     }
   },
-  "types": "lib/types/index.d.ts",
   "files": [
     "lib/*",
     "src/*",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -40,9 +40,9 @@
   "exports": {
     "source": "./src/index.ts",
     "import": "./lib/index.js",
-    "require": "./lib/cjs/index.js"
+    "require": "./lib/cjs/index.js",
+    "types": "./lib/types/index.d.ts"
   },
-  "types": "lib/types/index.d.ts",
   "files": [
     "lib/*",
     "src/*",

--- a/packages/prisma-client/package.json
+++ b/packages/prisma-client/package.json
@@ -31,9 +31,9 @@
   "exports": {
     "source": "./src/index.ts",
     "import": "./lib/index.js",
-    "require": "./lib/cjs/index.js"
+    "require": "./lib/cjs/index.js",
+    "types": "./lib/index.d.ts"
   },
-  "types": "lib/index.d.ts",
   "license": "MIT",
   "private": false,
   "dependencies": {

--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -10,14 +10,15 @@
     ".": {
       "source": "./src/index.ts",
       "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/types/index.d.ts"
     },
     "./index.server": {
       "source": "./src/index.server.ts",
-      "import": "./lib/index.server.js"
+      "import": "./lib/index.server.js",
+      "types": "./lib/types/index.server.d.ts"
     }
   },
-  "types": "lib/types/index.d.ts",
   "files": [
     "lib/*",
     "src/*",

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -34,14 +34,15 @@
     ".": {
       "source": "./src/index.ts",
       "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/types/index.d.ts"
     },
     "./index.server": {
       "source": "./src/index.server.ts",
-      "import": "./lib/index.server.js"
+      "import": "./lib/index.server.js",
+      "types": "./lib/types/index.server.d.ts"
     }
   },
-  "types": "lib/types/index.d.ts",
   "files": [
     "lib/*",
     "src/*"

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -65,20 +65,22 @@
     ".": {
       "source": "./src/index.ts",
       "import": "./lib/index.js",
-      "require": "./lib/cjs/index.js"
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/types/index.d.ts"
     },
     "./components": {
       "source": "./src/components/components.ts",
       "import": "./lib/components/components.js",
-      "require": "./lib/cjs/components/components.js"
+      "require": "./lib/cjs/components/components.js",
+      "types": "./lib/types/components/components.d.ts"
     },
     "./css-normalize": {
       "source": "./src/css/normalize.ts",
       "import": "./lib/css/normalize.js",
-      "require": "./lib/cjs/css/normalize.js"
+      "require": "./lib/cjs/css/normalize.js",
+      "types": "./lib/types/css/normalize.d.ts"
     }
   },
-  "types": "lib/types/index.d.ts",
   "files": [
     "lib/*",
     "src/*",

--- a/packages/sdk-components-react-remix/index.d.ts
+++ b/packages/sdk-components-react-remix/index.d.ts
@@ -1,1 +1,0 @@
-export * from "./lib/types/components";

--- a/packages/sdk-components-react-remix/metas.d.ts
+++ b/packages/sdk-components-react-remix/metas.d.ts
@@ -1,1 +1,0 @@
-export * from "./lib/types/metas";

--- a/packages/sdk-components-react-remix/package.json
+++ b/packages/sdk-components-react-remix/package.json
@@ -15,21 +15,21 @@
   "exports": {
     ".": {
       "source": "./src/components.ts",
-      "types": "./lib/types/components.d.ts",
       "import": "./lib/components.js",
-      "require": "./lib/cjs/components.js"
+      "require": "./lib/cjs/components.js",
+      "types": "./lib/types/components.d.ts"
     },
     "./metas": {
       "source": "./src/metas.ts",
-      "types": "./lib/types/metas.d.ts",
       "import": "./lib/metas.js",
-      "require": "./lib/cjs/metas.js"
+      "require": "./lib/cjs/metas.js",
+      "types": "./lib/types/metas.d.ts"
     },
     "./props": {
       "source": "./src/props.ts",
-      "types": "./lib/types/props.d.ts",
       "import": "./lib/props.js",
-      "require": "./lib/cjs/props.js"
+      "require": "./lib/cjs/props.js",
+      "types": "./lib/types/props.d.ts"
     }
   },
   "scripts": {

--- a/packages/sdk-components-react-remix/props.d.ts
+++ b/packages/sdk-components-react-remix/props.d.ts
@@ -1,1 +1,0 @@
-export * from "./lib/types/props";


### PR DESCRIPTION
Saas is swithing to moduleResolution=bundler.
Here I replaced types top level field with exoprts condition in all our packages. Thi should fix issues with new sdk components packages and simplify using additional entry points.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
