### PR TITLE
Add effects section with opacity and cursor

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/effects/effects.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/effects/effects.tsx
@@ -1,0 +1,58 @@
+import type { StyleProperty } from "@webstudio-is/css-data";
+import { Grid } from "@webstudio-is/design-system";
+import { styleConfigByName } from "../../shared/configs";
+import type { RenderCategoryProps } from "../../style-sections";
+import { PropertyName } from "../../shared/property-name";
+import { SelectControl, TextControl } from "../../controls";
+
+import { CollapsibleSection } from "../../shared/collapsible-section";
+import { theme } from "@webstudio-is/design-system";
+
+const properties: StyleProperty[] = ["cursor", "opacity"];
+
+export const EffectsSection = ({
+  currentStyle: style,
+  setProperty,
+  deleteProperty,
+}: RenderCategoryProps) => {
+  return (
+    <CollapsibleSection
+      label="Effects"
+      currentStyle={style}
+      properties={properties}
+    >
+      <Grid
+        gap={2}
+        css={{
+          gridTemplateColumns: `1fr ${theme.spacing[22]}`,
+        }}
+      >
+        <PropertyName
+          label={styleConfigByName("cursor").label}
+          property="cursor"
+          style={style}
+          onReset={() => deleteProperty("cursor")}
+        />
+        <SelectControl
+          property={"cursor"}
+          currentStyle={style}
+          setProperty={setProperty}
+          deleteProperty={deleteProperty}
+        />
+
+        <PropertyName
+          label={styleConfigByName("opacity").label}
+          property="opacity"
+          style={style}
+          onReset={() => deleteProperty("opacity")}
+        />
+        <TextControl
+          property={"opacity"}
+          currentStyle={style}
+          setProperty={setProperty}
+          deleteProperty={deleteProperty}
+        />
+      </Grid>
+    </CollapsibleSection>
+  );
+};

--- a/apps/builder/app/builder/features/style-panel/sections/index.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/index.ts
@@ -8,3 +8,4 @@ export * from "./typography/typography";
 export * from "./backgrounds/backgrounds";
 export * from "./borders/borders";
 export * from "./outline/outline";
+export * from "./effects/effects";

--- a/apps/builder/app/builder/features/style-panel/style-sections.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-sections.tsx
@@ -21,6 +21,7 @@ import {
   BackgroundsSection,
   BordersSection,
   OutlineSection,
+  EffectsSection,
 } from "./sections";
 
 export const categories = [
@@ -34,6 +35,7 @@ export const categories = [
   "backgrounds",
   "borders",
   "outline",
+  "effects",
 ];
 
 export type Category = (typeof categories)[number];
@@ -140,4 +142,5 @@ export const sections: {
   backgrounds: BackgroundsSection,
   borders: BordersSection,
   outline: OutlineSection,
+  effects: EffectsSection,
 };


### PR DESCRIPTION
## Description

ref #879

Known issues not fixed here.

Scrub on opacity doesn't work as expected
as depending on opacity dimension it has different min-max and step.

Also any numeric value of opacity is valid css value, and just clamped if it exceeds, so we can't consider values out of 0-1 range as percents too.

So couldn't be fixed fast.





## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
