### PR TITLE
Add background section tooltips

### DIFF
--- a/apps/builder/app/builder/features/style-panel/controls/position/position-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/position/position-control.tsx
@@ -3,7 +3,7 @@ import {
   type StyleValue,
   TupleValueItem,
 } from "@webstudio-is/css-data";
-import { Box, Flex, Grid, PositionGrid } from "@webstudio-is/design-system";
+import { Flex, Grid, PositionGrid } from "@webstudio-is/design-system";
 import type { ControlProps } from "../../style-sections";
 import { styleConfigByName } from "../../shared/configs";
 import { getStyleSource } from "../../shared/style-info";

--- a/apps/builder/app/builder/features/style-panel/controls/position/position-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/position/position-control.tsx
@@ -3,12 +3,13 @@ import {
   type StyleValue,
   TupleValueItem,
 } from "@webstudio-is/css-data";
-import { Flex, Label, PositionGrid, theme } from "@webstudio-is/design-system";
+import { Box, Flex, Grid, PositionGrid } from "@webstudio-is/design-system";
 import type { ControlProps } from "../../style-sections";
 import { styleConfigByName } from "../../shared/configs";
 import { getStyleSource } from "../../shared/style-info";
 import { CssValueInputContainer } from "./css-value-input-container";
 import type { SetValue } from "../../shared/use-style-data";
+import { NonResetablePropertyName } from "../../shared/property-name";
 
 const toPosition = (value: TupleValue) => {
   return {
@@ -67,7 +68,12 @@ export const PositionControl = ({
 
   return (
     <Flex direction="column" gap="1">
-      <Label>Position</Label>
+      <NonResetablePropertyName
+        style={currentStyle}
+        properties={[property]}
+        label="Position"
+      />
+
       <Flex gap="6">
         <PositionGrid
           selectedPosition={toPosition(value)}
@@ -81,36 +87,49 @@ export const PositionControl = ({
             });
           }}
         />
-        <Flex
-          css={{ my: theme.spacing[3] }}
-          direction="column"
-          justify="between"
+        <Grid
+          css={{
+            gridTemplateColumns: "max-content 1fr",
+          }}
+          align="center"
+          gapX="2"
         >
-          <Flex align="center" gap="2">
-            <Label>Left</Label>
-            <CssValueInputContainer
-              label={label}
-              property={property}
-              styleSource={styleSource}
-              keywords={keywords}
-              value={value.value[0]}
-              setValue={setValueX}
-              deleteProperty={deleteProperty}
+          <NonResetablePropertyName
+            style={currentStyle}
+            properties={[property]}
+            description="Left position offset"
+            label="Left"
+          />
+
+          <CssValueInputContainer
+            label={label}
+            property={property}
+            styleSource={styleSource}
+            keywords={keywords}
+            value={value.value[0]}
+            setValue={setValueX}
+            deleteProperty={deleteProperty}
+          />
+
+          <Box css={{ flexShrink: 0 }}>
+            <NonResetablePropertyName
+              style={currentStyle}
+              properties={[property]}
+              description="Top position offset"
+              label="Top"
             />
-          </Flex>
-          <Flex align="center" gap="2">
-            <Label>Top</Label>
-            <CssValueInputContainer
-              label={label}
-              property={property}
-              styleSource={styleSource}
-              keywords={keywords}
-              value={value.value[1]}
-              setValue={setValueY}
-              deleteProperty={deleteProperty}
-            />
-          </Flex>
-        </Flex>
+          </Box>
+
+          <CssValueInputContainer
+            label={label}
+            property={property}
+            styleSource={styleSource}
+            keywords={keywords}
+            value={value.value[1]}
+            setValue={setValueY}
+            deleteProperty={deleteProperty}
+          />
+        </Grid>
       </Flex>
     </Flex>
   );

--- a/apps/builder/app/builder/features/style-panel/controls/position/position-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/position/position-control.tsx
@@ -111,14 +111,12 @@ export const PositionControl = ({
             deleteProperty={deleteProperty}
           />
 
-          <Box css={{ flexShrink: 0 }}>
-            <NonResetablePropertyName
-              style={currentStyle}
-              properties={[property]}
-              description="Top position offset"
-              label="Top"
-            />
-          </Box>
+          <NonResetablePropertyName
+            style={currentStyle}
+            properties={[property]}
+            description="Top position offset"
+            label="Top"
+          />
 
           <CssValueInputContainer
             label={label}

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-content.tsx
@@ -8,12 +8,10 @@ import {
   theme,
   Flex,
   Grid,
-  Label,
   ToggleGroup,
   ToggleGroupItem,
   Separator,
   styled,
-  Tooltip,
 } from "@webstudio-is/design-system";
 import { ImageControl, SelectControl, PositionControl } from "../../controls";
 import type { StyleInfo } from "../../shared/style-info";
@@ -39,10 +37,10 @@ import {
   RepeatColumnIcon,
   RepeatRowIcon,
   CrossSmallIcon,
-  InformationIcon,
 } from "@webstudio-is/icons";
 import { toValue } from "@webstudio-is/css-engine";
 import { BackgroundGradient } from "./background-gradient";
+import { NonResetablePropertyName } from "../../shared/property-name";
 
 type BackgroundContentProps = {
   currentStyle: StyleInfo;
@@ -153,9 +151,11 @@ export const BackgroundContent = (props: BackgroundContentProps) => {
         >
           {imageGradientToggle === "image" && (
             <>
-              <Label color="default" truncate>
-                Image
-              </Label>
+              <NonResetablePropertyName
+                style={props.currentStyle}
+                properties={["backgroundImage"]}
+                label="Image"
+              />
 
               <FloatingPanelProvider container={elementRef}>
                 <ImageControl
@@ -170,28 +170,23 @@ export const BackgroundContent = (props: BackgroundContentProps) => {
 
           {imageGradientToggle === "gradient" && (
             <Flex css={{ gridColumn: "span 2" }} direction="column">
-              <Label color="default">
-                <Flex align={"center"} gap={1}>
-                  Code
-                  <Tooltip
-                    variant="wrapped"
-                    content={
-                      <>
-                        Paste a CSS gradient, for example:
-                        <br />
-                        <br />
-                        linear-gradient(...)
-                        <br />
-                        <br />
-                        If pasting from figma, remove the “background” property
-                        name.
-                      </>
-                    }
-                  >
-                    <InformationIcon />
-                  </Tooltip>
-                </Flex>
-              </Label>
+              <NonResetablePropertyName
+                style={props.currentStyle}
+                description={
+                  <>
+                    Paste a CSS gradient, for example:
+                    <br />
+                    <br />
+                    linear-gradient(...)
+                    <br />
+                    <br />
+                    If pasting from figma, remove the “background” property
+                    name.
+                  </>
+                }
+                properties={["backgroundImage"]}
+                label="Code"
+              />
 
               <BackgroundGradient
                 setProperty={setProperty}
@@ -202,9 +197,11 @@ export const BackgroundContent = (props: BackgroundContentProps) => {
             </Flex>
           )}
 
-          <Label color="default" truncate>
-            Clip
-          </Label>
+          <NonResetablePropertyName
+            style={props.currentStyle}
+            properties={["backgroundClip"]}
+            label="Clip"
+          />
 
           <SelectControl
             setProperty={setProperty}
@@ -213,9 +210,11 @@ export const BackgroundContent = (props: BackgroundContentProps) => {
             property="backgroundClip"
           />
 
-          <Label color="default" truncate>
-            Origin
-          </Label>
+          <NonResetablePropertyName
+            style={props.currentStyle}
+            properties={["backgroundOrigin"]}
+            label="Origin"
+          />
 
           <SelectControl
             setProperty={setProperty}
@@ -252,9 +251,11 @@ export const BackgroundContent = (props: BackgroundContentProps) => {
         >
           {imageGradientToggle === "image" && (
             <>
-              <Label color="default" truncate>
-                Repeat
-              </Label>
+              <NonResetablePropertyName
+                style={props.currentStyle}
+                properties={["backgroundRepeat"]}
+                label="Repeat"
+              />
 
               <Flex css={{ justifySelf: "end" }}>
                 <ToggleGroupControl
@@ -293,9 +294,11 @@ export const BackgroundContent = (props: BackgroundContentProps) => {
             </>
           )}
 
-          <Label color="default" truncate>
-            Attachment
-          </Label>
+          <NonResetablePropertyName
+            style={props.currentStyle}
+            properties={["backgroundAttachment"]}
+            label="Attachment"
+          />
 
           <Flex css={{ justifySelf: "end" }}>
             <ToggleGroup
@@ -317,9 +320,11 @@ export const BackgroundContent = (props: BackgroundContentProps) => {
             </ToggleGroup>
           </Flex>
 
-          <Label color="default" truncate>
-            Blend mode
-          </Label>
+          <NonResetablePropertyName
+            style={props.currentStyle}
+            properties={["backgroundBlendMode"]}
+            label="Blend mode"
+          />
 
           <SelectControl
             setProperty={setProperty}

--- a/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-size.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/backgrounds/background-size.tsx
@@ -1,4 +1,4 @@
-import { Grid, Label, Select, theme } from "@webstudio-is/design-system";
+import { Grid, Select, theme } from "@webstudio-is/design-system";
 import { toValue } from "@webstudio-is/css-engine";
 import { styleConfigByName } from "../../shared/configs";
 import { toPascalCase } from "../../shared/keyword-utils";
@@ -11,6 +11,7 @@ import {
   TupleValueItem,
 } from "@webstudio-is/css-data";
 import type { SetValue } from "../../shared/use-style-data";
+import { NonResetablePropertyName } from "../../shared/property-name";
 
 const StyleKeywordAuto = { type: "keyword" as const, value: "auto" };
 
@@ -72,9 +73,11 @@ export const BackgroundSize = (
         align="center"
         gap={2}
       >
-        <Label color="default" truncate>
-          Size
-        </Label>
+        <NonResetablePropertyName
+          style={props.currentStyle}
+          properties={[property]}
+          label="Size"
+        />
 
         <Select
           // show empty field instead of radix placeholder
@@ -104,13 +107,21 @@ export const BackgroundSize = (
         gapX={2}
         gapY={1}
       >
-        <Label color="default" disabled={customSizeDisabled} truncate>
-          Width
-        </Label>
+        <NonResetablePropertyName
+          style={props.currentStyle}
+          properties={[property]}
+          label="Width"
+          description="The width of the background image."
+          disabled={customSizeDisabled}
+        />
 
-        <Label color="default" disabled={customSizeDisabled} truncate>
-          Height
-        </Label>
+        <NonResetablePropertyName
+          style={props.currentStyle}
+          properties={[property]}
+          label="Height"
+          description="The height of the background image."
+          disabled={customSizeDisabled}
+        />
 
         <CssValueInputContainer
           disabled={customSizeDisabled}


### PR DESCRIPTION
## Description

closes #1786

Labels inside background section are not resetable and always have default color.

<img width="615" alt="image" src="https://github.com/webstudio-is/webstudio-builder/assets/5077042/18bb9490-106d-466b-a286-d633e029df76">

Info icon has gone from `Code` just custom description is now used

cc @taylornowotny 


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
