### PR TITLE
Fix insert into container without children

### DIFF
--- a/apps/builder/app/shared/tree-utils.test.ts
+++ b/apps/builder/app/shared/tree-utils.test.ts
@@ -361,6 +361,28 @@ describe("insert instances into container with text or rich text children", () =
       createInstancePair("inserted", "Box", []),
     ]);
   });
+
+  test("insert container without children", () => {
+    const getInstances = () =>
+      new Map([createInstancePair("root", "Body", [])]);
+
+    const instances1 = getInstances();
+    insertInstancesMutable(
+      instances1,
+      new Map(),
+      baseMetasMap,
+      [createInstance("inserted", "Box", [])],
+      [{ type: "id", value: "inserted" }],
+      {
+        parentSelector: ["root"],
+        position: 1,
+      }
+    );
+    expect(Array.from(instances1.entries())).toEqual([
+      createInstancePair("root", "Body", [{ type: "id", value: "inserted" }]),
+      createInstancePair("inserted", "Box", []),
+    ]);
+  });
 });
 
 test("reparent instance into target", () => {

--- a/apps/builder/app/shared/tree-utils.ts
+++ b/apps/builder/app/shared/tree-utils.ts
@@ -133,7 +133,7 @@ const wrapEditableChildrenAroundDropTargetMutable = (
 ) => {
   const [parentId] = dropTarget.parentSelector;
   const parentInstance = instances.get(parentId);
-  if (parentInstance === undefined) {
+  if (parentInstance === undefined || parentInstance.children.length === 0) {
     return;
   }
   // wrap only containers with text and rich text childre


### PR DESCRIPTION
Ref https://discord.com/channels/955905230107738152/955907841070346300/1118910260871168021

Container without children got additional empty text wrapper. Here fixed this by checking children existence.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
