### PR TITLE
Disable scroll when browser or resolution is not supported

### DIFF
--- a/apps/builder/app/builder/builder.css
+++ b/apps/builder/app/builder/builder.css
@@ -1,3 +1,7 @@
+html {
+  overflow: hidden;
+}
+
 body {
   overflow: hidden;
   overscroll-behavior: contain;

--- a/apps/builder/app/builder/features/blocking-alerts/alert.tsx
+++ b/apps/builder/app/builder/features/blocking-alerts/alert.tsx
@@ -3,7 +3,10 @@ import { AlertIcon } from "@webstudio-is/icons";
 
 const containerStyle = css({
   position: "absolute",
-  inset: 0,
+  top: 0,
+  left: 0,
+  width: "100vw",
+  height: "100vh",
   zIndex: theme.zIndices.max,
   background: "rgba(0, 0, 0, 0.9)",
 });

--- a/apps/builder/app/builder/features/blocking-alerts/blocking-alerts.tsx
+++ b/apps/builder/app/builder/features/blocking-alerts/blocking-alerts.tsx
@@ -39,12 +39,11 @@ export const BlockingAlerts = () => {
     .filter(Boolean)
     .pop();
 
+  // prevent scroll on mobile
   useEffect(() => {
     if (message === undefined) {
-      document.body.style.overflow = "";
       document.documentElement.style.overflow = "";
     } else {
-      document.body.style.overflow = "hidden";
       document.documentElement.style.overflow = "hidden";
     }
   }, [message]);

--- a/apps/builder/app/builder/features/blocking-alerts/blocking-alerts.tsx
+++ b/apps/builder/app/builder/features/blocking-alerts/blocking-alerts.tsx
@@ -39,15 +39,6 @@ export const BlockingAlerts = () => {
     .filter(Boolean)
     .pop();
 
-  // prevent scroll on mobile
-  useEffect(() => {
-    if (message === undefined) {
-      document.documentElement.style.overflow = "";
-    } else {
-      document.documentElement.style.overflow = "hidden";
-    }
-  }, [message]);
-
   if (message === undefined) {
     return null;
   }

--- a/apps/builder/app/builder/features/blocking-alerts/blocking-alerts.tsx
+++ b/apps/builder/app/builder/features/blocking-alerts/blocking-alerts.tsx
@@ -39,6 +39,16 @@ export const BlockingAlerts = () => {
     .filter(Boolean)
     .pop();
 
+  useEffect(() => {
+    if (message === undefined) {
+      document.body.style.overflow = "";
+      document.documentElement.style.overflow = "";
+    } else {
+      document.body.style.overflow = "hidden";
+      document.documentElement.style.overflow = "hidden";
+    }
+  }, [message]);
+
   if (message === undefined) {
     return null;
   }


### PR DESCRIPTION
Ref https://discord.com/channels/955905230107738152/955907841070346300/1119664468557828156

Set overflow hidden as simplest way. Need to test on different devices.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
