### PR TITLE
Change caret color to be visible

### DIFF
--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -1,4 +1,4 @@
-import { type MouseEvent, type FormEvent, useEffect } from "react";
+import { type MouseEvent, type FormEvent, useEffect, useState } from "react";
 import { Suspense, lazy, useCallback, useMemo, useRef } from "react";
 import { useStore } from "@nanostores/react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
@@ -32,6 +32,9 @@ import {
 } from "~/shared/tree-utils";
 import { SelectedInstanceConnector } from "./selected-instance-connector";
 import { handleLinkClick } from "./link";
+import { colord } from "colord";
+import { createCssEngine, type CssEngine } from "@webstudio-is/css-engine";
+import { nanoid } from "nanoid";
 
 const TextEditor = lazy(() => import("../text-editor"));
 
@@ -46,9 +49,38 @@ const ContentEditable = ({
   [componentAttribute]: Instance["component"];
 }) => {
   const [editor] = useLexicalComposerContext();
+  const [caretClassName] = useState(() => `a${nanoid()}`);
+  const engineRef = useRef<CssEngine | undefined>();
 
   const ref = useCallback(
     (rootElement: null | HTMLElement) => {
+      if (rootElement === null) {
+        if (engineRef.current !== undefined) {
+          engineRef.current.unmount();
+          engineRef.current = undefined;
+        }
+      }
+
+      if (rootElement !== null) {
+        const elementColor = window.getComputedStyle(rootElement).color;
+
+        const color = colord(elementColor).toRgb();
+        if (color.a < 0.1) {
+          // Apply caret color with animated color
+          const engine = createCssEngine({ name: "text-editor-caret" });
+          engineRef.current = engine;
+
+          engine.addPlaintextRule(`
+            .${caretClassName} { caret-color: #999; }
+          `);
+
+          if (rootElement.classList.contains(caretClassName) === false) {
+            rootElement.classList.add(caretClassName);
+          }
+          engine.render();
+        }
+      }
+
       // button with contentEditable does not let to press space
       // so add span inside and use it as editor element in lexical
       if (rootElement?.tagName === "BUTTON") {
@@ -63,7 +95,7 @@ const ContentEditable = ({
       editor.setRootElement(rootElement);
       elementRef.current = rootElement ?? null;
     },
-    [editor, elementRef]
+    [caretClassName, editor, elementRef]
   );
 
   return <Component ref={ref} {...props} />;

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -70,6 +70,7 @@ const ContentEditable = ({
           const engine = createCssEngine({ name: "text-editor-caret" });
           engineRef.current = engine;
 
+          // Animation on cursor needed to make it visible on any background
           engine.addPlaintextRule(`
 
             @keyframes ${caretClassName}-keyframes {

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -1,4 +1,4 @@
-import { type MouseEvent, type FormEvent, useEffect, useState } from "react";
+import { type MouseEvent, type FormEvent, useEffect } from "react";
 import { Suspense, lazy, useCallback, useMemo, useRef } from "react";
 import { useStore } from "@nanostores/react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
@@ -32,9 +32,6 @@ import {
 } from "~/shared/tree-utils";
 import { SelectedInstanceConnector } from "./selected-instance-connector";
 import { handleLinkClick } from "./link";
-import { colord } from "colord";
-import { createCssEngine, type CssEngine } from "@webstudio-is/css-engine";
-import { nanoid } from "nanoid";
 
 const TextEditor = lazy(() => import("../text-editor"));
 
@@ -49,50 +46,9 @@ const ContentEditable = ({
   [componentAttribute]: Instance["component"];
 }) => {
   const [editor] = useLexicalComposerContext();
-  const [caretClassName] = useState(() => `a${nanoid()}`);
-  const engineRef = useRef<CssEngine | undefined>();
 
   const ref = useCallback(
     (rootElement: null | HTMLElement) => {
-      if (rootElement === null) {
-        if (engineRef.current !== undefined) {
-          engineRef.current.unmount();
-          engineRef.current = undefined;
-        }
-      }
-
-      if (rootElement !== null) {
-        const elementColor = window.getComputedStyle(rootElement).color;
-
-        const color = colord(elementColor).toRgb();
-        if (color.a < 0.1) {
-          // Apply caret color with animated color
-          const engine = createCssEngine({ name: "text-editor-caret" });
-          engineRef.current = engine;
-
-          // Animation on cursor needed to make it visible on any background
-          engine.addPlaintextRule(`
-
-            @keyframes ${caretClassName}-keyframes {
-              from {caret-color: #666;}
-              to {caret-color: #999;}
-            }
-
-            .${caretClassName} {
-              animation-name: ${caretClassName}-keyframes;
-              animation-duration: 0.5s;
-              animation-iteration-count: infinite;
-              animation-direction: alternate;
-            }
-          `);
-
-          if (rootElement.classList.contains(caretClassName) === false) {
-            rootElement.classList.add(caretClassName);
-          }
-          engine.render();
-        }
-      }
-
       // button with contentEditable does not let to press space
       // so add span inside and use it as editor element in lexical
       if (rootElement?.tagName === "BUTTON") {
@@ -107,7 +63,7 @@ const ContentEditable = ({
       editor.setRootElement(rootElement);
       elementRef.current = rootElement ?? null;
     },
-    [caretClassName, editor, elementRef]
+    [editor, elementRef]
   );
 
   return <Component ref={ref} {...props} />;

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -71,7 +71,18 @@ const ContentEditable = ({
           engineRef.current = engine;
 
           engine.addPlaintextRule(`
-            .${caretClassName} { caret-color: #999; }
+
+            @keyframes ${caretClassName}-keyframes {
+              from {caret-color: #666;}
+              to {caret-color: #999;}
+            }
+
+            .${caretClassName} {
+              animation-name: ${caretClassName}-keyframes;
+              animation-duration: 0.5s;
+              animation-iteration-count: infinite;
+              animation-direction: alternate;
+            }
           `);
 
           if (rootElement.classList.contains(caretClassName) === false) {


### PR DESCRIPTION
## Description

Show cursor on edit even if text is transparent
example https://webstudio-builder-git-caret-color-webstudio-is.vercel.app/builder/f74e30c0-acfd-4bab-bf35-beaa19f41d0c
Edit any text


## Steps for reproduction

1. click button
3. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
