### PR TITLE
Override inherited with html style

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/style-info.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.ts
@@ -78,6 +78,7 @@ export type StyleValueInfo = {
   cascaded?: CascadedValueInfo;
   inherited?: InheritedValueInfo;
   preset?: StyleValue;
+  htmlValue?: StyleValue;
 };
 
 export type StyleInfo = {
@@ -130,6 +131,11 @@ export const getStyleSource = (
   for (const info of styleValueInfos) {
     if (info?.preset !== undefined) {
       return "preset";
+    }
+  }
+  for (const info of styleValueInfos) {
+    if (info?.htmlValue !== undefined) {
+      return "default";
     }
   }
   for (const info of styleValueInfos) {
@@ -581,8 +587,8 @@ export const useStyleInfo = () => {
     for (const property of styleProperties) {
       // temporary solution until we start computing all styles from data
       const computed = browserStyle?.[property];
+      const htmlValue = htmlStyle?.[property];
       const defaultValue =
-        htmlStyle?.[property] ??
         CUSTOM_DEFAULT_VALUES[property] ??
         properties[property as keyof typeof properties].initial;
       const preset = presetStyle?.[property];
@@ -597,6 +603,7 @@ export const useStyleInfo = () => {
         previousSource?.value ??
         cascaded?.value ??
         preset ??
+        htmlValue ??
         inherited?.value ??
         defaultValue;
       if (value) {
@@ -609,6 +616,7 @@ export const useStyleInfo = () => {
             cascaded,
             inherited,
             preset,
+            htmlValue,
             currentColor: computed,
           };
         } else {
@@ -620,6 +628,7 @@ export const useStyleInfo = () => {
             cascaded,
             inherited,
             preset,
+            htmlValue,
           };
         }
       }

--- a/packages/react-sdk/src/css/normalize.ts
+++ b/packages/react-sdk/src/css/normalize.ts
@@ -63,18 +63,7 @@ export const i = baseStyle;
 
 export const img = baseStyle;
 
-export const a = [
-  ...baseStyle,
-  {
-    property: "color",
-    value: { type: "rgb", r: 0, g: 0, b: 238, alpha: 1 },
-  },
-  {
-    state: ":visited",
-    property: "color",
-    value: { type: "rgb", r: 85, g: 26, b: 139, alpha: 1 },
-  },
-] satisfies Styles;
+export const a = baseStyle;
 export const li = baseStyle;
 export const ul = baseStyle;
 export const ol = baseStyle;


### PR DESCRIPTION
Html styles override inherited styles. This fixes the issue with link inheriting from body instead of showing predefined in browser style.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
