### PR TITLE
Add combined control descriptions

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/backgrounds.tsx
@@ -183,6 +183,7 @@ const BackgroundsCollapsibleSection = ({
           <PropertyName
             style={currentStyle}
             title="Backgrounds"
+            description="Sets background color, image or gradient and composes them with layers"
             properties={layeredBackgroundProps}
             label={
               <SectionTitleLabel color={layersStyleSource}>

--- a/apps/builder/app/builder/features/style-panel/sections/borders/border-property.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/border-property.tsx
@@ -30,6 +30,7 @@ export const BorderProperty = ({
   individualModeIcon,
   borderPropertyOptions,
   label,
+  description,
 }: Pick<
   RenderCategoryProps,
   "currentStyle" | "setProperty" | "deleteProperty" | "createBatchUpdate"
@@ -39,6 +40,7 @@ export const BorderProperty = ({
     [property in StyleProperty]: { icon?: ReactNode };
   }>;
   label: string;
+  description?: string;
 }) => {
   const borderProperties = Object.keys(borderPropertyOptions) as Array<
     keyof typeof borderPropertyOptions
@@ -117,6 +119,7 @@ export const BorderProperty = ({
           style={currentStyle}
           properties={borderProperties}
           label={label}
+          description={description}
           onReset={() => deleteBorderProperties(firstPropertyName)}
         />
 

--- a/apps/builder/app/builder/features/style-panel/sections/borders/border-radius.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/border-radius.tsx
@@ -38,6 +38,7 @@ export const BorderRadius = (
       deleteProperty={props.deleteProperty}
       createBatchUpdate={props.createBatchUpdate}
       label="Radius"
+      description="Sets the radius of border"
       borderPropertyOptions={borderPropertyOptions}
       individualModeIcon={<BorderRadiusIndividualIcon />}
     />

--- a/apps/builder/app/builder/features/style-panel/sections/borders/border-style.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/border-style.tsx
@@ -18,12 +18,12 @@ import { PropertyName } from "../../shared/property-name";
 import type { RenderCategoryProps } from "../../style-sections";
 import { deleteAllProperties, setAllProperties } from "./border-utils";
 
-const borderStyleProperties = [
+const borderStyleProperties: StyleProperty[] = [
   "borderTopStyle",
   "borderRightStyle",
   "borderLeftStyle",
   "borderBottomStyle",
-] as const satisfies readonly StyleProperty[];
+];
 
 const borderStyleValues = [
   { value: "none", Icon: SmallXIcon },
@@ -73,6 +73,7 @@ export const BorderStyle = (
         style={props.currentStyle}
         properties={borderStyleProperties}
         label={"Style"}
+        description="Sets the style of the border"
         onReset={() => deleteBorderProperties(firstPropertyName)}
       />
 

--- a/apps/builder/app/builder/features/style-panel/sections/borders/border-width.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/border-width.tsx
@@ -38,6 +38,7 @@ export const BorderWidth = (
       deleteProperty={props.deleteProperty}
       createBatchUpdate={props.createBatchUpdate}
       label="Width"
+      description="Sets the width of the border"
       borderPropertyOptions={borderPropertyOptions}
       individualModeIcon={<BorderWidthIndividualIcon />}
     />

--- a/apps/builder/app/builder/features/style-panel/sections/borders/borders.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/borders/borders.tsx
@@ -12,12 +12,12 @@ import { BorderWidth } from "./border-width";
 
 const { items: borderColorItems } = styleConfigByName("borderTopColor");
 
-const borderColorProperties = [
+const borderColorProperties: StyleProperty[] = [
   "borderTopColor",
   "borderRightColor",
   "borderBottomColor",
   "borderLeftColor",
-] as const;
+];
 
 const properties: StyleProperty[] = [
   ...borderColorProperties,
@@ -84,8 +84,9 @@ export const BordersSection = (props: RenderCategoryProps) => {
         >
           <PropertyName
             style={currentStyle}
-            properties={[borderColorProperty]}
+            properties={borderColorProperties}
             label={"Color"}
+            description="Sets the color of the border"
             onReset={() => deleteAllBorderColorProperties(borderColorProperty)}
           />
 

--- a/apps/builder/app/builder/features/style-panel/sections/flex-child/flex-child.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/flex-child/flex-child.tsx
@@ -109,6 +109,7 @@ const FlexChildSectionSizing = (props: RenderCategoryProps) => {
         style={currentStyle}
         properties={["flexGrow", "flexShrink"]}
         label="Sizing"
+        description="Specifies the ability of a flex item to grow or shrink"
         onReset={() => {
           setSizing.deleteProperty("flexGrow");
           setSizing.deleteProperty("flexShrink");

--- a/apps/builder/app/builder/features/style-panel/sections/typography/typography.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/typography/typography.tsx
@@ -85,7 +85,6 @@ export const TypographySectionFont = (props: RenderCategoryProps) => {
         <PropertyName
           style={currentStyle}
           label="Font"
-          title="Font Family"
           properties={["fontFamily"]}
           onReset={() => deleteProperty("fontFamily")}
         />
@@ -100,7 +99,6 @@ export const TypographySectionFont = (props: RenderCategoryProps) => {
         <PropertyName
           style={currentStyle}
           label="Weight"
-          title="Font Weight"
           properties={["fontWeight"]}
           onReset={() => deleteProperty("fontWeight")}
         />
@@ -144,7 +142,6 @@ export const TypographySectionSizing = (props: RenderCategoryProps) => {
           style={currentStyle}
           properties={["fontSize"]}
           label="Size"
-          title="Font Size"
           onReset={() => deleteProperty("fontSize")}
         />
         <TextControl
@@ -159,7 +156,6 @@ export const TypographySectionSizing = (props: RenderCategoryProps) => {
           style={currentStyle}
           properties={["lineHeight"]}
           label="Height"
-          title="Line Height"
           onReset={() => deleteProperty("lineHeight")}
         />
         <TextControl
@@ -174,7 +170,6 @@ export const TypographySectionSizing = (props: RenderCategoryProps) => {
           style={currentStyle}
           properties={["letterSpacing"]}
           label="Spacing"
-          title="Letter Spacing"
           onReset={() => deleteProperty("letterSpacing")}
         />
         <TextControl

--- a/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
@@ -1,12 +1,9 @@
 import { useState, type ReactElement } from "react";
 import { useStore } from "@nanostores/react";
 import {
-  declarationDescriptions,
-  propertyDescriptions,
-  type Style,
   type StyleProperty,
+  propertyDescriptions,
 } from "@webstudio-is/css-data";
-import { createCssEngine, toValue } from "@webstudio-is/css-engine";
 import {
   theme,
   Button,
@@ -80,26 +77,6 @@ const getSourceName = (
   }
 };
 
-// @todo consider reusing CssPreview component
-const getCssText = (
-  properties: readonly StyleProperty[],
-  instanceStyle: StyleInfo
-) => {
-  const cssEngine = createCssEngine();
-  const style: Style = {};
-  let property: StyleProperty;
-  for (property in instanceStyle) {
-    const value = instanceStyle[property];
-    if (value && properties.includes(property)) {
-      style[property] = value.value;
-    }
-  }
-  const rule = cssEngine.addStyleRule("instance", {
-    style,
-  });
-  return rule.styleMap.toString();
-};
-
 const getBreakpointName = (
   styleValueInfo: StyleValueInfo,
   breakpoints: Breakpoints,
@@ -120,40 +97,25 @@ const getBreakpointName = (
   return breakpoint?.minWidth ?? breakpoint?.maxWidth ?? "Base";
 };
 
-const getDescription = (
-  styleValueInfo: StyleValueInfo,
-  properties: readonly StyleProperty[]
-) => {
-  // @todo we don't know how to show a description in this case
+const getDescription = (properties: StyleProperty[]) => {
   if (properties.length > 1) {
     return;
   }
-  // @todo reuse it with CssPreview
-  const styleValue =
-    styleValueInfo.local ??
-    styleValueInfo.nextSource?.value ??
-    styleValueInfo.previousSource?.value ??
-    styleValueInfo.cascaded?.value ??
-    styleValueInfo.preset ??
-    styleValueInfo.inherited?.value;
-
   const property = properties[0];
-  const key = `${property}:${toValue(styleValue)}`;
-  if (key in declarationDescriptions) {
-    return declarationDescriptions[key as keyof typeof declarationDescriptions];
-  }
   return propertyDescriptions[property as keyof typeof propertyDescriptions];
 };
 
 const TooltipContent = ({
   title,
+  description,
   properties,
   style,
   onReset,
   onClose,
 }: {
   title: string;
-  properties: readonly StyleProperty[];
+  description?: string;
+  properties: StyleProperty[];
   style: StyleInfo;
   onReset: () => void;
   onClose: () => void;
@@ -172,7 +134,7 @@ const TooltipContent = ({
     return null;
   }
 
-  const description = getDescription(styleValueInfo, properties);
+  const descriptionWithFallback = description ?? getDescription(properties);
 
   const styleSource = getStyleSource(styleValueInfo);
   const sourceName = getSourceName(
@@ -180,7 +142,6 @@ const TooltipContent = ({
     styleValueInfo,
     selectedStyleSource
   );
-  const cssText = getCssText(properties, style);
   const breakpointName = getBreakpointName(
     styleValueInfo,
     breakpoints,
@@ -194,23 +155,21 @@ const TooltipContent = ({
   return (
     <Flex direction="column" gap="2" css={{ maxWidth: theme.spacing[28] }}>
       <Text variant="titles">{title}</Text>
-      {cssText && (
-        <ScrollArea>
-          <Text
-            variant="monoBold"
-            color="moreSubtle"
-            css={{
-              whiteSpace: "break-spaces",
-              maxHeight: "3em",
-              userSelect: "text",
-              cursor: "text",
-            }}
-          >
-            {cssText}
-          </Text>
-        </ScrollArea>
-      )}
-      {description && <Text>{description}</Text>}
+      <ScrollArea>
+        <Text
+          variant="monoBold"
+          color="moreSubtle"
+          css={{
+            whiteSpace: "break-spaces",
+            maxHeight: "3em",
+            userSelect: "text",
+            cursor: "text",
+          }}
+        >
+          {properties.join("\n")}
+        </Text>
+      </ScrollArea>
+      {descriptionWithFallback && <Text>{descriptionWithFallback}</Text>}
       {sourceName && (
         <Flex
           direction="column"
@@ -256,15 +215,17 @@ const TooltipContent = ({
 
 type PropertyNameProps = {
   style: StyleInfo;
-  properties: readonly StyleProperty[];
+  properties: StyleProperty[];
   label: string | ReactElement;
   title?: string;
+  description?: string;
   onReset: () => void;
 };
 
 export const PropertyName = ({
   style,
   title,
+  description,
   properties,
   label,
   onReset,
@@ -284,6 +245,7 @@ export const PropertyName = ({
               title ??
               (typeof label === "string" ? label : humanizeString(property))
             }
+            description={description}
             properties={properties}
             style={style}
             onReset={onReset}

--- a/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
@@ -14,6 +14,13 @@ import {
   ScrollArea,
 } from "@webstudio-is/design-system";
 import { ResetIcon } from "@webstudio-is/icons";
+import type {
+  Breakpoint,
+  Breakpoints,
+  StyleSource,
+  StyleSources,
+} from "@webstudio-is/project-build";
+import { toProperty } from "@webstudio-is/css-engine";
 import {
   breakpointsStore,
   instancesStore,
@@ -29,12 +36,6 @@ import {
 } from "./style-info";
 import { humanizeString } from "~/shared/string-utils";
 import { StyleSourceBadge } from "../style-source";
-import type {
-  Breakpoint,
-  Breakpoints,
-  StyleSource,
-  StyleSources,
-} from "@webstudio-is/project-build";
 
 // We don't return source name only in case of preset or default value.
 const getSourceName = (
@@ -166,7 +167,7 @@ const TooltipContent = ({
             cursor: "text",
           }}
         >
-          {properties.join("\n")}
+          {properties.map(toProperty).join("\n")}
         </Text>
       </ScrollArea>
       {descriptionWithFallback && <Text>{descriptionWithFallback}</Text>}

--- a/packages/css-data/src/__generated__/property-value-descriptions.ts
+++ b/packages/css-data/src/__generated__/property-value-descriptions.ts
@@ -177,7 +177,7 @@ export const properties = {
   gridTemplateColumns: "Sets the size of the first letter in a block of text",
   gridTemplateRows: "Sets the starting position of a grid item's column",
   hangingPunctuation: "Sets the ending position of a grid item's column",
-  height: "Sets the starting position of a grid item's row",
+  height: "Sets the height of an element",
   hyphenateCharacter: "Sets the ending position of a grid item's row",
   hyphens: "Defines named grid areas within the grid container",
   imageOrientation:

--- a/packages/css-engine/src/core/index.ts
+++ b/packages/css-engine/src/core/index.ts
@@ -8,6 +8,7 @@ export type {
 } from "./rules";
 export * from "./create-css-engine";
 export * from "./to-value";
+export * from "./to-property";
 export * from "./match-media";
 export * from "./equal-media";
 export * from "./compare-media";


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/pull/1785

Here fixed generated height description and added custom descriptions for following controls

- background
- borderWidth
- borderStyle
- borderColor
- borderRadius
- sizing

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
- [ ] hi @taylornowotny, I need you to do
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
