### PR TITLE
Compute currentColor

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
@@ -190,12 +190,26 @@ export const ColorPicker = ({
   const rgbValue = styleValueToRgbaColor(currentValue);
 
   // Change prefix color in sync with color picker, don't change during input changed
-  const prefixColor = styleValueResolve(
+  let prefixColor = styleValueResolve(
     currentValue.type === "keyword" || currentValue.type === "rgb"
       ? currentValue
       : value,
     currentColor
   );
+  // consider inherit on color same as currentColor
+  if (
+    property === "color" &&
+    prefixColor.type === "keyword" &&
+    prefixColor.value === "inherit"
+  ) {
+    prefixColor = {
+      type: "rgb",
+      r: currentColor.r,
+      g: currentColor.g,
+      b: currentColor.b,
+      alpha: currentColor.alpha,
+    };
+  }
 
   const prefixColorRgba = styleValueToRgbaColor(prefixColor);
 

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
@@ -1,18 +1,32 @@
-import { test, expect } from "@jest/globals";
+import { test, expect, describe } from "@jest/globals";
+import { renderHook } from "@testing-library/react-hooks";
 import * as defaultMetas from "@webstudio-is/sdk-components-react/metas";
-import type {
-  Breakpoints,
-  Instance,
-  Instances,
-  StyleDecl,
-  StylesList,
+import {
+  getStyleDeclKey,
+  type Breakpoints,
+  type Instance,
+  type Instances,
+  type StyleDecl,
+  type StylesList,
 } from "@webstudio-is/project-build";
+import {
+  breakpointsStore,
+  instancesStore,
+  registeredComponentMetasStore,
+  selectedInstanceIntanceToTagStore,
+  selectedInstanceSelectorStore,
+  selectedStyleSourceSelectorStore,
+  styleSourceSelectionsStore,
+  styleSourcesStore,
+  stylesStore,
+} from "~/shared/nano-states";
 import {
   getCascadedBreakpointIds,
   getCascadedInfo,
   getInheritedInfo,
   getNextSourceInfo,
   getPreviousSourceInfo,
+  useStyleInfo,
 } from "./style-info";
 
 const metas = new Map(Object.entries(defaultMetas));
@@ -345,4 +359,197 @@ test("compute styles from next sources", () => {
       },
     }
   `);
+});
+
+const resetStores = () => {
+  registeredComponentMetasStore.set(new Map());
+  instancesStore.set(new Map());
+  stylesStore.set(new Map());
+  styleSourcesStore.set(new Map());
+  styleSourceSelectionsStore.set(new Map());
+  breakpointsStore.set(new Map());
+  selectedInstanceSelectorStore.set(undefined);
+  selectedInstanceIntanceToTagStore.set(new Map());
+  selectedStyleSourceSelectorStore.set(undefined);
+};
+
+describe("color and currentColor", () => {
+  const bodyBoxInstances: Instances = new Map([
+    [
+      "body",
+      {
+        type: "instance",
+        id: "body",
+        component: "Body",
+        children: [{ type: "id", value: "box" }],
+      },
+    ],
+    ["box", { type: "instance", id: "box", component: "Box", children: [] }],
+  ]);
+  const baseBreakpoint = new Map([["base", { id: "base", label: "Base" }]]);
+
+  test("initial color and currentColor is taken from properties", () => {
+    resetStores();
+    instancesStore.set(bodyBoxInstances);
+    selectedInstanceSelectorStore.set(["box", "body"]);
+    const { result } = renderHook(() => useStyleInfo());
+    expect(result.current.color?.value).toEqual({
+      type: "keyword",
+      value: "black",
+    });
+    expect(result.current.color?.currentColor).toEqual({
+      type: "keyword",
+      value: "black",
+    });
+  });
+
+  test("color and currentColor inherits from parent instance", () => {
+    resetStores();
+    instancesStore.set(bodyBoxInstances);
+    breakpointsStore.set(baseBreakpoint);
+    styleSourcesStore.set(
+      new Map([["body.local", { id: "body.local", type: "local" }]])
+    );
+    styleSourceSelectionsStore.set(
+      new Map([["body", { instanceId: "body", values: ["body.local"] }]])
+    );
+    const bodyColor: StyleDecl = {
+      styleSourceId: "body.local",
+      breakpointId: "base",
+      property: "color",
+      value: { type: "keyword", value: "red" },
+    };
+    stylesStore.set(new Map([[getStyleDeclKey(bodyColor), bodyColor]]));
+    selectedInstanceSelectorStore.set(["box", "body"]);
+    const { result } = renderHook(() => useStyleInfo());
+    expect(result.current.color?.value).toEqual({
+      type: "keyword",
+      value: "red",
+    });
+    expect(result.current.color?.currentColor).toEqual({
+      type: "keyword",
+      value: "red",
+    });
+  });
+
+  test("color: inherit inherits from parent instance", () => {
+    resetStores();
+    instancesStore.set(bodyBoxInstances);
+    breakpointsStore.set(baseBreakpoint);
+    styleSourcesStore.set(
+      new Map([
+        ["body.local", { id: "body.local", type: "local" }],
+        ["box.local", { id: "box.local", type: "local" }],
+      ])
+    );
+    styleSourceSelectionsStore.set(
+      new Map([
+        ["body", { instanceId: "body", values: ["body.local"] }],
+        ["box", { instanceId: "box", values: ["box.local"] }],
+      ])
+    );
+    const bodyColor: StyleDecl = {
+      styleSourceId: "body.local",
+      breakpointId: "base",
+      property: "color",
+      value: { type: "keyword", value: "red" },
+    };
+    const boxColor: StyleDecl = {
+      styleSourceId: "box.local",
+      breakpointId: "base",
+      property: "color",
+      value: { type: "keyword", value: "inherit" },
+    };
+    stylesStore.set(
+      new Map([
+        [getStyleDeclKey(bodyColor), bodyColor],
+        [getStyleDeclKey(boxColor), boxColor],
+      ])
+    );
+    selectedInstanceSelectorStore.set(["box", "body"]);
+    const { result } = renderHook(() => useStyleInfo());
+    expect(result.current.color?.value).toEqual({
+      type: "keyword",
+      value: "inherit",
+    });
+    expect(result.current.color?.currentColor).toEqual({
+      type: "keyword",
+      value: "red",
+    });
+  });
+
+  test("color: currentColor inherits from parent instance", () => {
+    resetStores();
+    instancesStore.set(bodyBoxInstances);
+    breakpointsStore.set(baseBreakpoint);
+    styleSourcesStore.set(
+      new Map([
+        ["body.local", { id: "body.local", type: "local" }],
+        ["box.local", { id: "box.local", type: "local" }],
+      ])
+    );
+    styleSourceSelectionsStore.set(
+      new Map([
+        ["body", { instanceId: "body", values: ["body.local"] }],
+        ["box", { instanceId: "box", values: ["box.local"] }],
+      ])
+    );
+    const bodyColor: StyleDecl = {
+      styleSourceId: "body.local",
+      breakpointId: "base",
+      property: "color",
+      value: { type: "keyword", value: "red" },
+    };
+    const boxColor: StyleDecl = {
+      styleSourceId: "box.local",
+      breakpointId: "base",
+      property: "color",
+      value: { type: "keyword", value: "currentColor" },
+    };
+    stylesStore.set(
+      new Map([
+        [getStyleDeclKey(bodyColor), bodyColor],
+        [getStyleDeclKey(boxColor), boxColor],
+      ])
+    );
+    selectedInstanceSelectorStore.set(["box", "body"]);
+    const { result } = renderHook(() => useStyleInfo());
+    expect(result.current.color?.value).toEqual({
+      type: "keyword",
+      value: "currentColor",
+    });
+    expect(result.current.color?.currentColor).toEqual({
+      type: "keyword",
+      value: "red",
+    });
+  });
+
+  test("color and currentColor inherits default value", () => {
+    resetStores();
+    instancesStore.set(bodyBoxInstances);
+    breakpointsStore.set(baseBreakpoint);
+    styleSourcesStore.set(
+      new Map([["body.local", { id: "body.local", type: "local" }]])
+    );
+    styleSourceSelectionsStore.set(
+      new Map([["body", { instanceId: "body", values: ["body.local"] }]])
+    );
+    const bodyColor: StyleDecl = {
+      styleSourceId: "body.local",
+      breakpointId: "base",
+      property: "color",
+      value: { type: "keyword", value: "inherit" },
+    };
+    stylesStore.set(new Map([[getStyleDeclKey(bodyColor), bodyColor]]));
+    selectedInstanceSelectorStore.set(["box", "body"]);
+    const { result } = renderHook(() => useStyleInfo());
+    expect(result.current.color?.value).toEqual({
+      type: "keyword",
+      value: "inherit",
+    });
+    expect(result.current.color?.currentColor).toEqual({
+      type: "keyword",
+      value: "black",
+    });
+  });
 });

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.test.ts
@@ -179,13 +179,6 @@ test("compute inherited styles", () => {
     )
   ).toMatchInlineSnapshot(`
     {
-      "color": {
-        "instanceId": "1",
-        "value": {
-          "type": "keyword",
-          "value": "black",
-        },
-      },
       "fontFamily": {
         "instanceId": "1",
         "value": {

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.ts
@@ -594,30 +594,22 @@ export const useStyleInfo = () => {
       const previousSource = previousSourceInfo[property];
       const nextSource = nextSourceInfo[property];
       const local = selectedStyle?.[property];
-      const value =
+      const ownValue =
         local ??
         nextSource?.value ??
         previousSource?.value ??
         cascaded?.value ??
         preset ??
-        htmlValue ??
-        inherited?.value ??
-        defaultValue;
+        htmlValue;
+      const inheritedValue = inherited?.value;
+      const value = ownValue ?? inheritedValue ?? defaultValue;
       if (value) {
         if (property === "color") {
-          const ownValue =
-            local ??
-            nextSource?.value ??
-            previousSource?.value ??
-            cascaded?.value ??
-            preset ??
-            htmlValue;
           const ownColor =
             ownValue?.type === "keyword" &&
             (ownValue.value === "inherit" || ownValue.value === "currentColor")
               ? undefined
               : ownValue;
-          const inheritedValue = inherited?.value;
           const inheritedColor =
             inheritedValue?.type === "keyword" &&
             (inheritedValue.value === "inherit" ||

--- a/apps/builder/app/builder/features/style-panel/shared/style-info.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/style-info.ts
@@ -21,7 +21,6 @@ import { compareMedia } from "@webstudio-is/css-engine";
 import {
   type StyleSourceSelector,
   instancesStore,
-  selectedInstanceBrowserStyleStore,
   selectedInstanceSelectorStore,
   selectedInstanceIntanceToTagStore,
   stylesIndexStore,
@@ -418,7 +417,6 @@ export const useStyleInfo = () => {
   const selectedOrLastStyleSourceSelector = useStore(
     selectedOrLastStyleSourceSelectorStore
   );
-  const browserStyle = useStore(selectedInstanceBrowserStyleStore);
   const selectedInstanceIntanceToTag = useStore(
     selectedInstanceIntanceToTagStore
   );
@@ -586,7 +584,6 @@ export const useStyleInfo = () => {
     const styleInfoData: StyleInfo = {};
     for (const property of styleProperties) {
       // temporary solution until we start computing all styles from data
-      const computed = browserStyle?.[property];
       const htmlValue = htmlStyle?.[property];
       const defaultValue =
         CUSTOM_DEFAULT_VALUES[property] ??
@@ -608,6 +605,26 @@ export const useStyleInfo = () => {
         defaultValue;
       if (value) {
         if (property === "color") {
+          const ownValue =
+            local ??
+            nextSource?.value ??
+            previousSource?.value ??
+            cascaded?.value ??
+            preset ??
+            htmlValue;
+          const ownColor =
+            ownValue?.type === "keyword" &&
+            (ownValue.value === "inherit" || ownValue.value === "currentColor")
+              ? undefined
+              : ownValue;
+          const inheritedValue = inherited?.value;
+          const inheritedColor =
+            inheritedValue?.type === "keyword" &&
+            (inheritedValue.value === "inherit" ||
+              inheritedValue.value === "currentColor")
+              ? undefined
+              : inheritedValue;
+          const currentColor = ownColor ?? inheritedColor ?? defaultValue;
           styleInfoData[property] = {
             value,
             local,
@@ -617,7 +634,7 @@ export const useStyleInfo = () => {
             inherited,
             preset,
             htmlValue,
-            currentColor: computed,
+            currentColor,
           };
         } else {
           styleInfoData[property] = {
@@ -636,7 +653,6 @@ export const useStyleInfo = () => {
     return styleInfoData;
   }, [
     htmlStyle,
-    browserStyle,
     presetStyle,
     inheritedInfo,
     cascadedInfo,

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -103,6 +103,7 @@
     "@jest/globals": "^29.3.1",
     "@remix-run/dev": "1.15.0",
     "@storybook/react": "^6.5.16",
+    "@testing-library/react-hooks": "^8.0.1",
     "@types/hyphenate-style-name": "^1.0.0",
     "@types/lodash.debounce": "^4.0.6",
     "@types/prismjs": "^1.26.0",

--- a/packages/css-data/bin/mdn-data.ts
+++ b/packages/css-data/bin/mdn-data.ts
@@ -42,7 +42,8 @@ const normalizedValues = {
   "font-family": inheritValue,
   "font-size": inheritValue,
   "line-height": inheritValue,
-  color: inheritValue,
+  // canvastext
+  color: { type: "keyword", value: "black" },
   "column-gap": {
     type: "unit",
     value: 0,

--- a/packages/css-data/src/__generated__/properties.ts
+++ b/packages/css-data/src/__generated__/properties.ts
@@ -933,7 +933,7 @@ export const properties = {
     inherited: true,
     initial: {
       type: "keyword",
-      value: "inherit",
+      value: "black",
     },
     popularity: 0.90791486,
     appliesTo: "allElementsAndText",

--- a/packages/sdk-components-react/src/body.ws.tsx
+++ b/packages/sdk-components-react/src/body.ws.tsx
@@ -24,12 +24,6 @@ const presetStyle = {
       property: "lineHeight",
       value: { type: "unit", unit: "number", value: 1.5 },
     },
-    // temporary set root color
-    // until builder start to fallback "inherit" to black
-    {
-      property: "color",
-      value: { type: "keyword", value: "black" },
-    },
   ],
 } satisfies PresetStyle<typeof defaultTag>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,6 +303,9 @@ importers:
       '@storybook/react':
         specifier: ^6.5.16
         version: 6.5.16(@babel/core@7.21.0)(react-dom@18.2.0)(react@18.2.0)(require-from-string@2.0.2)(type-fest@3.7.1)(typescript@5.1.3)
+      '@testing-library/react-hooks':
+        specifier: ^8.0.1
+        version: 8.0.1(@types/react@18.0.35)(react-dom@18.2.0)(react-test-renderer@18.2.0)(react@18.2.0)
       '@types/hyphenate-style-name':
         specifier: ^1.0.0
         version: 1.0.0
@@ -746,7 +749,7 @@ importers:
         version: 6.5.16(@babel/core@7.21.0)(react-dom@18.2.0)(react@18.2.0)(require-from-string@2.0.2)(type-fest@3.7.1)(typescript@5.1.3)
       '@testing-library/react-hooks':
         specifier: ^8.0.1
-        version: 8.0.1(@types/react@18.0.35)(react-dom@18.2.0)(react@18.2.0)
+        version: 8.0.1(@types/react@18.0.35)(react-dom@18.2.0)(react-test-renderer@18.2.0)(react@18.2.0)
       '@types/lodash.merge':
         specifier: ^4.6.6
         version: 4.6.7
@@ -3773,6 +3776,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
+    dev: false
 
   /@babel/runtime@7.22.3:
     resolution: {integrity: sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==}
@@ -8480,7 +8484,7 @@ packages:
       defer-to-connect: 2.0.1
     dev: true
 
-  /@testing-library/react-hooks@8.0.1(@types/react@18.0.35)(react-dom@18.2.0)(react@18.2.0):
+  /@testing-library/react-hooks@8.0.1(@types/react@18.0.35)(react-dom@18.2.0)(react-test-renderer@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -8496,11 +8500,12 @@ packages:
       react-test-renderer:
         optional: true
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.22.3
       '@types/react': 18.0.35
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-error-boundary: 3.1.4(react@18.2.0)
+      react-test-renderer: 18.2.0(react@18.2.0)
     dev: true
 
   /@tootallnate/once@1.1.2:


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1536

Here replaced browser getComputedStyle for currentColor with computing from data.

`color: inherit` is now considered same as `color: currentColor` and displayed properly in UI.

Changed initial value for color from inherit to black (in mdn-data it's canvastext).

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
