### PR TITLE
Fix object fit, ignore loader

### DIFF
--- a/apps/builder/app/shared/nano-states/components-meta.ts
+++ b/apps/builder/app/shared/nano-states/components-meta.ts
@@ -29,15 +29,9 @@ export const registerComponentPropsMetas = (
   const prevPropsMetas = registeredComponentPropsMetasStore.get();
   const nextPropsMetas = new Map(prevPropsMetas);
   for (const [componentName, propsMeta] of Object.entries(newPropsMetas)) {
-    const { initialProps = [], props, ignoredProps = [] } = propsMeta;
-    const filteredProps: typeof props = {};
-    for (const [name, value] of Object.entries(props)) {
-      if (ignoredProps.includes(name) === false) {
-        filteredProps[name] = value;
-      }
-    }
+    const { initialProps = [], props } = propsMeta;
     const requiredProps: string[] = [];
-    for (const [name, value] of Object.entries(filteredProps)) {
+    for (const [name, value] of Object.entries(props)) {
       if (value.required && initialProps.includes(name) === false) {
         requiredProps.push(name);
       }
@@ -45,7 +39,7 @@ export const registerComponentPropsMetas = (
     nextPropsMetas.set(componentName, {
       // order of initialProps must be preserved
       initialProps: [...initialProps, ...requiredProps],
-      props: filteredProps,
+      props,
     });
   }
   registeredComponentPropsMetasStore.set(nextPropsMetas);

--- a/apps/builder/app/shared/nano-states/components-meta.ts
+++ b/apps/builder/app/shared/nano-states/components-meta.ts
@@ -29,9 +29,15 @@ export const registerComponentPropsMetas = (
   const prevPropsMetas = registeredComponentPropsMetasStore.get();
   const nextPropsMetas = new Map(prevPropsMetas);
   for (const [componentName, propsMeta] of Object.entries(newPropsMetas)) {
-    const { initialProps = [], props } = propsMeta;
-    const requiredProps: string[] = [];
+    const { initialProps = [], props, ignoredProps = [] } = propsMeta;
+    const filteredProps: typeof props = {};
     for (const [name, value] of Object.entries(props)) {
+      if (ignoredProps.includes(name) === false) {
+        filteredProps[name] = value;
+      }
+    }
+    const requiredProps: string[] = [];
+    for (const [name, value] of Object.entries(filteredProps)) {
       if (value.required && initialProps.includes(name) === false) {
         requiredProps.push(name);
       }
@@ -39,7 +45,7 @@ export const registerComponentPropsMetas = (
     nextPropsMetas.set(componentName, {
       // order of initialProps must be preserved
       initialProps: [...initialProps, ...requiredProps],
-      props: propsMeta.props,
+      props: filteredProps,
     });
   }
   registeredComponentPropsMetasStore.set(nextPropsMetas);

--- a/packages/react-sdk/src/components/component-meta.ts
+++ b/packages/react-sdk/src/components/component-meta.ts
@@ -11,7 +11,10 @@ export type PresetStyle<Tag extends HtmlTags = HtmlTags> = Partial<
 // so they can be exported separately and potentially tree-shaken
 const WsComponentPropsMeta = z.object({
   props: z.record(PropMeta),
+  // Props that will be always visible in properties panel.
   initialProps: z.array(z.string()).optional(),
+  // Props that will never show up in properties panel.
+  ignoredProps: z.array(z.string()).optional(),
 });
 
 export type WsComponentPropsMeta = z.infer<typeof WsComponentPropsMeta>;

--- a/packages/react-sdk/src/components/component-meta.ts
+++ b/packages/react-sdk/src/components/component-meta.ts
@@ -13,8 +13,6 @@ const WsComponentPropsMeta = z.object({
   props: z.record(PropMeta),
   // Props that will be always visible in properties panel.
   initialProps: z.array(z.string()).optional(),
-  // Props that will never show up in properties panel.
-  ignoredProps: z.array(z.string()).optional(),
 });
 
 export type WsComponentPropsMeta = z.infer<typeof WsComponentPropsMeta>;

--- a/packages/sdk-components-react/src/__generated__/image.props.ts
+++ b/packages/sdk-components-react/src/__generated__/image.props.ts
@@ -482,6 +482,5 @@ export const props: Record<string, PropMeta> = {
     type: "string",
   },
   quality: { required: false, control: "number", type: "number" },
-  loader: { required: true, control: "text", type: "string" },
   optimize: { required: false, control: "boolean", type: "boolean" },
 };

--- a/packages/sdk-components-react/src/__generated__/vimeo-preview-image.props.ts
+++ b/packages/sdk-components-react/src/__generated__/vimeo-preview-image.props.ts
@@ -482,6 +482,5 @@ export const props: Record<string, PropMeta> = {
     type: "string",
   },
   quality: { required: false, control: "number", type: "number" },
-  loader: { required: true, control: "text", type: "string" },
   optimize: { required: false, control: "boolean", type: "boolean" },
 };

--- a/packages/sdk-components-react/src/image.tsx
+++ b/packages/sdk-components-react/src/image.tsx
@@ -40,7 +40,7 @@ const imagePlaceholderSvg = `data:image/svg+xml;base64,${btoa(`<svg
   />
 </svg>`)}`;
 
-type Props = ComponentPropsWithoutRef<typeof WebstudioImage>;
+type Props = Omit<ComponentPropsWithoutRef<typeof WebstudioImage>, "loader">;
 
 export const Image = forwardRef<ElementRef<typeof defaultTag>, Props>(
   (props, ref) => {

--- a/packages/sdk-components-react/src/image.ws.tsx
+++ b/packages/sdk-components-react/src/image.ws.tsx
@@ -53,5 +53,4 @@ export const propsMeta: WsComponentPropsMeta = {
     ...propsOverrides,
   },
   initialProps: ["src", "width", "height", "alt", "loading"],
-  ignoredProps: ["loader"],
 };

--- a/packages/sdk-components-react/src/image.ws.tsx
+++ b/packages/sdk-components-react/src/image.ws.tsx
@@ -37,9 +37,6 @@ export const meta: WsComponentMeta = {
   order: 0,
 };
 
-// "loader" is our internal prop not intended to show up in the props panel
-const { loader, ...publicProps } = props;
-
 // Automatically generated props don't have the right control.
 export const propsOverrides = {
   src: {
@@ -52,8 +49,9 @@ export const propsOverrides = {
 
 export const propsMeta: WsComponentPropsMeta = {
   props: {
-    ...publicProps,
+    ...props,
     ...propsOverrides,
   },
   initialProps: ["src", "width", "height", "alt", "loading"],
+  ignoredProps: ["loader"],
 };

--- a/packages/sdk-components-react/src/vimeo-preview-image.ws.ts
+++ b/packages/sdk-components-react/src/vimeo-preview-image.ws.ts
@@ -19,4 +19,5 @@ export const meta: WsComponentMeta = {
 export const propsMeta: WsComponentPropsMeta = {
   props: { ...props, ...imagePropsOverrides },
   initialProps: imagePropsMeta.initialProps,
+  ignoredProps: imagePropsMeta.ignoredProps,
 };

--- a/packages/sdk-components-react/src/vimeo-preview-image.ws.ts
+++ b/packages/sdk-components-react/src/vimeo-preview-image.ws.ts
@@ -19,5 +19,4 @@ export const meta: WsComponentMeta = {
 export const propsMeta: WsComponentPropsMeta = {
   props: { ...props, ...imagePropsOverrides },
   initialProps: imagePropsMeta.initialProps,
-  ignoredProps: imagePropsMeta.ignoredProps,
 };

--- a/packages/sdk-components-react/src/vimeo.ws.ts
+++ b/packages/sdk-components-react/src/vimeo.ws.ts
@@ -49,7 +49,7 @@ export const meta: WsComponentMeta = {
               value: { type: "keyword", value: "absolute" },
             },
             {
-              property: "objectPosition",
+              property: "objectFit",
               value: { type: "keyword", value: "cover" },
             },
             {

--- a/packages/sdk-components-react/src/vimeo.ws.ts
+++ b/packages/sdk-components-react/src/vimeo.ws.ts
@@ -88,6 +88,11 @@ export const meta: WsComponentMeta = {
               name: "alt",
               value: "Vimeo video preview image",
             },
+            {
+              type: "string",
+              name: "sizes",
+              value: "100vw",
+            },
           ],
         },
         {


### PR DESCRIPTION
## Description

- I used object position instead of object fit by mistake
- Unrelated: ignore loader prop

## Steps for reproduction

1. add vimeo
2. select preview image
3. see it has object fit cover

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
