### PR TITLE
Publish tracking

### DIFF
--- a/apps/builder/app/builder/features/topbar/add-domain.tsx
+++ b/apps/builder/app/builder/features/topbar/add-domain.tsx
@@ -23,22 +23,22 @@ type DomainsAddProps = {
     input: { projectId: Project["id"] },
     onSuccess: () => void
   ) => void;
-  domainLoadingState: "idle" | "submitting";
-  publishIsInProgress: boolean;
+  domainState: "idle" | "submitting";
+  isPublishing: boolean;
 };
 
 export const AddDomain = ({
   projectId,
   onCreate,
   refreshDomainResult,
-  domainLoadingState,
-  publishIsInProgress,
+  domainState,
+  isPublishing,
 }: DomainsAddProps) => {
   const id = useId();
   const {
     send: create,
-    state,
-    error: createSystemError,
+    state: сreateState,
+    error: сreateSystemError,
   } = trpc.create.useMutation();
   const [isOpen, setIsOpen] = useState(false);
   const [domain, setDomain] = useState("");
@@ -98,9 +98,7 @@ export const AddDomain = ({
               placeholder="your-domain.com"
               value={domain}
               disabled={
-                publishIsInProgress ||
-                state !== "idle" ||
-                domainLoadingState !== "idle"
+                isPublishing || сreateState !== "idle" || domainState !== "idle"
               }
               onKeyDown={(event) => {
                 if (event.key === "Enter") {
@@ -123,10 +121,10 @@ export const AddDomain = ({
                 <Text color="destructive">{error}</Text>
               </>
             )}
-            {createSystemError !== undefined && (
+            {сreateSystemError !== undefined && (
               <>
                 {/* Something happened with network, api etc */}
-                <Text color="destructive">{createSystemError}</Text>
+                <Text color="destructive">{сreateSystemError}</Text>
                 <Text color="subtle">Please try again later</Text>
               </>
             )}
@@ -135,9 +133,7 @@ export const AddDomain = ({
 
         <Button
           disabled={
-            publishIsInProgress ||
-            state !== "idle" ||
-            domainLoadingState !== "idle"
+            isPublishing || сreateState !== "idle" || domainState !== "idle"
           }
           color={isOpen ? "primary" : "neutral"}
           css={{ width: "100%", flexShrink: 0 }}

--- a/apps/builder/app/builder/features/topbar/add-domain.tsx
+++ b/apps/builder/app/builder/features/topbar/add-domain.tsx
@@ -24,6 +24,7 @@ type DomainsAddProps = {
     onSuccess: () => void
   ) => void;
   domainLoadingState: "idle" | "submitting";
+  publishIsInProgress: boolean;
 };
 
 export const AddDomain = ({
@@ -31,6 +32,7 @@ export const AddDomain = ({
   onCreate,
   refreshDomainResult,
   domainLoadingState,
+  publishIsInProgress,
 }: DomainsAddProps) => {
   const id = useId();
   const {
@@ -95,7 +97,11 @@ export const AddDomain = ({
               autoFocus
               placeholder="your-domain.com"
               value={domain}
-              disabled={state !== "idle" || domainLoadingState !== "idle"}
+              disabled={
+                publishIsInProgress ||
+                state !== "idle" ||
+                domainLoadingState !== "idle"
+              }
               onKeyDown={(event) => {
                 if (event.key === "Enter") {
                   handleCreate();
@@ -128,7 +134,11 @@ export const AddDomain = ({
         )}
 
         <Button
-          disabled={state !== "idle" || domainLoadingState !== "idle"}
+          disabled={
+            publishIsInProgress ||
+            state !== "idle" ||
+            domainLoadingState !== "idle"
+          }
           color={isOpen ? "primary" : "neutral"}
           css={{ width: "100%", flexShrink: 0 }}
           onClick={() => {

--- a/apps/builder/app/builder/features/topbar/domains.tsx
+++ b/apps/builder/app/builder/features/topbar/domains.tsx
@@ -85,7 +85,7 @@ export const getStatus = (projectDomain: Domain) =>
     ? (`VERIFIED_${projectDomain.domain.status}` as const)
     : `UNVERIFIED`;
 
-const PENDING_TIMEOUT = 60 * 3 * 1000;
+export const PENDING_TIMEOUT = 60 * 3 * 1000;
 
 export const getPublishStatusAndText = ({
   updatedAt,

--- a/apps/builder/app/builder/features/topbar/domains.tsx
+++ b/apps/builder/app/builder/features/topbar/domains.tsx
@@ -202,8 +202,8 @@ const DomainItem = (props: {
     input: { projectId: Project["id"] },
     onSuccess?: () => void
   ) => void;
-  domainLoadingState: "idle" | "submitting";
-  publishIsInProgress: boolean;
+  domainState: "idle" | "submitting";
+  isPublishing: boolean;
 }) => {
   const {
     send: verify,
@@ -229,12 +229,12 @@ const DomainItem = (props: {
   const [isStatusLoading, setIsStatusLoading] = useState(true);
 
   const isRemoveInProgress =
-    removeState !== "idle" || props.domainLoadingState !== "idle";
+    removeState !== "idle" || props.domainState !== "idle";
 
   const isCheckStateInProgress =
     verifyState !== "idle" ||
     updateStatusState !== "idle" ||
-    props.domainLoadingState !== "idle";
+    props.domainState !== "idle";
 
   const status = props.projectDomain.verified
     ? (`VERIFIED_${props.projectDomain.domain.status}` as `VERIFIED_${DomainStatus}`)
@@ -389,7 +389,7 @@ const DomainItem = (props: {
             <Text color="destructive">{verifySystemError}</Text>
           )}
           <Button
-            disabled={props.publishIsInProgress || isCheckStateInProgress}
+            disabled={props.isPublishing || isCheckStateInProgress}
             color="primary"
             css={{ width: "100%", flexShrink: 0, mt: theme.spacing[3] }}
             onClick={handleVerify}
@@ -408,7 +408,7 @@ const DomainItem = (props: {
             <Text color="destructive">{updateStatusError}</Text>
           )}
           <Button
-            disabled={props.publishIsInProgress || isCheckStateInProgress}
+            disabled={props.isPublishing || isCheckStateInProgress}
             color="primary"
             css={{ width: "100%", flexShrink: 0, mt: theme.spacing[3] }}
             onClick={handleUpdateStatus}
@@ -427,7 +427,7 @@ const DomainItem = (props: {
       )}
 
       <Button
-        disabled={props.publishIsInProgress || isRemoveInProgress}
+        disabled={props.isPublishing || isRemoveInProgress}
         color="neutral"
         css={{ width: "100%", flexShrink: 0 }}
         onClick={() => {
@@ -539,16 +539,16 @@ type DomainsProps = {
     input: { projectId: Project["id"] },
     onSuccess?: () => void
   ) => void;
-  domainLoadingState: "idle" | "submitting";
-  publishIsInProgress: boolean;
+  domainState: "idle" | "submitting";
+  isPublishing: boolean;
 };
 
 export const Domains = ({
   newDomains,
   domains,
   refreshDomainResult,
-  domainLoadingState,
-  publishIsInProgress,
+  domainState,
+  isPublishing,
 }: DomainsProps) => {
   return (
     <>
@@ -558,8 +558,8 @@ export const Domains = ({
           projectDomain={projectDomain}
           initiallyOpen={newDomains.has(projectDomain.domain.domain)}
           refreshDomainResult={refreshDomainResult}
-          domainLoadingState={domainLoadingState}
-          publishIsInProgress={publishIsInProgress}
+          domainState={domainState}
+          isPublishing={isPublishing}
         />
       ))}
     </>

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -29,6 +29,7 @@ import {
   getPublishStatusAndText,
   getStatus,
   type Domain,
+  PENDING_TIMEOUT,
 } from "./domains";
 import { CollapsibleDomainSection } from "./collapsible-domain-section";
 import {
@@ -246,9 +247,13 @@ const Publish = ({
     if (publishIsInProgress) {
       let timeoutHandle: TimeoutId;
       let totalCalls = 0;
+      const timeout = 10000;
+      // Repeat few more times than timeout
+      const repeat = PENDING_TIMEOUT / timeout + 5;
+
       // Call refresh
       const execRefresh = () => {
-        if (totalCalls < 20) {
+        if (totalCalls < repeat) {
           totalCalls += 1;
           clearTimeout(timeoutHandle);
           timeoutHandle = setTimeout(() => {

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -259,7 +259,7 @@ const Publish = ({
           timeoutHandle = setTimeout(() => {
             refresh();
             execRefresh();
-          }, 10000);
+          }, timeout);
         }
       };
 

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Button,
   useId,
@@ -16,6 +16,7 @@ import {
   InputField,
   Separator,
   ScrollArea,
+  Box,
 } from "@webstudio-is/design-system";
 import { useIsPublishDialogOpen } from "../../shared/nano-states";
 import { validateProjectDomain, type Project } from "@webstudio-is/project";
@@ -23,7 +24,12 @@ import { getPublishedUrl } from "~/shared/router-utils";
 import { theme } from "@webstudio-is/design-system";
 import { useAuthPermit } from "~/shared/nano-states";
 import { isFeatureEnabled } from "@webstudio-is/feature-flags";
-import { Domains, getStatus } from "./domains";
+import {
+  Domains,
+  getPublishStatusAndText,
+  getStatus,
+  type Domain,
+} from "./domains";
 import { CollapsibleDomainSection } from "./collapsible-domain-section";
 import {
   CheckCircleIcon,
@@ -37,9 +43,34 @@ import { AddDomain } from "./add-domain";
 
 const trpc = createTrpcFetchProxy<DomainRouter>(builderDomainsPath);
 
-type PublishButtonProps = { project: Project };
+type ProjectData =
+  | {
+      success: true;
+      project: Project;
+    }
+  | {
+      success: false;
+      error: string;
+    };
 
-const ChangeProjectDomain = (props: PublishButtonProps) => {
+type PublishButtonProps = {
+  project: Project;
+  projectState: "idle" | "submitting";
+  publishIsInProgress: boolean;
+  projectLoad: (
+    props: { projectId: Project["id"] },
+    callback: (projectData: ProjectData) => void
+  ) => void;
+};
+
+type TimeoutId = undefined | ReturnType<typeof setTimeout>;
+
+const ChangeProjectDomain = ({
+  project,
+  projectLoad,
+  projectState,
+  publishIsInProgress,
+}: PublishButtonProps) => {
   const id = useId();
 
   const {
@@ -48,24 +79,12 @@ const ChangeProjectDomain = (props: PublishButtonProps) => {
     error: updateProjectSystemError,
   } = trpc.updateProjectDomain.useMutation();
 
-  const {
-    load: loadProject,
-    data: projectData,
-    state: projectState,
-    error: projectSystemError,
-  } = trpc.project.useQuery();
-
-  const [domain, setDomain] = useState(props.project.domain);
+  const [domain, setDomain] = useState(project.domain);
   const [error, setError] = useState<string>();
-
-  let project = props.project;
-  if (projectData?.success) {
-    project = projectData.project;
-  }
 
   const refreshProject = useCallback(
     () =>
-      loadProject({ projectId: props.project.id }, (projectData) => {
+      projectLoad({ projectId: project.id }, (projectData) => {
         if (projectData?.success === false) {
           setError(projectData.error);
           return;
@@ -73,7 +92,7 @@ const ChangeProjectDomain = (props: PublishButtonProps) => {
 
         setDomain(projectData.project.domain);
       }),
-    [loadProject, props.project.id]
+    [projectLoad, project.id]
   );
 
   useEffect(() => {
@@ -107,32 +126,20 @@ const ChangeProjectDomain = (props: PublishButtonProps) => {
     });
   };
 
-  if (projectSystemError !== undefined) {
-    return (
-      <Flex
-        css={{
-          m: theme.spacing[9],
-          overflowWrap: "anywhere",
-        }}
-        gap={2}
-        direction={"column"}
-      >
-        <Text color="destructive">{projectSystemError}</Text>
-        <Text color="subtle">Please try again later</Text>
-      </Flex>
-    );
-  }
-
-  if (projectData === undefined) {
-    return <div />;
-  }
+  const { statusText, status } =
+    project.latestBuild != null
+      ? getPublishStatusAndText(project.latestBuild)
+      : {
+          statusText: "Not published",
+          status: "PENDING",
+        };
 
   return (
     <CollapsibleDomainSection
       title={publishedUrl.host}
       suffix={
         <Grid flow="column">
-          <Tooltip content={error !== undefined ? error : "Everything is ok"}>
+          <Tooltip content={error !== undefined ? error : statusText}>
             <Flex
               align={"center"}
               justify={"center"}
@@ -141,12 +148,16 @@ const ChangeProjectDomain = (props: PublishButtonProps) => {
                 width: theme.spacing[12],
                 height: theme.spacing[12],
                 color:
-                  error !== undefined
+                  error !== undefined || status === "FAILED"
                     ? theme.colors.foregroundDestructive
                     : theme.colors.foregroundSuccessText,
               }}
             >
-              {error !== undefined ? <AlertIcon /> : <CheckCircleIcon />}
+              {error !== undefined || status === "FAILED" ? (
+                <AlertIcon />
+              ) : (
+                <CheckCircleIcon />
+              )}
             </Flex>
           </Tooltip>
 
@@ -172,7 +183,9 @@ const ChangeProjectDomain = (props: PublishButtonProps) => {
             placeholder="Domain"
             value={domain}
             disabled={
-              updateProjectDomainState !== "idle" || projectState !== "idle"
+              publishIsInProgress ||
+              updateProjectDomainState !== "idle" ||
+              projectState !== "idle"
             }
             onChange={(event) => {
               setError(undefined);
@@ -208,11 +221,19 @@ const ChangeProjectDomain = (props: PublishButtonProps) => {
 };
 
 const Publish = ({
-  projectId,
-  domains,
+  project,
+  domainsToPublish,
+  refresh,
+
+  publishIsInProgress,
+  setPublishIsInProgress,
 }: {
-  projectId: Project["id"];
-  domains: string[];
+  project: Project;
+  domainsToPublish: Domain[];
+  refresh: () => void;
+
+  publishIsInProgress: boolean;
+  setPublishIsInProgress: (publishIsInProgress: boolean) => void;
 }) => {
   const {
     send: publish,
@@ -220,6 +241,30 @@ const Publish = ({
     data: publishData,
     error: publishSystemError,
   } = trpc.publish.useMutation();
+
+  useEffect(() => {
+    if (publishIsInProgress) {
+      let timeoutHandle: TimeoutId;
+      let totalCalls = 0;
+      // Call refresh
+      const execRefresh = () => {
+        if (totalCalls < 20) {
+          totalCalls += 1;
+          clearTimeout(timeoutHandle);
+          timeoutHandle = setTimeout(() => {
+            refresh();
+            execRefresh();
+          }, 10000);
+        }
+      };
+
+      execRefresh();
+
+      return () => {
+        clearTimeout(timeoutHandle);
+      };
+    }
+  }, [publishIsInProgress, refresh]);
 
   return (
     <Flex
@@ -241,54 +286,138 @@ const Publish = ({
         <Text color="destructive">{publishData.error}</Text>
       )}
 
-      <Button
-        color="positive"
-        disabled={publishState !== "idle"}
-        onClick={() => {
-          publish({ projectId, domains });
-        }}
+      <Tooltip
+        content={
+          publishState !== "idle" || publishIsInProgress
+            ? "Publish process in progress"
+            : undefined
+        }
       >
-        Publish
-      </Button>
+        <Button
+          color="positive"
+          disabled={publishState !== "idle" || publishIsInProgress}
+          onClick={() => {
+            setPublishIsInProgress(true);
+
+            publish(
+              {
+                projectId: project.id,
+                domains: domainsToPublish.map(
+                  (projectDomain) => projectDomain.domain.domain
+                ),
+              },
+              () => {
+                refresh();
+              }
+            );
+          }}
+        >
+          Publish
+        </Button>
+      </Tooltip>
     </Flex>
   );
 };
 
-const Content = (props: PublishButtonProps) => {
+const Content = (props: { projectId: Project["id"] }) => {
   const [newDomains, setNewDomains] = useState(new Set<string>());
   const {
     data: domainsResult,
-    load: refreshDomainResult,
+    load: domainRefresh,
     state: domainLoadingState,
+    error: domainSystemError,
   } = trpc.findMany.useQuery();
 
-  useEffect(() => {
-    refreshDomainResult({ projectId: props.project.id });
-  }, [refreshDomainResult, props.project.id]);
+  const {
+    load: projectLoad,
+    data: projectData,
+    state: projectState,
+    error: projectSystemError,
+  } = trpc.project.useQuery();
 
-  // In the future we would allow to select what domains to publish,
-  // now we just publish all verified and active domains
-  const domainsToPublish = domainsResult?.success
-    ? domainsResult.data
-        .filter(
-          (projectDomain) => getStatus(projectDomain) === "VERIFIED_ACTIVE"
-        )
-        .map((projectDomain) => projectDomain.domain.domain)
-    : [];
+  useEffect(() => {
+    projectLoad({ projectId: props.projectId });
+    domainRefresh({ projectId: props.projectId });
+  }, [domainRefresh, props.projectId, projectLoad]);
+
+  const domainsToPublish = useMemo(
+    () =>
+      domainsResult?.success
+        ? domainsResult.data.filter(
+            (projectDomain) => getStatus(projectDomain) === "VERIFIED_ACTIVE"
+          )
+        : [],
+    [domainsResult]
+  );
+
+  const latestBuilds = useMemo(
+    () => [
+      projectData?.success ? projectData.project.latestBuild ?? null : null,
+      ...domainsToPublish.map((domain) => domain.latestBuid),
+    ],
+    [domainsToPublish, projectData]
+  );
+
+  const hasPendingState = useMemo(
+    () =>
+      latestBuilds.some((latestBuild) => {
+        if (latestBuild === null) {
+          return false;
+        }
+        const { status } = getPublishStatusAndText(latestBuild);
+        if (status === "PENDING") {
+          return true;
+        }
+      }),
+    [latestBuilds]
+  );
+
+  const [publishIsInProgress, setPublishIsInProgress] =
+    useState(hasPendingState);
+
+  useEffect(() => {
+    setPublishIsInProgress(hasPendingState);
+  }, [hasPendingState, setPublishIsInProgress]);
 
   return (
     <>
       <ScrollArea>
-        <ChangeProjectDomain project={props.project} />
+        {projectSystemError !== undefined && (
+          <Flex
+            css={{
+              m: theme.spacing[9],
+              overflowWrap: "anywhere",
+            }}
+            gap={2}
+            direction={"column"}
+          >
+            <Text color="destructive">{projectSystemError}</Text>
+            <Text color="subtle">Please try again later</Text>
+          </Flex>
+        )}
+
+        {projectData?.success && (
+          <ChangeProjectDomain
+            projectLoad={projectLoad}
+            projectState={projectState}
+            project={projectData.project}
+            publishIsInProgress={publishIsInProgress}
+          />
+        )}
 
         {isFeatureEnabled("domains") && (
           <>
+            {domainSystemError !== undefined && (
+              <Text color="destructive">{domainSystemError}</Text>
+            )}
+
             {domainsResult?.success === true && (
               <Domains
                 newDomains={newDomains}
                 domains={domainsResult.data}
-                refreshDomainResult={refreshDomainResult}
+                refreshDomainResult={domainRefresh}
                 domainLoadingState={domainLoadingState}
+                publishIsInProgress={publishIsInProgress}
               />
             )}
             {domainsResult?.success === false && (
@@ -312,19 +441,33 @@ const Content = (props: PublishButtonProps) => {
           </Flex>
 
           <AddDomain
-            projectId={props.project.id}
-            refreshDomainResult={refreshDomainResult}
+            projectId={props.projectId}
+            refreshDomainResult={domainRefresh}
             domainLoadingState={domainLoadingState}
             onCreate={(domain) => {
               setNewDomains((prev) => {
                 return new Set([...prev, domain]);
               });
             }}
+            publishIsInProgress={publishIsInProgress}
           />
         </>
       )}
 
-      <Publish projectId={props.project.id} domains={domainsToPublish} />
+      {projectData?.success === true ? (
+        <Publish
+          project={projectData.project}
+          domainsToPublish={domainsToPublish}
+          refresh={() => {
+            projectLoad({ projectId: props.projectId });
+            domainRefresh({ projectId: props.projectId });
+          }}
+          publishIsInProgress={publishIsInProgress}
+          setPublishIsInProgress={setPublishIsInProgress}
+        />
+      ) : (
+        <Box css={{ height: theme.spacing[8] }} />
+      )}
     </>
   );
 };
@@ -358,7 +501,7 @@ export const PublishButton = ({ project }: PublishButtonProps) => {
         }}
       >
         <FloatingPanelPopoverTitle>Publish</FloatingPanelPopoverTitle>
-        <Content project={project} />
+        <Content projectId={project.id} />
       </FloatingPanelPopoverContent>
     </FloatingPanelPopover>
   );

--- a/apps/builder/app/builder/features/topbar/publish.tsx
+++ b/apps/builder/app/builder/features/topbar/publish.tsx
@@ -53,7 +53,7 @@ type ProjectData =
       error: string;
     };
 
-type PublishButtonProps = {
+type ChangeProjectDomainProps = {
   project: Project;
   projectState: "idle" | "submitting";
   publishIsInProgress: boolean;
@@ -70,7 +70,7 @@ const ChangeProjectDomain = ({
   projectLoad,
   projectState,
   publishIsInProgress,
-}: PublishButtonProps) => {
+}: ChangeProjectDomainProps) => {
   const id = useId();
 
   const {
@@ -472,7 +472,10 @@ const Content = (props: { projectId: Project["id"] }) => {
   );
 };
 
-export const PublishButton = ({ project }: PublishButtonProps) => {
+type PublishProps = {
+  projectId: Project["id"];
+};
+export const PublishButton = ({ projectId }: PublishProps) => {
   const [isOpen, setIsOpen] = useIsPublishDialogOpen();
   const [authPermit] = useAuthPermit();
 
@@ -501,7 +504,7 @@ export const PublishButton = ({ project }: PublishButtonProps) => {
         }}
       >
         <FloatingPanelPopoverTitle>Publish</FloatingPanelPopoverTitle>
-        <Content projectId={project.id} />
+        <Content projectId={projectId} />
       </FloatingPanelPopoverContent>
     </FloatingPanelPopover>
   );

--- a/apps/builder/app/builder/features/topbar/topbar.tsx
+++ b/apps/builder/app/builder/features/topbar/topbar.tsx
@@ -71,7 +71,7 @@ export const Topbar = ({ gridArea, project, publish }: TopbarProps) => {
           <SyncStatus />
           <PreviewButton />
           <ShareButton projectId={project.id} />
-          <PublishButton project={project} />
+          <PublishButton projectId={project.id} />
         </ToolbarToggleGroup>
       </Toolbar>
     </nav>

--- a/apps/builder/app/dashboard/dashboard.stories.tsx
+++ b/apps/builder/app/dashboard/dashboard.stories.tsx
@@ -40,6 +40,7 @@ export const WithProjects: ComponentStory<typeof Dashboard> = () => {
       userId: null,
       isDeleted: false,
       isPublished: false,
+      latestBuild: null,
     },
   ];
   const router = createRouter(<Dashboard user={user} projects={projects} />);

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -58,6 +58,7 @@
     "@webstudio-is/sdk-components-react-remix": "workspace:^",
     "@webstudio-is/trpc-interface": "workspace:^",
     "colord": "^2.9.3",
+    "date-fns": "^2.30.0",
     "debug": "^4.3.4",
     "detect-font": "^0.1.5",
     "downshift": "^6.1.7",

--- a/packages/domain/src/trpc/domain.ts
+++ b/packages/domain/src/trpc/domain.ts
@@ -13,6 +13,7 @@ export const domainRouter = router({
     .query(async ({ input, ctx }) => {
       try {
         const project = await projectDb.project.loadById(input.projectId, ctx);
+
         return {
           success: true,
           project,
@@ -28,17 +29,18 @@ export const domainRouter = router({
     .input(z.object({ projectId: z.string(), domains: z.array(z.string()) }))
     .mutation(async ({ input, ctx }) => {
       try {
+        const project = await projectDb.project.loadById(input.projectId, ctx);
+
         const build = await createProductionBuild(
           {
             projectId: input.projectId,
             deployment: {
               domains: input.domains,
+              projectDomain: project.domain,
             },
           },
           ctx
         );
-
-        const project = await projectDb.project.loadById(input.projectId, ctx);
 
         const { deploymentTrpc, env } = ctx.deployment;
 

--- a/packages/prisma-client/prisma/migrations/20230606165920_deployment-project-domain/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20230606165920_deployment-project-domain/migration.sql
@@ -1,0 +1,10 @@
+UPDATE
+  "Build"
+SET
+  deployment = deployment::jsonb ||('{"projectDomain": "' || "Project".domain || '" }')::jsonb
+FROM
+  "Project"
+WHERE
+  "Project".id = "Build"."projectId"
+  AND "Build".deployment IS NOT NULL;
+

--- a/packages/prisma-client/prisma/migrations/20230606234538_latest-build/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20230606234538_latest-build/migration.sql
@@ -1,0 +1,92 @@
+-- CreateEnum
+CREATE TYPE "PublishStatus" AS ENUM ('PENDING', 'PUBLISHED', 'FAILED');
+
+-- AlterTable
+ALTER TABLE "Build" ADD COLUMN     "publishStatus" "PublishStatus" NOT NULL DEFAULT 'PENDING';
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Project_id_domain_key" ON "Project"("id", "domain");
+
+
+CREATE OR REPLACE VIEW "LatestBuildPerProjectDomain" AS
+WITH lbd AS (
+  SELECT DISTINCT ON ("projectId",
+    "domain")
+    jsonb_array_elements_text(deployment::jsonb -> 'domains') AS "domain",
+    bld.id AS "buildId",
+    bld."projectId",
+    bld."updatedAt",
+    bld."publishStatus"
+  FROM
+    "Build" bld
+  WHERE
+    bld.deployment IS NOT NULL
+  ORDER BY
+    bld."projectId",
+    "domain",
+    bld."createdAt" DESC,
+    "buildId"
+),
+lb AS (
+  SELECT DISTINCT ON ("projectId")
+    bld.id AS "buildId",
+    bld."projectId",
+    bld."updatedAt",
+    bld."publishStatus"
+  FROM
+    "Build" bld
+  WHERE
+    bld.deployment IS NOT NULL
+  ORDER BY
+    bld."projectId",
+    bld."createdAt" DESC,
+    "buildId"
+)
+SELECT
+  d.id AS "domainId",
+  lbd."projectId",
+  lbd."buildId",
+  coalesce(lbd."updatedAt" = lb."updatedAt", FALSE) AS "isLatestBuild",
+  lbd."publishStatus",
+  lbd."updatedAt"
+FROM
+  lbd,
+  lb,
+  "Domain" d
+WHERE
+  lbd.domain = d.domain
+  AND lb."projectId" = lbd."projectId";
+
+CREATE OR REPLACE VIEW "LatestBuildPerProject" AS
+WITH lb AS (
+  SELECT DISTINCT ON ("projectId")
+    bld.id AS "buildId",
+    bld."projectId",
+    bld."updatedAt"
+  FROM
+    "Build" bld
+  WHERE
+    bld.deployment IS NOT NULL
+  ORDER BY
+    bld."projectId",
+    bld."createdAt" DESC,
+    "buildId"
+)
+SELECT DISTINCT ON ("projectId", "domain")
+  bld.id AS "buildId",
+  bld."projectId",
+  deployment::jsonb ->> 'projectDomain' AS domain,
+  coalesce(bld."updatedAt" = lb."updatedAt", FALSE) AS "isLatestBuild",
+  bld."updatedAt",
+  bld."publishStatus"
+FROM
+  "Build" bld,
+  lb
+WHERE
+  bld.deployment IS NOT NULL
+  AND lb."projectId" = bld."projectId"
+ORDER BY
+  bld."projectId",
+  "domain",
+  bld."createdAt" DESC,
+  "buildId";

--- a/packages/prisma-client/prisma/migrations/20230606234538_latest-build/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20230606234538_latest-build/migration.sql
@@ -4,6 +4,9 @@ CREATE TYPE "PublishStatus" AS ENUM ('PENDING', 'PUBLISHED', 'FAILED');
 -- AlterTable
 ALTER TABLE "Build" ADD COLUMN     "publishStatus" "PublishStatus" NOT NULL DEFAULT 'PENDING';
 
+-- Update existing and published
+UPDATE "Build" SET "publishStatus" = 'PUBLISHED' WHERE deployment IS NOT NULL;
+
 -- CreateIndex
 CREATE UNIQUE INDEX "Project_id_domain_key" ON "Project"("id", "domain");
 

--- a/packages/prisma-client/prisma/schema.prisma
+++ b/packages/prisma-client/prisma/schema.prisma
@@ -62,19 +62,27 @@ model User {
 }
 
 model Project {
-  id            String          @id @default(uuid())
-  createdAt     DateTime        @default(now())
+  id            String                 @id @default(uuid())
+  createdAt     DateTime               @default(now())
   title         String
-  domain        String          @unique
-  user          User?           @relation(fields: [userId], references: [id])
+  domain        String                 @unique
+  user          User?                  @relation(fields: [userId], references: [id])
   userId        String?
   build         Build[]
-  isDeleted     Boolean         @default(false)
+  isDeleted     Boolean                @default(false)
   files         File[]
-  ProjectDomain ProjectDomain[]
+  projectDomain ProjectDomain[]
+  latestBuild   LatestBuildPerProject?
 
   @@unique([id, isDeleted])
   @@unique([domain, isDeleted])
+  @@unique([id, domain])
+}
+
+enum PublishStatus {
+  PENDING
+  PUBLISHED
+  FAILED
 }
 
 model Build {
@@ -94,7 +102,8 @@ model Build {
   props                 String @default("[]")
   instances             String @default("[]")
 
-  deployment String?
+  deployment    String?
+  publishStatus PublishStatus @default(PENDING)
 
   @@id([id, projectId])
 }
@@ -132,13 +141,14 @@ model Domain {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
-  ProjectDomain     ProjectDomain[]
+  ProjectDomain ProjectDomain[]
   // Last known txtRecord of the domain (to check domain ownership)
-  txtRecord         String?
+  txtRecord     String?
   // create, init, pending, active, error
-  status            DomainStatus        @default(INITIALIZING)
+  status        DomainStatus    @default(INITIALIZING)
   // In case of status="error", this will contain the error message
-  error             String?
+  error         String?
+
   projectWithDomain ProjectWithDomain[]
 }
 
@@ -174,7 +184,37 @@ view ProjectWithDomain {
   // To count statistics per user
   userId   String?
 
+  // We can deploy on per domain basis, here for each project domain we have latest build
+  latestBuid LatestBuildPerProjectDomain?
+
   @@id([projectId, domainId])
+}
+
+view LatestBuildPerProjectDomain {
+  domainId          String
+  buildId           String
+  projectId         String
+  projectWithDomain ProjectWithDomain @relation(fields: [projectId, domainId], references: [projectId, domainId])
+
+  isLatestBuild Boolean
+  publishStatus PublishStatus
+  updatedAt     DateTime
+
+  @@id([projectId, domainId])
+}
+
+view LatestBuildPerProject {
+  buildId String
+
+  projectId String
+  domain    String
+  project   Project @relation(fields: [projectId, domain], references: [id, domain])
+
+  isLatestBuild Boolean
+  publishStatus PublishStatus
+  updatedAt     DateTime
+
+  @@id([projectId, domain])
 }
 
 // Dashboard

--- a/packages/prisma-client/src/prisma.ts
+++ b/packages/prisma-client/src/prisma.ts
@@ -58,7 +58,7 @@ prisma.$on("query", (e) => {
   );
 
   // eslint-disable-next-line no-console
-  console.log("Params: " + e.params.slice(0, 100));
+  console.log("Params: " + e.params.slice(0, 200));
   // eslint-disable-next-line no-console
   console.log("Duration: " + e.duration + "ms");
 });

--- a/packages/prisma-client/src/types.ts
+++ b/packages/prisma-client/src/types.ts
@@ -9,4 +9,7 @@ export type {
   AuthorizationToken,
   DomainStatus,
   Domain,
+  ProjectWithDomain,
+  LatestBuildPerProjectDomain,
+  LatestBuildPerProject,
 } from "./__generated__";

--- a/packages/prisma-client/src/types.ts
+++ b/packages/prisma-client/src/types.ts
@@ -12,4 +12,5 @@ export type {
   ProjectWithDomain,
   LatestBuildPerProjectDomain,
   LatestBuildPerProject,
+  PublishStatus,
 } from "./__generated__";

--- a/packages/project-build/src/schema/deployment.ts
+++ b/packages/project-build/src/schema/deployment.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const Deployment = z.object({
   domains: z.array(z.string()),
+  projectDomain: z.string(),
 });
 
 export type Deployment = z.infer<typeof Deployment>;

--- a/packages/project/src/db/project.ts
+++ b/packages/project/src/db/project.ts
@@ -28,6 +28,9 @@ export const loadById = async (
 
   const data = await prisma.project.findUnique({
     where: { id_isDeleted: { id: projectId, isDeleted: false } },
+    include: {
+      latestBuild: true,
+    },
   });
 
   return Project.parse(data);

--- a/packages/project/src/shared/schema.ts
+++ b/packages/project/src/shared/schema.ts
@@ -16,6 +16,14 @@ export const Project = z.object({
   userId: z.string().nullable(),
   isDeleted: z.boolean(),
   domain: z.string(),
+  latestBuild: z
+    .object({
+      buildId: z.string(),
+      isLatestBuild: z.boolean(),
+      publishStatus: z.enum(["PENDING", "PUBLISHED", "FAILED"]),
+      updatedAt: z.date().transform((date) => date.toISOString()),
+    })
+    .nullable(),
 });
 export type Project = z.infer<typeof Project>;
 

--- a/packages/project/src/shared/schema.ts
+++ b/packages/project/src/shared/schema.ts
@@ -16,14 +16,16 @@ export const Project = z.object({
   userId: z.string().nullable(),
   isDeleted: z.boolean(),
   domain: z.string(),
-  latestBuild: z
-    .object({
-      buildId: z.string(),
-      isLatestBuild: z.boolean(),
-      publishStatus: z.enum(["PENDING", "PUBLISHED", "FAILED"]),
-      updatedAt: z.date().transform((date) => date.toISOString()),
-    })
-    .nullable(),
+  latestBuild: z.optional(
+    z
+      .object({
+        buildId: z.string(),
+        isLatestBuild: z.boolean(),
+        publishStatus: z.enum(["PENDING", "PUBLISHED", "FAILED"]),
+        updatedAt: z.date().transform((date) => date.toISOString()),
+      })
+      .nullable()
+  ),
 });
 export type Project = z.infer<typeof Project>;
 

--- a/packages/trpc-interface/src/shared/deployment.ts
+++ b/packages/trpc-interface/src/shared/deployment.ts
@@ -30,6 +30,9 @@ export const deploymentRouter = router({
     .input(PublishInput)
     .output(Output)
     .mutation(async ({ input, ctx }) => {
-      return { success: false, error: "Not implemented" };
+      return {
+        success: false,
+        error: `Not implemented, use buildId=${input.buildId}`,
+      };
     }),
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       colord:
         specifier: ^2.9.3
         version: 2.9.3
+      date-fns:
+        specifier: ^2.30.0
+        version: 2.30.0
       debug:
         specifier: ^4.3.4
         version: 4.3.4
@@ -3743,6 +3746,12 @@ packages:
 
   /@babel/runtime@7.20.13:
     resolution: {integrity: sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.13.11
+
+  /@babel/runtime@7.22.3:
+    resolution: {integrity: sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
@@ -9777,7 +9786,7 @@ packages:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.22.3
       cosmiconfig: 7.0.1
       resolve: 1.22.1
 
@@ -11012,6 +11021,13 @@ packages:
   /data-uri-to-buffer@3.0.1:
     resolution: {integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==}
     engines: {node: '>= 6'}
+
+  /date-fns@2.30.0:
+    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
+    engines: {node: '>=0.11'}
+    dependencies:
+      '@babel/runtime': 7.22.3
+    dev: false
 
   /deasync@0.1.28:
     resolution: {integrity: sha512-QqLF6inIDwiATrfROIyQtwOQxjZuek13WRYZ7donU5wJPLoP67MnYxA6QtqdvdBy2mMqv5m3UefBVdJjvevOYg==}
@@ -14671,7 +14687,7 @@ packages:
     resolution: {integrity: sha512-prXSYk799h3GY3iOWnC6ZigYzMPjxN2svgjJ9shk7oMadSNX3wXy0B6F32PMJv7qtMnrIbUxoEHzbutvxR2LBQ==}
     engines: {node: '>=6.0.0', npm: '>=6.0.0', yarn: '>=1.0.0'}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.22.3
       app-root-dir: 1.0.2
       core-js: 3.23.3
       dotenv: 8.6.0
@@ -15095,7 +15111,7 @@ packages:
   /media-query-parser@2.0.2:
     resolution: {integrity: sha512-1N4qp+jE0pL5Xv4uEcwVUhIkwdUO3S/9gML90nqKA7v7FcOS5vUtatfzok9S9U1EJU8dHWlcv95WLnKmmxZI9w==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.22.3
     dev: true
 
   /media-typer@0.3.0:
@@ -16625,7 +16641,7 @@ packages:
     resolution: {integrity: sha512-Sz2Lkdxz6F2Pgnpi9U5Ng/WdWAUZxmHrNPoVlm3aAemxoy2Qy7LGjQg4uf8qKelDAUW94F4np3iH2YPf2qefcQ==}
     engines: {node: '>=10'}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.22.3
     dev: false
 
   /pony-cause@2.1.4:
@@ -17131,7 +17147,7 @@ packages:
     dependencies:
       '@babel/core': 7.21.0
       '@babel/generator': 7.21.1
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.22.3
       ast-types: 0.14.2
       commander: 2.20.3
       doctrine: 3.0.0
@@ -17231,7 +17247,7 @@ packages:
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.22.3
       is-dom: 1.1.0
       prop-types: 15.8.1
       react: 17.0.2
@@ -17520,7 +17536,7 @@ packages:
   /regenerator-transform@0.15.1:
     resolution: {integrity: sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.22.3
 
   /regex-not@1.0.2:
     resolution: {integrity: sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==}


### PR DESCRIPTION
## Description

Add `latestBuild` for each entry in publish dialog
Now we are tracking publish stat for each domain. 
This information is needed to show checkboxes in publish design (next PRs).

2 new Views were created.

To get the latest build by project + domain
To get the latest build for wstd.xx domain

Publish status is shown per domain (as not every domain would be published each time)

<img width="362" alt="image" src="https://github.com/webstudio-is/webstudio-builder/assets/5077042/b4e0357a-63f5-47ba-a119-59ef1adf81d2">

During publish all buttons are disabled as per design

<img width="348" alt="image" src="https://github.com/webstudio-is/webstudio-builder/assets/5077042/94720bd3-4bda-488c-81f7-71ea9ba2d530">

Also added tooltip on publish button (not in design)

<img width="366" alt="image" src="https://github.com/webstudio-is/webstudio-builder/assets/5077042/c764a785-aea9-487b-a480-642410293ee3">



## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
