### PR TITLE
Add Build.dataSources

### DIFF
--- a/apps/builder/app/routes/rest.patch.ts
+++ b/apps/builder/app/routes/rest.patch.ts
@@ -8,6 +8,9 @@ import {
   Instances,
   Pages,
   Props,
+  DataSources,
+  parseDataSources,
+  serializeDataSources,
   StyleSourceSelections,
   StyleSources,
   Styles,
@@ -82,6 +85,7 @@ export const action = async ({ request }: ActionArgs) => {
     breakpoints?: Breakpoints;
     instances?: Instances;
     props?: Props;
+    dataSources?: DataSources;
     styleSources?: StyleSources;
     styleSourceSelections?: StyleSourceSelections;
     styles?: Styles;
@@ -156,6 +160,13 @@ export const action = async ({ request }: ActionArgs) => {
         continue;
       }
 
+      if (namespace === "dataSources") {
+        const dataSources =
+          buildData.dataSources ?? parseDataSources(build.dataSources);
+        buildData.dataSources = applyPatches(dataSources, patches);
+        continue;
+      }
+
       if (namespace === "breakpoints") {
         const breakpoints =
           buildData.breakpoints ??
@@ -201,6 +212,12 @@ export const action = async ({ request }: ActionArgs) => {
 
   if (buildData.props) {
     dbBuildData.props = serializeProps(Props.parse(buildData.props));
+  }
+
+  if (buildData.dataSources) {
+    dbBuildData.dataSources = serializeDataSources(
+      DataSources.parse(buildData.dataSources)
+    );
   }
 
   if (buildData.styleSources) {

--- a/packages/prisma-client/prisma/migrations/20230619131628_build_data_sources/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20230619131628_build_data_sources/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Build" ADD COLUMN     "dataSources" TEXT NOT NULL DEFAULT '[]';

--- a/packages/prisma-client/prisma/schema.prisma
+++ b/packages/prisma-client/prisma/schema.prisma
@@ -100,6 +100,7 @@ model Build {
   styleSources          String @default("[]")
   styleSourceSelections String @default("[]")
   props                 String @default("[]")
+  dataSources           String @default("[]")
   instances             String @default("[]")
 
   deployment    String?

--- a/packages/project-build/src/db/build.ts
+++ b/packages/project-build/src/db/build.ts
@@ -18,13 +18,11 @@ import {
   parseBreakpoints,
   serializeBreakpoints,
 } from "./breakpoints";
-import { parseStyles, serializeStyles } from "./styles";
-import { parseStyleSources, serializeStyleSources } from "./style-sources";
-import {
-  parseStyleSourceSelections,
-  serializeStyleSourceSelections,
-} from "./style-source-selections";
-import { parseProps, serializeProps } from "./props";
+import { parseStyles } from "./styles";
+import { parseStyleSources } from "./style-sources";
+import { parseStyleSourceSelections } from "./style-source-selections";
+import { parseProps } from "./props";
+import { parseDataSources } from "../schema/data-sources";
 import { parseInstances, serializeInstances } from "./instances";
 import { parseDeployment, serializeDeployment } from "./deployment";
 import type { Deployment } from "../schema/deployment";
@@ -50,6 +48,7 @@ const parseBuild = async (build: DbBuild): Promise<Build> => {
       parseStyleSourceSelections(build.styleSourceSelections, skipValidation)
     );
     const props = Array.from(parseProps(build.props, skipValidation));
+    const dataSources = Array.from(parseDataSources(build.dataSources));
     const instances = Array.from(
       parseInstances(build.instances, skipValidation)
     );
@@ -67,6 +66,7 @@ const parseBuild = async (build: DbBuild): Promise<Build> => {
       styleSources,
       styleSourceSelections,
       props,
+      dataSources,
       instances,
       deployment,
     };
@@ -160,10 +160,6 @@ export const createBuild = async (
       projectId: props.projectId,
       pages: JSON.stringify(newPages),
       breakpoints: serializeBreakpoints(new Map(createInitialBreakpoints())),
-      styles: serializeStyles(new Map()),
-      styleSources: serializeStyleSources(new Map()),
-      styleSourceSelections: serializeStyleSourceSelections(new Map()),
-      props: serializeProps(new Map()),
       instances: serializeInstances(new Map(newInstances)),
     },
   });

--- a/packages/project-build/src/index.ts
+++ b/packages/project-build/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./schema/pages";
 export * from "./schema/instances";
 export * from "./schema/props";
+export * from "./schema/data-sources";
 export * from "./schema/styles";
 export * from "./schema/style-sources";
 export * from "./schema/style-source-selections";

--- a/packages/project-build/src/schema/data-sources.ts
+++ b/packages/project-build/src/schema/data-sources.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+const DataSourceId = z.string();
+
+export const DataSource = z.union([
+  z.object({
+    id: DataSourceId,
+    name: z.string(),
+    type: z.literal("string"),
+    defaultValue: z.string(),
+  }),
+  z.object({
+    id: DataSourceId,
+    name: z.string(),
+    type: z.literal("boolean"),
+    defaultValue: z.boolean(),
+  }),
+]);
+
+export type DataSource = z.infer<typeof DataSource>;
+
+export const DataSourcesList = z.array(DataSource);
+
+export type DataSourcesList = z.infer<typeof DataSourcesList>;
+
+export const DataSources = z.map(DataSourceId, DataSource);
+
+export type DataSources = z.infer<typeof DataSources>;
+
+export const parseDataSources = (dataSourcesString: string): DataSources => {
+  const dataSourcesList = JSON.parse(dataSourcesString) as DataSourcesList;
+  return new Map(
+    dataSourcesList.map((dataSource) => [dataSource.id, dataSource])
+  );
+};
+
+export const serializeDataSources = (dataSources: DataSources) => {
+  const dataSourcesList: DataSourcesList = Array.from(dataSources.values());
+  return JSON.stringify(dataSourcesList);
+};

--- a/packages/project-build/src/types.ts
+++ b/packages/project-build/src/types.ts
@@ -6,6 +6,7 @@ import type { Instance } from "./schema/instances";
 import type { Prop } from "./schema/props";
 import type { StyleSourceSelection } from "./schema/style-source-selections";
 import type { Deployment } from "./schema/deployment";
+import type { DataSource } from "./schema/data-sources";
 
 export type Build = {
   id: string;
@@ -19,5 +20,6 @@ export type Build = {
   styleSourceSelections: [Instance["id"], StyleSourceSelection][];
   props: [Prop["id"], Prop][];
   instances: [Instance["id"], Instance][];
+  dataSources: [DataSource["id"], DataSource][];
   deployment?: Deployment | undefined;
 };


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1529

Here initial setup for data sources which are will be used to maintain runtime stores. It has unique id, name for ui, type and defaultValue to initialize store with it.

For now added only string and boolean types which are necessary for Form component. In the future will be extended with more types.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
