### PR TITLE
Add toast when cannot add component

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
@@ -190,7 +190,7 @@ export const useDraggable = ({
     if (dropTarget === undefined) {
       const meta = metas.get(component);
       if (meta) {
-        toast(formatInsertionError(component, meta));
+        toast.error(formatInsertionError(component, meta));
       }
       return;
     }

--- a/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
@@ -8,6 +8,7 @@ import {
   Flex,
   useDrag,
   ComponentCard,
+  toast,
 } from "@webstudio-is/design-system";
 import {
   instancesStore,
@@ -96,6 +97,25 @@ export const elementToComponentName = (
   return false;
 };
 
+const formatInsertionError = (component: string, meta: WsComponentMeta) => {
+  const or = new Intl.ListFormat("en", {
+    type: "disjunction",
+  });
+  const and = new Intl.ListFormat("en", {
+    type: "conjunction",
+  });
+  const messages: string[] = [];
+  if (meta.requiredAncestors) {
+    const listString = or.format(meta.requiredAncestors);
+    messages.push(`can be added only inside of ${listString}`);
+  }
+  if (meta.invalidAncestors) {
+    const listString = and.format(meta.invalidAncestors);
+    messages.push(`cannot be added inside of ${listString}`);
+  }
+  return `${component} ${and.format(messages)}`;
+};
+
 export const useDraggable = ({
   publish,
   metaByComponentName,
@@ -156,16 +176,25 @@ export const useDraggable = ({
     if (selectedPage === undefined) {
       return;
     }
+    const instanceSelector = selectedInstanceSelectorStore.get() ?? [
+      selectedPage.rootInstanceId,
+    ];
+    const metas = registeredComponentMetasStore.get();
     const dropTarget = findClosestDroppableTarget(
-      registeredComponentMetasStore.get(),
+      metas,
       instancesStore.get(),
       // fallback to root as drop target
-      selectedInstanceSelectorStore.get() ?? [selectedPage.rootInstanceId],
+      instanceSelector,
       [component]
     );
-    if (dropTarget) {
-      insertNewComponentInstance(component, dropTarget);
+    if (dropTarget === undefined) {
+      const meta = metas.get(component);
+      if (meta) {
+        toast(formatInsertionError(component, meta));
+      }
+      return;
     }
+    insertNewComponentInstance(component, dropTarget);
   };
 
   return {

--- a/packages/tsconfig/remix.json
+++ b/packages/tsconfig/remix.json
@@ -5,9 +5,9 @@
   "compilerOptions": {
     "noEmit": true,
     "jsx": "react-jsx",
-    "target": "ES2020",
+    "target": "ES2021",
     "module": "ES2020",
-    "lib": ["DOM", "DOM.Iterable", "ES2020"]
+    "lib": ["DOM", "DOM.Iterable", "ES2021"]
   },
   "include": ["app", "remix.env.d.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Here added toast with explanation why user cannot add some components. Uses Intl.ListFormat to make it human readable.

<img width="385" alt="Screenshot 2023-06-03 at 17 35 35" src="https://github.com/webstudio-is/webstudio-builder/assets/5635476/613fae93-9231-4c47-9d7e-94e7f99fac7b">
<img width="347" alt="Screenshot 2023-06-03 at 17 37 07" src="https://github.com/webstudio-is/webstudio-builder/assets/5635476/0d2dafec-dcaa-43af-bf1d-c63b3dc387d0">
<img width="335" alt="Screenshot 2023-06-03 at 17 38 14" src="https://github.com/webstudio-is/webstudio-builder/assets/5635476/f15b4eee-3b93-491e-a0fc-bc7f369ca558">


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
