### PR TITLE
Prevent selection of pasted data

### DIFF
--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -19,7 +19,6 @@ import {
   instancesStore,
   selectedPageStore,
   breakpointsStore,
-  selectedStyleSourceSelectorStore,
   assetsStore,
   projectStore,
   registeredComponentMetasStore,

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -314,14 +314,6 @@ export const onPaste = (clipboardData: string) => {
         copiedStyleSourceIds,
         mergedBreakpointIds
       );
-
-      // first item is guaranteed root of copied tree
-      const copiedRootInstanceId = Array.from(copiedInstanceIds.values())[0];
-      selectedInstanceSelectorStore.set([
-        copiedRootInstanceId,
-        ...instanceSelector,
-      ]);
-      selectedStyleSourceSelectorStore.set(undefined);
     }
   );
 };


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio/discussions/34

Looks like selection of pasted data does not work well so here remove it.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
