### PR TITLE
Avoid default import from react

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/space/value-text.stories.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/space/value-text.stories.tsx
@@ -1,16 +1,13 @@
 import type { ComponentMeta } from "@storybook/react";
-import React from "react";
+import { type ComponentProps, useState } from "react";
 import { parseCssValue } from "@webstudio-is/css-data";
 import { SpaceLayout } from "./layout";
 import { ValueText as ValueTextComponent } from "./value-text";
 
 export const ValueText = (
-  args: Pick<
-    React.ComponentProps<typeof ValueTextComponent>,
-    "source" | "value"
-  >
+  args: Pick<ComponentProps<typeof ValueTextComponent>, "source" | "value">
 ) => {
-  const [hovered, setHovered] = React.useState<{ property: string }>();
+  const [hovered, setHovered] = useState<{ property: string }>();
   return (
     <SpaceLayout
       onHover={setHovered}

--- a/apps/builder/app/builder/features/style-panel/style-settings.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-settings.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from "react";
 import type { StyleProperty } from "@webstudio-is/css-data";
 import {
   categories,
@@ -10,7 +11,6 @@ import type { StyleInfo } from "./shared/style-info";
 import { useStore } from "@nanostores/react";
 import { selectedInstanceSelectorStore } from "~/shared/nano-states";
 import { useInstanceStyleData } from "./shared/style-info";
-import React from "react";
 
 export type StyleSettingsProps = {
   currentStyle: StyleInfo;
@@ -50,9 +50,7 @@ export const StyleSettings = ({
 
     if (shouldRenderCategory(categoryProps, parentStyle)) {
       all.push(
-        <React.Fragment key={category}>
-          {renderCategory(categoryProps)}
-        </React.Fragment>
+        <Fragment key={category}>{renderCategory(categoryProps)}</Fragment>
       );
     }
   }

--- a/packages/design-system/src/components/__DEPRECATED__/heading.tsx
+++ b/packages/design-system/src/components/__DEPRECATED__/heading.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { type ComponentProps, type ElementRef, forwardRef } from "react";
 import { DeprecatedText } from "./text";
 import type { VariantProps, CSS } from "../../stitches.config";
 import merge from "lodash.merge";
@@ -11,11 +11,11 @@ type HeadingVariants = { size?: HeadingSizeVariants } & Omit<
   VariantProps<typeof DeprecatedText>,
   "size"
 >;
-type HeadingProps = React.ComponentProps<typeof DEFAULT_TAG> &
+type HeadingProps = ComponentProps<typeof DEFAULT_TAG> &
   HeadingVariants & { css?: CSS; as?: string };
 
-export const DeprecatedHeading = React.forwardRef<
-  React.ElementRef<typeof DEFAULT_TAG>,
+export const DeprecatedHeading = forwardRef<
+  ElementRef<typeof DEFAULT_TAG>,
   HeadingProps
 >((props, forwardedRef) => {
   // '2' here is the default heading size variant

--- a/packages/design-system/src/components/__DEPRECATED__/paragraph.tsx
+++ b/packages/design-system/src/components/__DEPRECATED__/paragraph.tsx
@@ -1,4 +1,4 @@
-import React, { type ComponentProps } from "react";
+import { type ComponentProps, type ElementRef, forwardRef } from "react";
 import { DeprecatedText2 } from "./text2";
 
 const DEFAULT_TAG = "p";
@@ -6,8 +6,8 @@ const DEFAULT_TAG = "p";
 type ParagraphProps = ComponentProps<typeof DEFAULT_TAG> &
   ComponentProps<typeof DeprecatedText2>;
 
-export const DeprecatedParagraph = React.forwardRef<
-  React.ElementRef<typeof DEFAULT_TAG>,
+export const DeprecatedParagraph = forwardRef<
+  ElementRef<typeof DEFAULT_TAG>,
   ParagraphProps
 >(({ css, ...props }, forwardedRef) => {
   return (

--- a/packages/design-system/src/components/__DEPRECATED__/popover.tsx
+++ b/packages/design-system/src/components/__DEPRECATED__/popover.tsx
@@ -1,4 +1,9 @@
-import React from "react";
+import {
+  type ComponentProps,
+  type ElementRef,
+  type ReactNode,
+  forwardRef,
+} from "react";
 import { CrossLargeIcon } from "@webstudio-is/icons";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { Box } from "../box";
@@ -10,8 +15,8 @@ import { Separator } from "../separator";
 import { styled, type CSS } from "../../stitches.config";
 import { theme } from "../../stitches.config";
 
-type PopoverProps = React.ComponentProps<typeof PopoverPrimitive.Root> & {
-  children: React.ReactNode;
+type PopoverProps = ComponentProps<typeof PopoverPrimitive.Root> & {
+  children: ReactNode;
 };
 
 export const DeprecatedPopover = ({ children, ...props }: PopoverProps) => {
@@ -30,7 +35,7 @@ const StyledContent = styled(PopoverPrimitive.Content, panelStyle, {
   flexDirection: "column",
 });
 
-type PopoverContentPrimitiveProps = React.ComponentProps<
+type PopoverContentPrimitiveProps = ComponentProps<
   typeof PopoverPrimitive.Content
 >;
 
@@ -39,8 +44,8 @@ type PopoverContentProps = PopoverContentPrimitiveProps & {
   hideArrow?: boolean;
 };
 
-export const DeprecatedPopoverContent = React.forwardRef<
-  React.ElementRef<typeof StyledContent>,
+export const DeprecatedPopoverContent = forwardRef<
+  ElementRef<typeof StyledContent>,
   PopoverContentProps
 >(({ children, hideArrow, ...props }, fowardedRef) => (
   <StyledContent

--- a/packages/design-system/src/components/__DEPRECATED__/text-field.tsx
+++ b/packages/design-system/src/components/__DEPRECATED__/text-field.tsx
@@ -1,8 +1,11 @@
 import { mergeRefs } from "@react-aria/utils";
-import React, {
+import {
   type ComponentProps,
   type RefObject,
   type FocusEventHandler,
+  forwardRef,
+  useRef,
+  useCallback,
 } from "react";
 import { useFocusWithin } from "@react-aria/interactions";
 import { css, styled, theme } from "../../stitches.config";
@@ -221,9 +224,9 @@ export const useDeprecatedTextFieldFocus = ({
   RefObject<HTMLInputElement>,
   ComponentProps<typeof DeprecatedTextFieldContainer>
 ] => {
-  const ref = React.useRef<HTMLInputElement>(null);
+  const ref = useRef<HTMLInputElement>(null);
 
-  const onClickCapture = React.useCallback(() => {
+  const onClickCapture = useCallback(() => {
     ref.current?.focus();
   }, [ref]);
 
@@ -260,7 +263,7 @@ export type DeprecatedTextFieldProps = Pick<
     suffix?: React.ReactNode;
   };
 
-export const DeprecatedTextField = React.forwardRef<
+export const DeprecatedTextField = forwardRef<
   HTMLDivElement,
   DeprecatedTextFieldProps
 >((props, forwardedRef) => {

--- a/packages/design-system/src/components/avatar.tsx
+++ b/packages/design-system/src/components/avatar.tsx
@@ -1,4 +1,9 @@
-import React from "react";
+import {
+  type ComponentProps,
+  type ElementRef,
+  type ReactNode,
+  forwardRef,
+} from "react";
 import { styled, type VariantProps, type CSS } from "../stitches.config";
 import * as AvatarPrimitive from "@radix-ui/react-avatar";
 import { Box } from "./box";
@@ -240,22 +245,22 @@ export const AvatarGroup = styled("div", {
   },
 });
 
-type StatusVariants = React.ComponentProps<typeof Status>;
+type StatusVariants = ComponentProps<typeof Status>;
 type StatusColors = Pick<StatusVariants, "variant">;
 
 type AvatarVariants = VariantProps<typeof StyledAvatar>;
-type AvatarPrimitiveProps = React.ComponentProps<typeof AvatarPrimitive.Root>;
+type AvatarPrimitiveProps = ComponentProps<typeof AvatarPrimitive.Root>;
 type AvatarOwnProps = AvatarPrimitiveProps &
   AvatarVariants & {
     css?: CSS;
     alt?: string;
     src?: string;
-    fallback?: React.ReactNode;
+    fallback?: ReactNode;
     status?: StatusColors["variant"];
   };
 
-export const Avatar = React.forwardRef<
-  React.ElementRef<typeof StyledAvatar>,
+export const Avatar = forwardRef<
+  ElementRef<typeof StyledAvatar>,
   AvatarOwnProps
 >(
   (

--- a/packages/design-system/src/components/combobox.stories.tsx
+++ b/packages/design-system/src/components/combobox.stories.tsx
@@ -1,5 +1,5 @@
 import { MagnifyingGlassIcon } from "@webstudio-is/icons";
-import React, { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { DeprecatedTextField } from "./__DEPRECATED__/text-field";
 import {
   ComboboxListboxItem,
@@ -14,7 +14,7 @@ import type {
 } from "downshift";
 
 export const Complex = () => {
-  const [value, setValue] = React.useState<string | null>(null);
+  const [value, setValue] = useState<string | null>(null);
 
   const stateReducer = useCallback(
     (

--- a/packages/design-system/src/components/dialog.tsx
+++ b/packages/design-system/src/components/dialog.tsx
@@ -1,4 +1,9 @@
-import React, { type ReactNode, type ComponentProps, type Ref } from "react";
+import {
+  type ReactNode,
+  type ComponentProps,
+  type Ref,
+  forwardRef,
+} from "react";
 import * as Primitive from "@radix-ui/react-dialog";
 import { css, theme, keyframes, type CSS } from "../stitches.config";
 import { PanelTitle } from "./panel-title";
@@ -15,7 +20,7 @@ export const DialogClose = Primitive.Close;
 // https://www.radix-ui.com/docs/primitives/components/dialog#description
 export const DialogDescription = Primitive.Description;
 
-export const DialogContent = React.forwardRef(
+export const DialogContent = forwardRef(
   (
     {
       children,

--- a/packages/design-system/src/components/enhanced-tooltip.tsx
+++ b/packages/design-system/src/components/enhanced-tooltip.tsx
@@ -1,7 +1,8 @@
-import React, {
+import {
   type Ref,
   type ComponentProps,
   type FocusEvent,
+  forwardRef,
   useRef,
   useState,
   createContext,
@@ -52,7 +53,7 @@ export const useEnhancedTooltipProps = () => useContext(EnhancedTooltipContext);
  * 1. Don't show the tooltip if any click or key-down was made inside Tooltip.Trigger
  * 2. Show Tooltip on focus after the delay
  **/
-export const EnhancedTooltip = React.forwardRef(
+export const EnhancedTooltip = forwardRef(
   (
     props: Omit<TooltipProps, "open" | "onOpenChange">,
     ref: Ref<HTMLDivElement>

--- a/packages/design-system/src/components/floating-panel-popover.tsx
+++ b/packages/design-system/src/components/floating-panel-popover.tsx
@@ -1,4 +1,9 @@
-import React, { type ComponentProps, type Ref, type ReactNode } from "react";
+import {
+  type ComponentProps,
+  type Ref,
+  type ReactNode,
+  forwardRef,
+} from "react";
 import * as Primitive from "@radix-ui/react-popover";
 import { css, theme, type CSS } from "../stitches.config";
 import { PanelTitle } from "./panel-title";
@@ -13,7 +18,7 @@ const contentStyle = css(floatingPanelStyle, {
   overflowY: "auto",
 });
 
-export const FloatingPanelPopoverContent = React.forwardRef(
+export const FloatingPanelPopoverContent = forwardRef(
   (
     {
       children,

--- a/packages/design-system/src/components/popover.tsx
+++ b/packages/design-system/src/components/popover.tsx
@@ -1,4 +1,4 @@
-import React, { type ComponentProps, type Ref } from "react";
+import { type ComponentProps, type Ref, forwardRef } from "react";
 import * as Primitive from "@radix-ui/react-popover";
 import { css, theme, styled, type CSS } from "../stitches.config";
 import { Separator } from "./separator";
@@ -36,7 +36,7 @@ const Arrow = () => (
   </Primitive.Arrow>
 );
 
-export const PopoverContent = React.forwardRef(
+export const PopoverContent = forwardRef(
   (
     {
       children,

--- a/packages/design-system/src/components/primitives/dnd/canvas.stories.tsx
+++ b/packages/design-system/src/components/primitives/dnd/canvas.stories.tsx
@@ -1,5 +1,5 @@
 import type { ComponentMeta } from "@storybook/react";
-import React, { useState, useRef } from "react";
+import { type CSSProperties, useState, useRef } from "react";
 import { Box } from "../../box";
 import { useDrop, type DropTarget } from "./use-drop";
 import { useDrag } from "./use-drag";
@@ -15,7 +15,7 @@ const ROOT_ID = "root";
 
 type ItemData = {
   id: string;
-  style: React.CSSProperties;
+  style: CSSProperties;
   acceptsChildren: boolean;
   children: ItemData[];
 };

--- a/packages/design-system/src/components/progress-radial.tsx
+++ b/packages/design-system/src/components/progress-radial.tsx
@@ -1,15 +1,13 @@
-import React from "react";
+import { type ComponentProps, type ElementRef, forwardRef } from "react";
 import type { CSS } from "../stitches.config";
 import * as ProgressPrimitive from "@radix-ui/react-progress";
 import { Box } from "./box";
 
-type ProgressBarPrimitiveProps = React.ComponentProps<
-  typeof ProgressPrimitive.Root
->;
+type ProgressBarPrimitiveProps = ComponentProps<typeof ProgressPrimitive.Root>;
 type ProgressRadialProps = ProgressBarPrimitiveProps & { css?: CSS };
 
-export const ProgressRadial = React.forwardRef<
-  React.ElementRef<typeof ProgressPrimitive.Root>,
+export const ProgressRadial = forwardRef<
+  ElementRef<typeof ProgressPrimitive.Root>,
   ProgressRadialProps
 >(({ value, max = 100, css, ...props }, forwardedRef) => {
   const percentage = value != null ? Math.round((value / max) * 100) : 0;

--- a/packages/design-system/src/components/select.stories.tsx
+++ b/packages/design-system/src/components/select.stories.tsx
@@ -1,6 +1,6 @@
 import type { ComponentStory } from "@storybook/react";
 import { GapVerticalIcon } from "@webstudio-is/icons";
-import React from "react";
+import { useState } from "react";
 import { NestedIconLabel } from "./nested-icon-label";
 import { Select, type SelectOption } from "./select";
 
@@ -10,7 +10,7 @@ export default {
 
 export const Simple: ComponentStory<typeof Select> = () => {
   const options = ["Apple", "Banana", "Orange"];
-  const [value, setValue] = React.useState(options[0]);
+  const [value, setValue] = useState(options[0]);
   return (
     <Select name="fruit" options={options} value={value} onChange={setValue} />
   );
@@ -66,7 +66,7 @@ export const WithComplexItems: ComponentStory<typeof Select> = () => {
     grape: { icon: "🍇" },
   } as const;
   const options = Object.keys(items);
-  const [value, setValue] = React.useState(options[0]);
+  const [value, setValue] = useState(options[0]);
   const getLabel = (option: SelectOption) =>
     value && option in items
       ? `${items[option as keyof typeof items]?.icon} ${option}`
@@ -86,7 +86,7 @@ export const Boundaries: ComponentStory<typeof Select> = () => {
   const items = Array(100)
     .fill(0)
     .map((_, index) => `Item ${index}`);
-  const [value, setValue] = React.useState(items[0]);
+  const [value, setValue] = useState(items[0]);
   return (
     <Select name="fruit" options={items} value={value} onChange={setValue} />
   );

--- a/packages/design-system/src/components/select.tsx
+++ b/packages/design-system/src/components/select.tsx
@@ -1,9 +1,10 @@
 import * as Primitive from "@radix-ui/react-select";
-import React, {
+import {
   type ReactNode,
   type Ref,
   type ComponentProps,
   useMemo,
+  forwardRef,
 } from "react";
 import {
   menuCss,
@@ -70,7 +71,7 @@ type SelectItemProps = ComponentProps<typeof StyledItem> & {
   children: ReactNode;
   icon?: ReactNode;
 };
-export const SelectItem = React.forwardRef(SelectItemBase);
+export const SelectItem = forwardRef(SelectItemBase);
 
 export type SelectOption = string;
 
@@ -182,6 +183,6 @@ const SelectBase = <Option,>(
   );
 };
 
-export const Select = React.forwardRef(SelectBase) as <Option>(
+export const Select = forwardRef(SelectBase) as <Option>(
   props: SelectProps<Option> & { ref?: Ref<HTMLButtonElement> }
 ) => JSX.Element | null;

--- a/packages/design-system/src/components/sidebar-tabs.tsx
+++ b/packages/design-system/src/components/sidebar-tabs.tsx
@@ -1,5 +1,5 @@
 // @todo this should be a local customization in sidebar left, not a reusable component
-import React from "react";
+import { type ComponentProps, type ElementRef, forwardRef } from "react";
 import { type CSS, styled } from "../stitches.config";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
 import { theme } from "../stitches.config";
@@ -51,11 +51,11 @@ const StyledTabsList = styled(TabsPrimitive.List, {
   flexGrow: 1,
 });
 
-type TabsListPrimitiveProps = React.ComponentProps<typeof TabsPrimitive.List>;
+type TabsListPrimitiveProps = ComponentProps<typeof TabsPrimitive.List>;
 type TabsListProps = TabsListPrimitiveProps & { css?: CSS };
 
-export const SidebarTabsList = React.forwardRef<
-  React.ElementRef<typeof StyledTabsList>,
+export const SidebarTabsList = forwardRef<
+  ElementRef<typeof StyledTabsList>,
   TabsListProps
 >((props, forwardedRef) => (
   <>

--- a/packages/design-system/src/components/slider.tsx
+++ b/packages/design-system/src/components/slider.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { type ComponentProps, type ElementRef, forwardRef } from "react";
 import { styled, type CSS } from "../stitches.config";
 import * as SliderPrimitive from "@radix-ui/react-slider";
 import { theme } from "../stitches.config";
@@ -85,7 +85,7 @@ export const StyledSlider = styled(SliderPrimitive.Root, {
 });
 
 type SliderPrimitiveProps = Omit<
-  React.ComponentProps<typeof SliderPrimitive.Root>,
+  ComponentProps<typeof SliderPrimitive.Root>,
   "value" | "defaultValue"
 > & {
   value?: number | number[];
@@ -103,28 +103,27 @@ const toArrayValue = (value?: Array<number> | number) => {
   return [value];
 };
 
-export const Slider = React.forwardRef<
-  React.ElementRef<typeof StyledSlider>,
-  SliderProps
->(({ value, defaultValue, ...props }, forwardedRef) => {
-  const realValue = value || defaultValue || 0;
-  const hasRange = Array.isArray(realValue);
-  const thumbsArray = hasRange ? realValue : [realValue];
+export const Slider = forwardRef<ElementRef<typeof StyledSlider>, SliderProps>(
+  ({ value, defaultValue, ...props }, forwardedRef) => {
+    const realValue = value || defaultValue || 0;
+    const hasRange = Array.isArray(realValue);
+    const thumbsArray = hasRange ? realValue : [realValue];
 
-  return (
-    <StyledSlider
-      {...props}
-      ref={forwardedRef}
-      value={toArrayValue(value)}
-      defaultValue={toArrayValue(defaultValue)}
-    >
-      <SliderTrack>
-        <SliderRange />
-      </SliderTrack>
-      {thumbsArray?.map((_, i: number) => (
-        <SliderThumb key={i} />
-      ))}
-    </StyledSlider>
-  );
-});
+    return (
+      <StyledSlider
+        {...props}
+        ref={forwardedRef}
+        value={toArrayValue(value)}
+        defaultValue={toArrayValue(defaultValue)}
+      >
+        <SliderTrack>
+          <SliderRange />
+        </SliderTrack>
+        {thumbsArray?.map((_, i: number) => (
+          <SliderThumb key={i} />
+        ))}
+      </StyledSlider>
+    );
+  }
+);
 Slider.displayName = "Slider";

--- a/packages/design-system/src/components/tabs.tsx
+++ b/packages/design-system/src/components/tabs.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { type ComponentProps, type ElementRef, forwardRef } from "react";
 import { styled, type CSS } from "../stitches.config";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
 import { DeprecatedText2 } from "./__DEPRECATED__/text2";
@@ -62,11 +62,11 @@ const StyledTabsList = styled(TabsPrimitive.List, {
   },
 });
 
-type TabsListPrimitiveProps = React.ComponentProps<typeof TabsPrimitive.List>;
+type TabsListPrimitiveProps = ComponentProps<typeof TabsPrimitive.List>;
 type TabsListProps = TabsListPrimitiveProps & { css?: CSS };
 
-export const TabsList = React.forwardRef<
-  React.ElementRef<typeof StyledTabsList>,
+export const TabsList = forwardRef<
+  ElementRef<typeof StyledTabsList>,
   TabsListProps
 >((props, forwardedRef) => (
   <>

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -52,6 +52,15 @@ module.exports = {
         ],
       },
     ],
+    "no-restricted-syntax": [
+      "error",
+      {
+        message:
+          "Do not import default from React, use a named imports instead",
+        selector:
+          'ImportDeclaration[source.value="react"] ImportDefaultSpecifier',
+      },
+    ],
   },
   overrides: [
     {


### PR DESCRIPTION
Default import cannot be optimized by mangling variables so better restrict with linter.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
