### PR TITLE
Set only parsed values from style panel

### DIFF
--- a/apps/builder/app/builder/features/style-panel/controls/font-family/font-family-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/font-family/font-family-control.tsx
@@ -18,7 +18,14 @@ export const FontFamilyControl = ({
   return (
     <FloatingPanel
       title="Fonts"
-      content={<FontsManager value={toValue(value)} onChange={setValue} />}
+      content={
+        <FontsManager
+          value={toValue(value)}
+          onChange={(newValue) => {
+            setValue({ type: "fontFamily", value: [newValue] });
+          }}
+        />
+      }
       onOpenChange={setIsOpen}
     >
       <DeprecatedTextField

--- a/apps/builder/app/builder/features/style-panel/controls/font-weight/font-weight-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/font-weight/font-weight-control.tsx
@@ -114,7 +114,7 @@ export const FontWeightControl = ({
           (option) => option.label === label
         );
         if (selected) {
-          setValue(selected.weight);
+          setValue({ type: "keyword", value: selected.weight });
         }
       }}
     />

--- a/apps/builder/app/builder/features/style-panel/controls/menu/menu-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/menu/menu-control.tsx
@@ -43,8 +43,10 @@ export const MenuControl = ({
       label={label}
       items={items}
       value={String(currentValue)}
-      onChange={setValue}
-      onHover={(value) => setValue(value, { isEphemeral: true })}
+      onChange={(value) => setValue({ type: "keyword", value })}
+      onHover={(value) =>
+        setValue({ type: "keyword", value }, { isEphemeral: true })
+      }
       onReset={() => {
         deleteProperty(property);
       }}

--- a/apps/builder/app/builder/features/style-panel/sections/flex-child/flex-child.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/flex-child/flex-child.tsx
@@ -60,7 +60,7 @@ const FlexChildSectionAlign = (props: RenderCategoryProps) => {
       />
       <ToggleGroupControl
         styleSource={getStyleSource(currentStyle.alignSelf)}
-        onValueChange={(value) => setAlignSelf(value)}
+        onValueChange={(value) => setAlignSelf({ type: "keyword", value })}
         value={toValue(currentStyle.alignSelf?.value)}
         items={[
           {
@@ -124,20 +124,44 @@ const FlexChildSectionSizing = (props: RenderCategoryProps) => {
         onValueChange={(value) => {
           switch (value) {
             case "none": {
-              setSizing.setProperty("flexGrow")("0");
-              setSizing.setProperty("flexShrink")("0");
+              setSizing.setProperty("flexGrow")({
+                type: "unit",
+                value: 0,
+                unit: "number",
+              });
+              setSizing.setProperty("flexShrink")({
+                type: "unit",
+                value: 0,
+                unit: "number",
+              });
               setSizing.publish();
               break;
             }
             case "grow": {
-              setSizing.setProperty("flexGrow")("1");
-              setSizing.setProperty("flexShrink")("0");
+              setSizing.setProperty("flexGrow")({
+                type: "unit",
+                value: 1,
+                unit: "number",
+              });
+              setSizing.setProperty("flexShrink")({
+                type: "unit",
+                value: 0,
+                unit: "number",
+              });
               setSizing.publish();
               break;
             }
             case "shrink": {
-              setSizing.setProperty("flexGrow")("0");
-              setSizing.setProperty("flexShrink")("1");
+              setSizing.setProperty("flexGrow")({
+                type: "unit",
+                value: 0,
+                unit: "number",
+              });
+              setSizing.setProperty("flexShrink")({
+                type: "unit",
+                value: 1,
+                unit: "number",
+              });
               setSizing.publish();
               break;
             }
@@ -261,7 +285,7 @@ const FlexChildSectionOrder = (props: RenderCategoryProps) => {
             case "0":
             case "1":
             case "-1": {
-              setOrder(value);
+              setOrder({ type: "unit", value: Number(value), unit: "number" });
               break;
             }
           }

--- a/apps/builder/app/builder/features/style-panel/sections/layout/shared/flex-grid.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/layout/shared/flex-grid.tsx
@@ -143,8 +143,8 @@ export const FlexGrid = ({
               onClick={() => {
                 const justifyContent = alignment[x];
                 const alignItems = alignment[y];
-                setAlignItems(alignItems);
-                setJustifyContent(justifyContent);
+                setAlignItems({ type: "keyword", value: alignItems });
+                setJustifyContent({ type: "keyword", value: justifyContent });
                 batchUpdate.publish();
               }}
             >

--- a/apps/builder/app/builder/features/style-panel/sections/outline/outline-style.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/outline/outline-style.tsx
@@ -60,7 +60,9 @@ export const OutlineStyle = (
         }}
         type="single"
         value={outlineStyleValue}
-        onValueChange={(value) => setProperty(property)(value)}
+        onValueChange={(value) =>
+          setProperty(property)({ type: "keyword", value })
+        }
       >
         {outlineStyleValues.map(({ value, Icon }) => (
           <ToggleGroupItem key={value} value={value}>

--- a/apps/builder/app/builder/features/style-panel/sections/typography/typography.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/typography/typography.tsx
@@ -204,7 +204,7 @@ export const TypographySectionAdvanced = (props: RenderCategoryProps) => {
       >
         <ToggleGroupControl
           styleSource={getStyleSource(currentStyle.textAlign)}
-          onValueChange={(value) => setTextAlign(value)}
+          onValueChange={(value) => setTextAlign({ type: "keyword", value })}
           value={String(getTextAlign(toValue(currentStyle.textAlign?.value)))}
           items={[
             {
@@ -231,7 +231,9 @@ export const TypographySectionAdvanced = (props: RenderCategoryProps) => {
         />
         <ToggleGroupControl
           styleSource={getStyleSource(currentStyle.textDecorationLine)}
-          onValueChange={(value) => setTextDecorationLine(value)}
+          onValueChange={(value) =>
+            setTextDecorationLine({ type: "keyword", value })
+          }
           value={toValue(currentStyle.textDecorationLine?.value)}
           items={[
             {
@@ -261,7 +263,9 @@ export const TypographySectionAdvanced = (props: RenderCategoryProps) => {
       >
         <ToggleGroupControl
           styleSource={getStyleSource(currentStyle.textTransform)}
-          onValueChange={(value) => setTextTransform(value)}
+          onValueChange={(value) =>
+            setTextTransform({ type: "keyword", value })
+          }
           value={toValue(currentStyle.textTransform?.value)}
           items={[
             {
@@ -288,7 +292,7 @@ export const TypographySectionAdvanced = (props: RenderCategoryProps) => {
         />
         <ToggleGroupControl
           styleSource={getStyleSource(currentStyle.fontStyle)}
-          onValueChange={(value) => setFontStyle(value)}
+          onValueChange={(value) => setFontStyle({ type: "keyword", value })}
           value={toValue(currentStyle.fontStyle?.value)}
           items={[
             {
@@ -344,7 +348,9 @@ export const TypographySectionAdvancedPopover = (
             />
             <ToggleGroupControl
               styleSource={getStyleSource(currentStyle.direction)}
-              onValueChange={(value) => setDirection(value)}
+              onValueChange={(value) =>
+                setDirection({ type: "keyword", value })
+              }
               value={toValue(currentStyle.direction?.value)}
               items={[
                 {
@@ -369,7 +375,7 @@ export const TypographySectionAdvancedPopover = (
             />
             <ToggleGroupControl
               styleSource={getStyleSource(currentStyle.hyphens)}
-              onValueChange={(value) => setHyphens(value)}
+              onValueChange={(value) => setHyphens({ type: "keyword", value })}
               value={toValue(currentStyle.hyphens?.value)}
               items={[
                 {
@@ -394,7 +400,9 @@ export const TypographySectionAdvancedPopover = (
             />
             <ToggleGroupControl
               styleSource={getStyleSource(currentStyle.textOverflow)}
-              onValueChange={(value) => setTextOverflow(value)}
+              onValueChange={(value) =>
+                setTextOverflow({ type: "keyword", value })
+              }
               value={toValue(currentStyle.textOverflow?.value)}
               items={[
                 {

--- a/apps/builder/app/builder/features/style-panel/shared/use-style-data.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/use-style-data.ts
@@ -1,7 +1,6 @@
 import { useCallback } from "react";
 import { useStore } from "@nanostores/react";
 import store from "immerhin";
-import warnOnce from "warn-once";
 import {
   type Breakpoint,
   type Instance,
@@ -10,15 +9,13 @@ import {
 import type { StyleProperty, StyleValue } from "@webstudio-is/css-data";
 import type { Publish } from "~/shared/pubsub";
 import {
+  selectedBreakpointStore,
   selectedOrLastStyleSourceSelectorStore,
   selectedStyleSourceStore,
   styleSourceSelectionsStore,
   styleSourcesStore,
   stylesStore,
 } from "~/shared/nano-states";
-import { selectedBreakpointStore } from "~/shared/nano-states";
-// @todo: must be removed, now it's only for compatibility with existing code
-import { parseCssValue } from "@webstudio-is/css-data";
 import { useStyleInfo } from "./style-info";
 
 export type StyleUpdate =
@@ -53,9 +50,8 @@ type UseStyleData = {
 
 export type StyleUpdateOptions = { isEphemeral: boolean };
 
-// @todo: style must have StyleValue type always, get rid of string.
 export type SetValue = (
-  style: string | StyleValue,
+  style: StyleValue,
   options?: StyleUpdateOptions
 ) => void;
 
@@ -67,9 +63,7 @@ export type DeleteProperty = (
 ) => void;
 
 export type CreateBatchUpdate = () => {
-  setProperty: (
-    property: StyleProperty
-  ) => (style: string | StyleValue) => void;
+  setProperty: (property: StyleProperty) => (style: StyleValue) => void;
   deleteProperty: (property: StyleProperty) => void;
   publish: (options?: StyleUpdateOptions) => void;
 };
@@ -151,32 +145,11 @@ export const useStyleData = ({ selectedInstance, publish }: UseStyleData) => {
     [publish, selectedBreakpoint, selectedInstance]
   );
 
-  // @deprecated should not be called
-  const toStyleValue = (property: StyleProperty, value: string) => {
-    if (property === "fontFamily") {
-      return { type: "fontFamily" as const, value: [value] };
-    }
-
-    return parseCssValue(property, value);
-  };
-
   const setProperty = useCallback<SetProperty>(
     (property) => {
-      return (inputOrStyle, options = { isEphemeral: false }) => {
-        warnOnce(
-          typeof inputOrStyle === "string",
-          "setProperty should be called with a style object, string is deprecated"
-        );
-
-        const nextValue =
-          typeof inputOrStyle === "string"
-            ? toStyleValue(property, inputOrStyle)
-            : inputOrStyle;
-
-        if (nextValue.type !== "invalid") {
-          const updates = [
-            { operation: "set" as const, property, value: nextValue },
-          ];
+      return (value, options = { isEphemeral: false }) => {
+        if (value.type !== "invalid") {
+          const updates = [{ operation: "set" as const, property, value }];
           const type = options.isEphemeral ? "preview" : "update";
 
           publishUpdates(type, updates);
@@ -199,17 +172,7 @@ export const useStyleData = ({ selectedInstance, publish }: UseStyleData) => {
     let updates: StyleUpdates["updates"] = [];
 
     const setProperty = (property: StyleProperty) => {
-      const setValue = (inputOrStyle: string | StyleValue) => {
-        warnOnce(
-          typeof inputOrStyle === "string",
-          "setProperty should be called with a style object, string is deprecated"
-        );
-
-        const value =
-          typeof inputOrStyle === "string"
-            ? toStyleValue(property, inputOrStyle)
-            : inputOrStyle;
-
+      const setValue = (value: StyleValue) => {
         if (value.type === "invalid") {
           return;
         }


### PR DESCRIPTION
Here removed legacy part which always set unparsed value and needed to parse it before saving in db. Many cases are easily converted to keywords.

Blocker for box-shadow support https://github.com/webstudio-is/webstudio-builder/pull/1634

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
