### PR TITLE
Tooltips improvements

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
@@ -151,13 +151,11 @@ const TooltipContent = ({
     selectedStyleSource
   );
   const cssText = getCssText(properties, style);
-  let breakpoint = selectedBreakpoint;
-  if (styleValueInfo?.cascaded) {
-    const { breakpointId } = styleValueInfo.cascaded;
-    breakpoint = breakpoints.get(breakpointId);
-  }
-
-  const breakpointName = breakpoint?.minWidth ?? breakpoint?.maxWidth ?? "Base";
+  const breakpointName = getBreakpointName(
+    styleValueInfo,
+    breakpoints,
+    selectedBreakpoint
+  );
 
   if (styleValueInfo.inherited && styleValueInfo.local === undefined) {
     instance = instances.get(styleValueInfo.inherited.instanceId);

--- a/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
@@ -27,7 +27,12 @@ import {
 } from "./style-info";
 import { humanizeString } from "~/shared/string-utils";
 import { StyleSourceBadge } from "../style-source";
-import type { StyleSource, StyleSources } from "@webstudio-is/project-build";
+import type {
+  Breakpoint,
+  Breakpoints,
+  StyleSource,
+  StyleSources,
+} from "@webstudio-is/project-build";
 
 // We don't return source name only in case of preset or default value.
 const getSourceName = (
@@ -88,6 +93,26 @@ const getCssText = (
     style,
   });
   return rule.styleMap.toString();
+};
+
+const getBreakpointName = (
+  styleValueInfo: StyleValueInfo,
+  breakpoints: Breakpoints,
+  selectedBreakpoint?: Breakpoint
+) => {
+  let breakpoint;
+  if (
+    styleValueInfo.local ||
+    styleValueInfo.previousSource ||
+    styleValueInfo.nextSource
+  ) {
+    breakpoint = selectedBreakpoint;
+  } else if (styleValueInfo.cascaded) {
+    const { breakpointId } = styleValueInfo.cascaded;
+    breakpoint = breakpoints.get(breakpointId);
+  }
+
+  return breakpoint?.minWidth ?? breakpoint?.maxWidth ?? "Base";
 };
 
 const TooltipContent = ({

--- a/packages/css-data/src/index.ts
+++ b/packages/css-data/src/index.ts
@@ -5,6 +5,10 @@ export const html: Html = exportedHtml;
 
 export * from "./__generated__/keyword-values";
 export * from "./__generated__/units";
+export {
+  properties as propertyDescriptions,
+  declarations as declarationDescriptions,
+} from "./__generated__/property-value-descriptions";
 export * from "./schema";
 
 // longhand property parsers


### PR DESCRIPTION
## Description

- Fixes a bunch of wrong logic for showing style source origin info in the tooltip
- Renders GPT descriptions

## Steps for reproduction

1. check tooltips in style panel


## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
