### PR TITLE
Fix text-align control default value

### DIFF
--- a/packages/css-data/bin/mdn-data.ts
+++ b/packages/css-data/bin/mdn-data.ts
@@ -42,6 +42,8 @@ const normalizedValues = {
   "font-family": inheritValue,
   "font-size": inheritValue,
   "line-height": inheritValue,
+  // startOrNamelessValueIfLTRRightIfRTL
+  "text-align": { type: "keyword", value: "start" },
   // canvastext
   color: { type: "keyword", value: "black" },
   "column-gap": {

--- a/packages/css-data/src/__generated__/properties.ts
+++ b/packages/css-data/src/__generated__/properties.ts
@@ -3118,7 +3118,7 @@ export const properties = {
     inherited: true,
     initial: {
       type: "keyword",
-      value: "startOrNamelessValueIfLTRRightIfRTL",
+      value: "start",
     },
     popularity: 0.89287477,
     appliesTo: "blockContainers",


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1794

Here fixed initial value in css data. Mdn provides unclear value because of legacy browsers. Here we need to override it with actual "start".

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
