### PR TITLE
Check types outside of src folder

### DIFF
--- a/packages/asset-uploader/package.json
+++ b/packages/asset-uploader/package.json
@@ -11,7 +11,7 @@
     "checks": "pnpm typecheck && pnpm lint && pnpm test",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc --declarationDir lib/types",
+    "dts": "tsc --project tsconfig.dts.json",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"
   },
   "dependencies": {

--- a/packages/asset-uploader/tsconfig.dts.json
+++ b/packages/asset-uploader/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/asset-uploader/tsconfig.json
+++ b/packages/asset-uploader/tsconfig.json
@@ -1,10 +1,3 @@
 {
-  "extends": "@webstudio-is/tsconfig/base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "module": "ES2020",
-    "target": "ES2020",
-    "outDir": "./lib",
-    "rootDir": "./src"
-  }
+  "extends": "@webstudio-is/tsconfig/base.json"
 }

--- a/packages/authorization-token/package.json
+++ b/packages/authorization-token/package.json
@@ -11,7 +11,7 @@
     "checks": "pnpm typecheck && pnpm lint",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc --declarationDir lib/types",
+    "dts": "tsc --project tsconfig.dts.json",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"
   },
   "dependencies": {

--- a/packages/authorization-token/tsconfig.dts.json
+++ b/packages/authorization-token/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/authorization-token/tsconfig.json
+++ b/packages/authorization-token/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "@webstudio-is/tsconfig/base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "module": "ES2020",
-    "target": "ES2020"
-  }
+  "extends": "@webstudio-is/tsconfig/base.json"
 }

--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -12,7 +12,7 @@
     "build": "build-package",
     "build:mdn-data": "tsx ./bin/mdn-data.ts ./src/__generated__ &&  prettier --write \"./src/__generated__/**/*.ts\"",
     "build:descriptions": "tsx ./bin/property-value-descriptions.ts",
-    "dts": "tsc --declarationDir lib/types",
+    "dts": "tsc --project tsconfig.dts.json",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },

--- a/packages/css-data/tsconfig.dts.json
+++ b/packages/css-data/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/css-data/tsconfig.json
+++ b/packages/css-data/tsconfig.json
@@ -1,9 +1,3 @@
 {
-  "extends": "@webstudio-is/tsconfig/base.json",
-  "include": ["src", "bin"],
-  "compilerOptions": {
-    "module": "ES2020",
-    "target": "ES2020",
-    "outDir": "./lib"
-  }
+  "extends": "@webstudio-is/tsconfig/base.json"
 }

--- a/packages/css-engine/package.json
+++ b/packages/css-engine/package.json
@@ -10,7 +10,7 @@
     "checks": "pnpm typecheck && pnpm lint && pnpm test",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc --declarationDir lib/types",
+    "dts": "tsc --project tsconfig.dts.json",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0",
     "storybook:run": "start-storybook -p 6006",

--- a/packages/css-engine/tsconfig.dts.json
+++ b/packages/css-engine/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/css-engine/tsconfig.json
+++ b/packages/css-engine/tsconfig.json
@@ -1,10 +1,3 @@
 {
-  "extends": "@webstudio-is/tsconfig/base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "module": "ES2020",
-    "target": "ES2020",
-    "outDir": "./lib",
-    "rootDir": "./src"
-  }
+  "extends": "@webstudio-is/tsconfig/base.json"
 }

--- a/packages/css-vars/package.json
+++ b/packages/css-vars/package.json
@@ -10,7 +10,7 @@
     "checks": "pnpm typecheck && pnpm lint",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc --declarationDir lib/types",
+    "dts": "tsc --project tsconfig.dts.json",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"
   },
   "devDependencies": {

--- a/packages/css-vars/tsconfig.dts.json
+++ b/packages/css-vars/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/css-vars/tsconfig.json
+++ b/packages/css-vars/tsconfig.json
@@ -1,10 +1,3 @@
 {
-  "extends": "@webstudio-is/tsconfig/base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "module": "ES2020",
-    "target": "ES2020",
-    "outDir": "./lib",
-    "rootDir": "./src"
-  }
+  "extends": "@webstudio-is/tsconfig/base.json"
 }

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -11,6 +11,7 @@
     "checks": "pnpm typecheck && pnpm lint",
     "dev": "build-package --watch",
     "build": "build-package",
+    "dts": "tsc --project tsconfig.dts.json",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"
   },
   "dependencies": {

--- a/packages/dashboard/tsconfig.dts.json
+++ b/packages/dashboard/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/dashboard/tsconfig.json
+++ b/packages/dashboard/tsconfig.json
@@ -1,10 +1,3 @@
 {
-  "extends": "@webstudio-is/tsconfig/base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "module": "ES2020",
-    "target": "ES2020",
-    "outDir": "./lib",
-    "rootDir": "./src"
-  }
+  "extends": "@webstudio-is/tsconfig/base.json"
 }

--- a/packages/design-system/bin/transform-figma-tokens.ts
+++ b/packages/design-system/bin/transform-figma-tokens.ts
@@ -173,7 +173,7 @@ const printFontWeight = (path: string[], unparsedValue: unknown) => {
 
 const printFontFamily = (path: string[], unparsedValue: unknown) => {
   const value = parse(path, unparsedValue, FontFamilySchema);
-  return fontFamilyMapping[value] || value;
+  return fontFamilyMapping[value as keyof typeof fontFamilyMapping] || value;
 };
 
 const printFontSize = (path: string[], unparsedValue: unknown) => {
@@ -300,7 +300,9 @@ const main = () => {
     // no need to check for __proto__ (prototype polution)
     // because we know pathToName returns a string without "_"
     record[pathToName(path, type)] =
-      type in printerByType ? printerByType[type](path, value) : value;
+      type in printerByType
+        ? printerByType[type as keyof typeof printerByType](path, value)
+        : value;
   });
 
   writeFileSync(

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -9,7 +9,7 @@
     "dev": "build-package --watch",
     "build": "build-package",
     "build-figma-tokens": "tsx ./bin/transform-figma-tokens.ts",
-    "dts": "tsc --declarationDir lib/types",
+    "dts": "tsc --project tsconfig.dts.json",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",

--- a/packages/design-system/tsconfig.dts.json
+++ b/packages/design-system/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/design-system/tsconfig.json
+++ b/packages/design-system/tsconfig.json
@@ -1,11 +1,3 @@
 {
-  "extends": "@webstudio-is/tsconfig/base.json",
-  "include": ["src", "bin/transform.ts"],
-  "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2020"],
-    "module": "ES2020",
-    "target": "ES2020",
-    "rootDir": "./src",
-    "outDir": "./lib"
-  }
+  "extends": "@webstudio-is/tsconfig/base.json"
 }

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -11,7 +11,7 @@
     "checks": "pnpm typecheck && pnpm lint",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc --declarationDir lib/types",
+    "dts": "tsc --project tsconfig.dts.json",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"
   },
   "dependencies": {

--- a/packages/domain/tsconfig.dts.json
+++ b/packages/domain/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/domain/tsconfig.json
+++ b/packages/domain/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "@webstudio-is/tsconfig/base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "module": "ES2020",
-    "target": "ES2020"
-  }
+  "extends": "@webstudio-is/tsconfig/base.json"
 }

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -10,7 +10,7 @@
     "checks": "pnpm typecheck && pnpm lint",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc --declarationDir lib/types",
+    "dts": "tsc --project tsconfig.dts.json",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"
   },
   "dependencies": {},

--- a/packages/feature-flags/tsconfig.dts.json
+++ b/packages/feature-flags/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/feature-flags/tsconfig.json
+++ b/packages/feature-flags/tsconfig.json
@@ -1,10 +1,3 @@
 {
-  "extends": "@webstudio-is/tsconfig/base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "module": "ES2020",
-    "target": "ES2020",
-    "outDir": "./lib",
-    "rootDir": "./src"
-  }
+  "extends": "@webstudio-is/tsconfig/base.json"
 }

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -11,7 +11,7 @@
     "checks": "pnpm typecheck && pnpm lint && pnpm test",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc --declarationDir lib/types",
+    "dts": "tsc --project tsconfig.dts.json",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"
   },
   "dependencies": {

--- a/packages/fonts/tsconfig.dts.json
+++ b/packages/fonts/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/fonts/tsconfig.json
+++ b/packages/fonts/tsconfig.json
@@ -1,10 +1,3 @@
 {
-  "extends": "@webstudio-is/tsconfig/base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "module": "ES2020",
-    "target": "ES2020",
-    "rootDir": "./src",
-    "outDir": "./lib"
-  }
+  "extends": "@webstudio-is/tsconfig/base.json"
 }

--- a/packages/form-handlers/package.json
+++ b/packages/form-handlers/package.json
@@ -11,7 +11,7 @@
     "checks": "pnpm typecheck && pnpm lint",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc --declarationDir lib/types",
+    "dts": "tsc --project tsconfig.dts.json",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"
   },
   "dependencies": {

--- a/packages/form-handlers/tsconfig.dts.json
+++ b/packages/form-handlers/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/form-handlers/tsconfig.json
+++ b/packages/form-handlers/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "@webstudio-is/tsconfig/base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "module": "ES2020",
-    "target": "ES2020"
-  }
+  "extends": "@webstudio-is/tsconfig/base.json"
 }

--- a/packages/generate-arg-types/package.json
+++ b/packages/generate-arg-types/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc --declarationDir lib/types",
+    "dts": "tsc --project tsconfig.dts.json",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "checks": "pnpm typecheck && pnpm lint",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"

--- a/packages/generate-arg-types/tsconfig.dts.json
+++ b/packages/generate-arg-types/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/generate-arg-types/tsconfig.json
+++ b/packages/generate-arg-types/tsconfig.json
@@ -1,10 +1,3 @@
 {
-  "extends": "@webstudio-is/tsconfig/base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "module": "ES2020",
-    "target": "ES2020",
-    "rootDir": "./src",
-    "outDir": "./lib"
-  }
+  "extends": "@webstudio-is/tsconfig/base.json"
 }

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc --declarationDir lib/types",
+    "dts": "tsc --project tsconfig.dts.json",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0",

--- a/packages/http-client/tsconfig.dts.json
+++ b/packages/http-client/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src", "../../@types/**/*.d.ts"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/http-client/tsconfig.json
+++ b/packages/http-client/tsconfig.json
@@ -1,11 +1,4 @@
 {
   "extends": "@webstudio-is/tsconfig/base.json",
-  "include": ["src", "../../@types/**/*.d.ts"],
-  "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2020"],
-    "module": "ES2020",
-    "target": "ES2020",
-    "outDir": "./lib",
-    "rootDir": "./src"
-  }
+  "include": ["./", "../../@types/**/*.d.ts"]
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc --declarationDir lib/types",
+    "dts": "tsc --project tsconfig.dts.json",
     "generate": "rm -fr src/__generated__ && NODE_OPTIONS='--loader=tsx' svgo-jsx svgo-jsx.config.ts && tsx svg-string.ts",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0",

--- a/packages/icons/svgo-jsx.config.ts
+++ b/packages/icons/svgo-jsx.config.ts
@@ -2,7 +2,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import type { Config } from "@svgo/jsx";
 
-const template = ({
+const template: Config["template"] = ({
   sourceFile,
   componentName,
   jsx,

--- a/packages/icons/tsconfig.dts.json
+++ b/packages/icons/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -1,11 +1,3 @@
 {
-  "extends": "@webstudio-is/tsconfig/base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2020"],
-    "module": "es2020",
-    "target": "ES2020",
-    "outDir": "./lib",
-    "rootDir": "./src"
-  }
+  "extends": "@webstudio-is/tsconfig/base.json"
 }

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -11,7 +11,7 @@
     "checks": "pnpm typecheck && pnpm lint && pnpm test",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc --declarationDir lib/types",
+    "dts": "tsc --project tsconfig.dts.json",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0",
     "storybook:run": "start-storybook -p 6006",
     "storybook:build": "build-storybook"

--- a/packages/image/tsconfig.dts.json
+++ b/packages/image/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/image/tsconfig.json
+++ b/packages/image/tsconfig.json
@@ -1,10 +1,3 @@
 {
-  "extends": "@webstudio-is/tsconfig/base.json",
-  "include": ["src", "./src/**/__generated__/*.json"],
-  "compilerOptions": {
-    "module": "ES2020",
-    "target": "ES2020",
-    "rootDir": "./src",
-    "outDir": "./lib"
-  }
+  "extends": "@webstudio-is/tsconfig/base.json"
 }

--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -32,7 +32,7 @@
     "checks": "pnpm typecheck && pnpm lint && pnpm test",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc --declarationDir lib/types"
+    "dts": "tsc --project tsconfig.dts.json"
   },
   "dependencies": {
     "@webstudio-is/css-data": "workspace:^",

--- a/packages/project-build/tsconfig.dts.json
+++ b/packages/project-build/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/project-build/tsconfig.json
+++ b/packages/project-build/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "@webstudio-is/tsconfig/base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "module": "ES2020",
-    "target": "ES2020"
-  }
+  "extends": "@webstudio-is/tsconfig/base.json"
 }

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -10,7 +10,7 @@
     "checks": "pnpm typecheck && pnpm lint",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc --declarationDir lib/types",
+    "dts": "tsc --project tsconfig.dts.json",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"
   },
   "dependencies": {

--- a/packages/project/tsconfig.dts.json
+++ b/packages/project/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/project/tsconfig.json
+++ b/packages/project/tsconfig.json
@@ -1,10 +1,3 @@
 {
-  "extends": "@webstudio-is/tsconfig/base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "module": "ES2020",
-    "target": "ES2020",
-    "outDir": "./lib",
-    "rootDir": "./src"
-  }
+  "extends": "@webstudio-is/tsconfig/base.json"
 }

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -9,7 +9,7 @@
     "dev": "build-package --watch",
     "build": "build-package",
     "build:args": "generate-arg-types './src/components/*.tsx ./src/app/custom-components/*.tsx !./src/**/*.stories.tsx !./src/**/*.ws.tsx' && prettier --write \"**/*.props.ts\"",
-    "dts": "tsc --declarationDir lib/types",
+    "dts": "tsc --project tsconfig.dts.json",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0",

--- a/packages/react-sdk/tsconfig.dts.json
+++ b/packages/react-sdk/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src", "../../@types/**/*.d.ts"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/react-sdk/tsconfig.json
+++ b/packages/react-sdk/tsconfig.json
@@ -1,15 +1,4 @@
 {
   "extends": "@webstudio-is/tsconfig/base.json",
-  "include": [
-    "./src",
-    "./src/**/__generated__/*.json",
-    "../../@types/**/*.d.ts"
-  ],
-  "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2020"],
-    "module": "ES2020",
-    "target": "ES2020",
-    "outDir": "./lib",
-    "rootDir": "./src"
-  }
+  "include": ["./", "../../@types/**/*.d.ts"]
 }

--- a/packages/sdk-components-react-remix/package.json
+++ b/packages/sdk-components-react-remix/package.json
@@ -36,7 +36,7 @@
     "dev": "build-package --watch",
     "build": "build-package",
     "build:args": "generate-arg-types './src/*.tsx !./src/**/*.stories.tsx !./src/**/*.ws.tsx' && prettier --write \"**/*.props.ts\"",
-    "dts": "tsc --declarationDir lib/types",
+    "dts": "tsc --project tsconfig.dts.json",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0",
     "checks": "pnpm typecheck && pnpm lint"

--- a/packages/sdk-components-react-remix/tsconfig.dts.json
+++ b/packages/sdk-components-react-remix/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src", "../../@types/**/*.d.ts"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/sdk-components-react-remix/tsconfig.json
+++ b/packages/sdk-components-react-remix/tsconfig.json
@@ -1,10 +1,4 @@
 {
   "extends": "@webstudio-is/tsconfig/base.json",
-  "include": ["./src", "../../@types/**/*.d.ts"],
-  "compilerOptions": {
-    "module": "ES2020",
-    "target": "ES2020",
-    "outDir": "./lib",
-    "rootDir": "./src"
-  }
+  "include": ["./", "../../@types/**/*.d.ts"]
 }

--- a/packages/sdk-components-react/package.json
+++ b/packages/sdk-components-react/package.json
@@ -36,7 +36,7 @@
     "dev": "build-package --watch",
     "build": "build-package",
     "build:args": "generate-arg-types './src/*.tsx !./src/*.stories.tsx !./src/*.ws.tsx' && prettier --write \"**/*.props.ts\"",
-    "dts": "tsc --declarationDir lib/types",
+    "dts": "tsc --project tsconfig.dts.json",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0",
     "checks": "pnpm typecheck && pnpm lint",

--- a/packages/sdk-components-react/tsconfig.dts.json
+++ b/packages/sdk-components-react/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src", "../../@types/**/*.d.ts"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/sdk-components-react/tsconfig.json
+++ b/packages/sdk-components-react/tsconfig.json
@@ -1,10 +1,4 @@
 {
   "extends": "@webstudio-is/tsconfig/base.json",
-  "include": ["./src", "../../@types/**/*.d.ts"],
-  "compilerOptions": {
-    "module": "ES2020",
-    "target": "ES2020",
-    "outDir": "./lib",
-    "rootDir": "./src"
-  }
+  "include": ["./", "../../@types/**/*.d.ts"]
 }

--- a/packages/trpc-interface/package.json
+++ b/packages/trpc-interface/package.json
@@ -11,7 +11,7 @@
     "checks": "pnpm typecheck && pnpm lint",
     "dev": "build-package --watch",
     "build": "build-package",
-    "dts": "tsc --declarationDir lib/types",
+    "dts": "tsc --project tsconfig.dts.json",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"
   },
   "dependencies": {

--- a/packages/trpc-interface/tsconfig.dts.json
+++ b/packages/trpc-interface/tsconfig.dts.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "declarationDir": "lib/types"
+  }
+}

--- a/packages/trpc-interface/tsconfig.json
+++ b/packages/trpc-interface/tsconfig.json
@@ -1,10 +1,3 @@
 {
-  "extends": "@webstudio-is/tsconfig/base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "module": "ES2020",
-    "target": "ES2020",
-    "outDir": "./lib",
-    "rootDir": "./src"
-  }
+  "extends": "@webstudio-is/tsconfig/base.json"
 }

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -2,6 +2,8 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Default",
   "compilerOptions": {
+    "module": "ES2022",
+    "target": "ES2020",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "inlineSources": false,


### PR DESCRIPTION
We generate dts type for each package on publish.
It requires us to include only "src" to output same structure as in src folder. Though we have configs and cli scripts outside of it which should be typechecked, they cannot be ignored.

Ideally would be to have one-line commands in package.json. Though typescript always has problems with build step. In this case the CLI have everything to configure this except "include" and "exclude" flags.

So here to workaround that I added tsconfig.dts.json to distinct dts generation and typechecking.

Blocker for https://github.com/webstudio-is/webstudio-builder/pull/1634

## Code Review

- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
- [ ] hi @Andarist, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
