### PR TITLE
Support shorthand property in tooltips

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
@@ -184,6 +184,7 @@ const BackgroundsCollapsibleSection = ({
             style={currentStyle}
             title="Backgrounds"
             properties={layeredBackgroundProps}
+            shorthandProperty="background"
             label={
               <SectionTitleLabel color={layersStyleSource}>
                 {label}

--- a/apps/builder/app/builder/features/style-panel/sections/borders/border-property.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/border-property.tsx
@@ -29,6 +29,7 @@ export const BorderProperty = ({
   createBatchUpdate,
   individualModeIcon,
   borderPropertyOptions,
+  shorthandProperty,
   label,
 }: Pick<
   RenderCategoryProps,
@@ -38,6 +39,7 @@ export const BorderProperty = ({
   borderPropertyOptions: Partial<{
     [property in StyleProperty]: { icon?: ReactNode };
   }>;
+  shorthandProperty?: string;
   label: string;
 }) => {
   const borderProperties = Object.keys(borderPropertyOptions) as Array<
@@ -116,6 +118,7 @@ export const BorderProperty = ({
         <PropertyName
           style={currentStyle}
           properties={borderProperties}
+          shorthandProperty={shorthandProperty}
           label={label}
           onReset={() => deleteBorderProperties(firstPropertyName)}
         />

--- a/apps/builder/app/builder/features/style-panel/sections/borders/border-radius.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/border-radius.tsx
@@ -39,6 +39,7 @@ export const BorderRadius = (
       createBatchUpdate={props.createBatchUpdate}
       label="Radius"
       borderPropertyOptions={borderPropertyOptions}
+      shorthandProperty="borderRadius"
       individualModeIcon={<BorderRadiusIndividualIcon />}
     />
   );

--- a/apps/builder/app/builder/features/style-panel/sections/borders/border-style.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/border-style.tsx
@@ -72,6 +72,7 @@ export const BorderStyle = (
       <PropertyName
         style={props.currentStyle}
         properties={borderStyleProperties}
+        shorthandProperty="borderStyle"
         label={"Style"}
         onReset={() => deleteBorderProperties(firstPropertyName)}
       />

--- a/apps/builder/app/builder/features/style-panel/sections/borders/border-width.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/border-width.tsx
@@ -39,6 +39,7 @@ export const BorderWidth = (
       createBatchUpdate={props.createBatchUpdate}
       label="Width"
       borderPropertyOptions={borderPropertyOptions}
+      shorthandProperty="borderWidth"
       individualModeIcon={<BorderWidthIndividualIcon />}
     />
   );

--- a/apps/builder/app/builder/features/style-panel/sections/borders/borders.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/borders.tsx
@@ -84,7 +84,8 @@ export const BordersSection = (props: RenderCategoryProps) => {
         >
           <PropertyName
             style={currentStyle}
-            properties={[borderColorProperty]}
+            properties={borderColorProperties}
+            shorthandProperty="borderColor"
             label={"Color"}
             onReset={() => deleteAllBorderColorProperties(borderColorProperty)}
           />

--- a/apps/builder/app/builder/features/style-panel/sections/flex-child/flex-child.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/flex-child/flex-child.tsx
@@ -108,6 +108,7 @@ const FlexChildSectionSizing = (props: RenderCategoryProps) => {
       <PropertyName
         style={currentStyle}
         properties={["flexGrow", "flexShrink"]}
+        shorthandProperty="sizing"
         label="Sizing"
         onReset={() => {
           setSizing.deleteProperty("flexGrow");
@@ -123,20 +124,44 @@ const FlexChildSectionSizing = (props: RenderCategoryProps) => {
         onValueChange={(value) => {
           switch (value) {
             case "none": {
-              setSizing.setProperty("flexGrow")("0");
-              setSizing.setProperty("flexShrink")("0");
+              setSizing.setProperty("flexGrow")({
+                type: "unit",
+                value: 0,
+                unit: "number",
+              });
+              setSizing.setProperty("flexShrink")({
+                type: "unit",
+                value: 0,
+                unit: "number",
+              });
               setSizing.publish();
               break;
             }
             case "grow": {
-              setSizing.setProperty("flexGrow")("1");
-              setSizing.setProperty("flexShrink")("0");
+              setSizing.setProperty("flexGrow")({
+                type: "unit",
+                value: 1,
+                unit: "number",
+              });
+              setSizing.setProperty("flexShrink")({
+                type: "unit",
+                value: 0,
+                unit: "number",
+              });
               setSizing.publish();
               break;
             }
             case "shrink": {
-              setSizing.setProperty("flexGrow")("0");
-              setSizing.setProperty("flexShrink")("1");
+              setSizing.setProperty("flexGrow")({
+                type: "unit",
+                value: 0,
+                unit: "number",
+              });
+              setSizing.setProperty("flexShrink")({
+                type: "unit",
+                value: 1,
+                unit: "number",
+              });
               setSizing.publish();
               break;
             }

--- a/packages/css-data/src/__generated__/property-value-descriptions.ts
+++ b/packages/css-data/src/__generated__/property-value-descriptions.ts
@@ -37,6 +37,8 @@ export const properties = {
   backgroundRepeat: "Sets the size of a background image",
   backgroundSize:
     "Defines how an element should behave if its content overflows its block-level container",
+  background:
+    "Sets background color, image or gradient and composes them with layers",
   blockOverflow: "Sets the height of an element",
   blockSize: "Sets the width of an element",
   borderBlockColor: "Sets the color of the block borders",
@@ -88,6 +90,10 @@ export const properties = {
   borderTopRightRadius: "Sets the radius of the top right border",
   borderTopStyle: "Sets the style of the top border",
   borderTopWidth: "Sets the width of the top border",
+  borderWidth: "Sets the width of the border",
+  borderStyle: "Sets the style of the border",
+  borderColor: "Sets the color of the border",
+  borderRadius: "Sets the radius of border",
   bottom: "Sets the distance between the bottom edge and the parent container",
   boxDecorationBreak:
     "Specifies how box decorations should be broken between lines",
@@ -140,6 +146,7 @@ export const properties = {
   flexGrow:
     "Specifies the ability of a flex item to grow to fill available space",
   flexShrink: "Specifies the ability of a flex item to shrink if necessary",
+  sizing: "Specifies the ability of a flex item to grow or shrink",
   flexWrap:
     "Specifies whether flex items are forced onto one line or can wrap onto multiple lines",
   float: "Specifies the horizontal alignment of an element",
@@ -177,7 +184,7 @@ export const properties = {
   gridTemplateColumns: "Sets the size of the first letter in a block of text",
   gridTemplateRows: "Sets the starting position of a grid item's column",
   hangingPunctuation: "Sets the ending position of a grid item's column",
-  height: "Sets the starting position of a grid item's row",
+  height: "Sets the height of an element",
   hyphenateCharacter: "Sets the ending position of a grid item's row",
   hyphens: "Defines named grid areas within the grid container",
   imageOrientation:
@@ -1272,6 +1279,14 @@ export const declarations = {
   "borderTopStyle:inherit":
     "Sets the style of the top border to be the same as its parent element",
   "borderTopStyle:unset": "Removes any previously set style for the top border",
+  "borderStyle:none,none,none,none":
+    "Sets the style of the border to no border",
+  "borderStyle:solid,solid,solid,solid":
+    "Sets the style of the border to a solid line",
+  "borderStyle:dashed,dashed,dashed,dashed":
+    "Sets the style of the border to a dashed line",
+  "borderStyle:dotted,dotted,dotted,dotted":
+    "Sets the style of the border to a dotted line",
   "borderTopWidth:thin": "Sets the width of the top border to be thin",
   "borderTopWidth:medium":
     "Sets the width of the top border to be the default value",
@@ -1962,6 +1977,9 @@ export const declarations = {
   "flexShrink:inherit":
     "Inherits the amount of space a flex item will shrink from its parent element",
   "flexShrink:unset": "Sets the ability for a flex item to shrink if necessary",
+  "sizing:0,0": "Flex item doesn't grow or shrink",
+  "sizing:1,0": "Flex item grows to fill available space",
+  "sizing:0,1": "Flex item shrinks if necessary",
   "flexWrap:nowrap": "Prevents flex items from wrapping to a new line",
   "flexWrap:wrap": "Allows flex items to wrap to a new line if necessary",
   "flexWrap:wrap-reverse":


### PR DESCRIPTION
Added following shorthand property in tooltip configuration
- background
- borderWidth
- borderStyle
- borderColor
- borderRadius
- sizing

Also fixed height description.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
