### PR TITLE
Fix focus after style source duplicating

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
@@ -125,19 +125,24 @@ const useEditableText = ({
   const getValue = () => elementRef.current?.textContent ?? "";
 
   useEffect(() => {
-    if (elementRef.current === null) {
+    const element = elementRef.current;
+    if (element === null) {
       return;
     }
 
     if (isEditing) {
-      elementRef.current.setAttribute("contenteditable", "plaintext-only");
-      elementRef.current.focus();
-      getSelection()?.selectAllChildren(elementRef.current);
-      lastValueRef.current = getValue();
+      element.setAttribute("contenteditable", "plaintext-only");
+      // the next frame is necessary when newly created element
+      // need to get focus, for example after duplicate operation
+      requestAnimationFrame(() => {
+        element.focus();
+        getSelection()?.selectAllChildren(element);
+        lastValueRef.current = getValue();
+      });
       return;
     }
 
-    elementRef.current?.removeAttribute("contenteditable");
+    element.removeAttribute("contenteditable");
   }, [isEditing]);
 
   const handleFinishEditing = (


### PR DESCRIPTION
Ref https://discord.com/channels/955905230107738152/955907841070346300/1118983173037105163

Newly created elements cannot obtain focus in effect. We need to focus in the next frame.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
