### PR TITLE
Add "clear styles" option for local style source

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.tsx
@@ -295,6 +295,16 @@ const renameStyleSource = (id: StyleSource["id"], label: string) => {
   });
 };
 
+const clearStyles = (styleSourceId: StyleSource["id"]) => {
+  store.createTransaction([stylesStore], (styles) => {
+    for (const [styleDeclKey, styleDecl] of styles) {
+      if (styleDecl.styleSourceId === styleSourceId) {
+        styles.delete(styleDeclKey);
+      }
+    }
+  });
+};
+
 const componentStatesStore = computed(
   [selectedInstanceStore, registeredComponentMetasStore],
   (selectedInstance, registeredComponentMetas) => {
@@ -375,6 +385,7 @@ export const StyleSourcesSection = () => {
           convertLocalStyleSourceToToken(id);
           setEditingItemId(id);
         }}
+        onClearStyles={clearStyles}
         onRemoveItem={(id) => {
           removeStyleSourceFromInstance(id);
         }}

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
@@ -212,6 +212,7 @@ type StyleSourceInputProps<Item extends IntermediateItem> = {
   onSelectAutocompleteItem?: (item: Item) => void;
   onRemoveItem?: (id: Item["id"]) => void;
   onDeleteItem?: (id: Item["id"]) => void;
+  onClearStyles?: (id: Item["id"]) => void;
   onDuplicateItem?: (id: Item["id"]) => void;
   onConvertToToken?: (id: Item["id"]) => void;
   onCreateItem?: (label: string) => void;
@@ -275,6 +276,7 @@ const renderMenuItems = (props: {
   onEnable?: (itemId: IntermediateItem["id"]) => void;
   onRemove?: (itemId: IntermediateItem["id"]) => void;
   onDelete?: (itemId: IntermediateItem["id"]) => void;
+  onClearStyles?: (itemId: IntermediateItem["id"]) => void;
 }) => {
   return (
     <>
@@ -293,6 +295,14 @@ const renderMenuItems = (props: {
           onSelect={() => props.onConvertToToken?.(props.item.id)}
         >
           Convert to token
+        </DropdownMenuItem>
+      )}
+      {props.item.source === "local" && (
+        <DropdownMenuItem
+          destructive={true}
+          onSelect={() => props.onClearStyles?.(props.item.id)}
+        >
+          Clear styles
         </DropdownMenuItem>
       )}
       {/* @todo implement disabling
@@ -451,6 +461,7 @@ export const StyleSourceInput = (
                 onEdit: props.onEditItem,
                 onRemove: props.onRemoveItem,
                 onDelete: props.onDeleteItem,
+                onClearStyles: props.onClearStyles,
               })
             }
             onChangeItem={props.onChangeItem}


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1799

Here added "Clear styles" option in "Local" style source menu.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
