### PR TITLE
Fix tooltip

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
@@ -15,7 +15,6 @@ import { ResetIcon } from "@webstudio-is/icons";
 import {
   breakpointsStore,
   instancesStore,
-  selectedInstanceSelectorStore,
   selectedInstanceStore,
   styleSourcesStore,
 } from "~/shared/nano-states";
@@ -25,7 +24,6 @@ import {
   type StyleValueInfo,
 } from "./style-info";
 import { humanizeString } from "~/shared/string-utils";
-import { useInstanceStyleData } from "./style-info";
 import { StyleSourceBadge } from "../style-source";
 import type { StyleSources } from "@webstudio-is/project-build";
 import { isBaseBreakpoint } from "~/shared/breakpoints";
@@ -64,7 +62,7 @@ const getSourceName = (
 // @todo consider reusing CssPreview component
 const getCssText = (
   properties: readonly StyleProperty[],
-  instanceStyle: Style
+  instanceStyle: StyleInfo
 ) => {
   const cssEngine = createCssEngine();
   const style: Style = {};
@@ -72,7 +70,7 @@ const getCssText = (
   for (property in instanceStyle) {
     const value = instanceStyle[property];
     if (value && properties.includes(property)) {
-      style[property] = value;
+      style[property] = value.value;
     }
   }
   const rule = cssEngine.addStyleRule("instance", {
@@ -96,8 +94,6 @@ const TooltipContent = ({
   onReset: () => void;
   onClose: () => void;
 }) => {
-  const selectedInstanceSelector = useStore(selectedInstanceSelectorStore);
-  const instanceStyle = useInstanceStyleData(selectedInstanceSelector);
   const breakpoints = useStore(breakpointsStore);
   const instances = useStore(instancesStore);
   const styleSources = useStore(styleSourcesStore);
@@ -109,7 +105,7 @@ const TooltipContent = ({
   const sourceName = getSourceName(styleSources, styleValueInfo);
   const showValueOrigin =
     styleSource === "overwritten" || styleSource === "remote";
-  const cssText = getCssText(properties, instanceStyle);
+  const cssText = getCssText(properties, style);
   let breakpointName;
 
   const breakpointId = styleValueInfo?.cascaded?.breakpointId;


### PR DESCRIPTION
## Description

Fix tooltip to show right color etc values

<img width="357" alt="image" src="https://github.com/webstudio-is/webstudio-builder/assets/5077042/482b67a0-fc25-4856-b433-78139d0ae8ac">


Before was `black`

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
