### PR TITLE
Fix hydration error

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/navigator/css-preview.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/navigator/css-preview.tsx
@@ -73,11 +73,11 @@ export const CssPreview = () => {
     <CollapsibleSection label="CSS Preview" fullWidth>
       <ScrollArea css={{ px: theme.spacing[9] }}>
         <pre tabIndex={0} className={preStyle()}>
-          <code
+          <div
             className="language-css"
             style={{ whiteSpace: "break-spaces" }}
             dangerouslySetInnerHTML={{ __html: code }}
-          ></code>
+          ></div>
         </pre>
       </ScrollArea>
     </CollapsibleSection>


### PR DESCRIPTION
## Description

Fixes this on each start

```
react_devtools_backend_compact.js:2367 Warning: Prop `className` did not match. Server: "c-dKXKjp c-gcikI language-css" Client: "c-dKXKjp c-gcikI"
    at pre
    at div
    at div
```

Looks like a bug with pre and code element combination in react hydration



## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
