### PR TITLE
Support data source insert from template

### DIFF
--- a/apps/builder/app/builder/features/props-panel/controls/combined.tsx
+++ b/apps/builder/app/builder/features/props-panel/controls/combined.tsx
@@ -15,6 +15,10 @@ export const renderControl = ({
   prop,
   ...rest
 }: ControlProps<string, string> & { key?: string }) => {
+  if (prop?.type === "dataSource") {
+    throw Error("Data source is not resolved");
+  }
+
   if (
     meta.control === "text" &&
     (prop === undefined || prop.type === "string")

--- a/apps/builder/app/builder/features/props-panel/use-props-logic.ts
+++ b/apps/builder/app/builder/features/props-panel/use-props-logic.ts
@@ -77,6 +77,10 @@ const getDefaultMetaForType = (type: Prop["type"]): PropMeta => {
       throw new Error(
         "A prop with type string[] must have a meta, we can't provide a default one because we need a list of options"
       );
+    case "dataSource":
+      throw new Error(
+        "A prop with type dataSource must have a meta, we can't provide a default one because we need a list of options"
+      );
     default:
       throw new Error(`Usupported data type: ${type satisfies never}`);
   }

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -168,26 +168,15 @@ const getTreeData = (targetInstanceSelector: InstanceSelector) => {
     // unbind data source from prop
     if (prop.type === "dataSource") {
       const dataSource = dataSources.get(prop.value);
-      if (dataSource?.type === "string") {
+      if (dataSource) {
+        const { id, name, ...rest } = dataSource;
         return {
           id: prop.id,
           instanceId: prop.instanceId,
           name: prop.name,
-          type: dataSource.type,
-          value: dataSource.defaultValue,
+          ...rest,
         } satisfies Prop;
       }
-      if (dataSource?.type === "boolean") {
-        return {
-          id: prop.id,
-          instanceId: prop.instanceId,
-          name: prop.name,
-          type: dataSource.type,
-          value: dataSource.defaultValue,
-        } satisfies Prop;
-      }
-      // ensure all data source types are mapped to props
-      dataSource satisfies undefined;
     }
     return prop;
   });

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -19,6 +19,7 @@ import {
   textEditingInstanceSelectorStore,
   breakpointsStore,
   registeredComponentMetasStore,
+  dataSourcesStore,
 } from "./nano-states";
 import {
   type DroppableTarget,
@@ -175,6 +176,7 @@ export const insertTemplate = (
     children,
     instances: insertedInstances,
     props: insertedProps,
+    dataSources: insertedDataSources,
     styleSourceSelections: insertedStyleSourceSelections,
     styleSources: insertedStyleSources,
     styles: insertedStyles,
@@ -184,11 +186,19 @@ export const insertTemplate = (
     [
       instancesStore,
       propsStore,
+      dataSourcesStore,
       styleSourceSelectionsStore,
       styleSourcesStore,
       stylesStore,
     ],
-    (instances, props, styleSourceSelections, styleSources, styles) => {
+    (
+      instances,
+      props,
+      dataSources,
+      styleSourceSelections,
+      styleSources,
+      styles
+    ) => {
       insertInstancesMutable(
         instances,
         props,
@@ -198,6 +208,9 @@ export const insertTemplate = (
         dropTarget
       );
       insertPropsCopyMutable(props, insertedProps, new Map());
+      for (const dataSource of insertedDataSources) {
+        dataSources.set(dataSource.id, dataSource);
+      }
       insertStyleSourcesCopyMutable(
         styleSources,
         insertedStyleSources,

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -7,6 +7,7 @@ import type { Asset, Assets } from "@webstudio-is/asset-uploader";
 import type { ItemDropTarget, Placement } from "@webstudio-is/design-system";
 import type {
   Breakpoint,
+  DataSources,
   Instance,
   Prop,
   Props,
@@ -58,6 +59,8 @@ export const rootInstanceStore = computed(
     return instances.get(selectedPage.rootInstanceId);
   }
 );
+
+export const dataSourcesStore = atom<DataSources>(new Map());
 
 export const propsStore = atom<Props>(new Map());
 export const propsIndexStore = computed(propsStore, (props) => {

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -8,6 +8,7 @@ import {
   pagesStore,
   instancesStore,
   propsStore,
+  dataSourcesStore,
   breakpointsStore,
   stylesStore,
   styleSourcesStore,
@@ -66,6 +67,7 @@ export const registerContainers = () => {
   store.register("styleSources", styleSourcesStore);
   store.register("styleSourceSelections", styleSourceSelectionsStore);
   store.register("props", propsStore);
+  store.register("dataSources", dataSourcesStore);
   store.register("assets", assetsStore);
   // synchronize whole states
   clientStores.set("project", projectStore);

--- a/packages/project-build/src/schema/data-sources.ts
+++ b/packages/project-build/src/schema/data-sources.ts
@@ -7,13 +7,14 @@ export const DataSource = z.union([
     id: DataSourceId,
     name: z.string(),
     type: z.literal("string"),
-    defaultValue: z.string(),
+    // initial value of data source store
+    value: z.string(),
   }),
   z.object({
     id: DataSourceId,
     name: z.string(),
     type: z.literal("boolean"),
-    defaultValue: z.boolean(),
+    value: z.boolean(),
   }),
 ]);
 

--- a/packages/project-build/src/schema/props.ts
+++ b/packages/project-build/src/schema/props.ts
@@ -46,6 +46,12 @@ export const Prop = z.union([
     type: z.literal("string[]"),
     value: z.array(z.string()),
   }),
+  z.object({
+    ...baseProp,
+    type: z.literal("dataSource"),
+    // data source id
+    value: z.string(),
+  }),
 ]);
 
 export type Prop = z.infer<typeof Prop>;

--- a/packages/react-sdk/src/embed-template.test.ts
+++ b/packages/react-sdk/src/embed-template.test.ts
@@ -276,7 +276,7 @@ test("generate data for embedding from props bound to data sources", () => {
         id: expectString,
         name: "showOtherBoxDataSource",
         type: "boolean",
-        defaultValue: false,
+        value: false,
       },
     ],
     styleSourceSelections: [],

--- a/packages/react-sdk/src/embed-template.test.ts
+++ b/packages/react-sdk/src/embed-template.test.ts
@@ -224,7 +224,7 @@ test("generate data for embedding from props bound to data sources", () => {
             {
               type: "boolean",
               name: "showOtherBox",
-              dataSourceReference: "showOtherBoxDataSource",
+              dataSourceRef: "showOtherBoxDataSource",
               value: false,
             },
           ],
@@ -237,7 +237,7 @@ test("generate data for embedding from props bound to data sources", () => {
             {
               type: "boolean",
               name: showAttribute,
-              dataSourceReference: "showOtherBoxDataSource",
+              dataSourceRef: "showOtherBoxDataSource",
               value: false,
             },
           ],

--- a/packages/react-sdk/src/embed-template.test.ts
+++ b/packages/react-sdk/src/embed-template.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@jest/globals";
 import { generateDataFromEmbedTemplate } from "./embed-template";
+import { showAttribute } from "./tree";
 
 const expectString = expect.any(String) as unknown as string;
 
@@ -44,6 +45,7 @@ test("generate data for embedding from instances and text", () => {
       },
     ],
     props: [],
+    dataSources: [],
     styleSourceSelections: [],
     styleSources: [],
     styles: [],
@@ -112,6 +114,7 @@ test("generate data for embedding from props", () => {
         value: "value3",
       },
     ],
+    dataSources: [],
     styleSourceSelections: [],
     styleSources: [],
     styles: [],
@@ -163,6 +166,7 @@ test("generate data for embedding from styles", () => {
       },
     ],
     props: [],
+    dataSources: [],
     styleSourceSelections: [
       {
         instanceId: expectString,
@@ -206,5 +210,77 @@ test("generate data for embedding from styles", () => {
         value: { type: "keyword", value: "black" },
       },
     ],
+  });
+});
+
+test("generate data for embedding from props bound to data sources", () => {
+  expect(
+    generateDataFromEmbedTemplate(
+      [
+        {
+          type: "instance",
+          component: "Box1",
+          props: [
+            {
+              type: "boolean",
+              name: "showOtherBox",
+              dataSourceReference: "showOtherBoxDataSource",
+              value: false,
+            },
+          ],
+          children: [],
+        },
+        {
+          type: "instance",
+          component: "Box2",
+          props: [
+            {
+              type: "boolean",
+              name: showAttribute,
+              dataSourceReference: "showOtherBoxDataSource",
+              value: false,
+            },
+          ],
+          children: [],
+        },
+      ],
+      defaultBreakpointId
+    )
+  ).toEqual({
+    children: [
+      { type: "id", value: expectString },
+      { type: "id", value: expectString },
+    ],
+    instances: [
+      { type: "instance", id: expectString, component: "Box1", children: [] },
+      { type: "instance", id: expectString, component: "Box2", children: [] },
+    ],
+    props: [
+      {
+        id: expectString,
+        instanceId: expectString,
+        type: "dataSource",
+        name: "showOtherBox",
+        value: expectString,
+      },
+      {
+        id: expectString,
+        instanceId: expectString,
+        type: "dataSource",
+        name: showAttribute,
+        value: expectString,
+      },
+    ],
+    dataSources: [
+      {
+        id: expectString,
+        name: "showOtherBoxDataSource",
+        type: "boolean",
+        defaultValue: false,
+      },
+    ],
+    styleSourceSelections: [],
+    styleSources: [],
+    styles: [],
   });
 });

--- a/packages/react-sdk/src/embed-template.ts
+++ b/packages/react-sdk/src/embed-template.ts
@@ -24,25 +24,25 @@ const EmbedTemplateProp = z.union([
   z.object({
     type: z.literal("number"),
     name: z.string(),
-    dataSourceReference: z.optional(z.string()),
+    dataSourceRef: z.optional(z.string()),
     value: z.number(),
   }),
   z.object({
     type: z.literal("string"),
     name: z.string(),
-    dataSourceReference: z.optional(z.string()),
+    dataSourceRef: z.optional(z.string()),
     value: z.string(),
   }),
   z.object({
     type: z.literal("boolean"),
     name: z.string(),
-    dataSourceReference: z.optional(z.string()),
+    dataSourceRef: z.optional(z.string()),
     value: z.boolean(),
   }),
   z.object({
     type: z.literal("string[]"),
     name: z.string(),
-    dataSourceReference: z.optional(z.string()),
+    dataSourceRef: z.optional(z.string()),
     value: z.array(z.string()),
   }),
 ]);
@@ -96,7 +96,7 @@ const createInstancesFromTemplate = (
   treeTemplate: WsEmbedTemplate,
   instances: InstancesList,
   props: PropsList,
-  dataSourceByReference: Map<string, DataSource>,
+  dataSourceByRef: Map<string, DataSource>,
   styleSourceSelections: StyleSourceSelectionsList,
   styleSources: StyleSourcesList,
   styles: StylesList,
@@ -111,14 +111,14 @@ const createInstancesFromTemplate = (
       if (item.props) {
         for (const prop of item.props) {
           const propId = nanoid();
-          if (prop.dataSourceReference === undefined) {
+          if (prop.dataSourceRef === undefined) {
             props.push({ id: propId, instanceId, ...prop });
             continue;
           }
-          let dataSource = dataSourceByReference.get(prop.dataSourceReference);
+          let dataSource = dataSourceByRef.get(prop.dataSourceRef);
           if (dataSource === undefined) {
             const id = nanoid();
-            const { name: propName, dataSourceReference: name, ...rest } = prop;
+            const { name: propName, dataSourceRef: name, ...rest } = prop;
             if (rest.type === "boolean" || rest.type === "string") {
               dataSource = { id, name, ...rest };
             } else {
@@ -126,7 +126,7 @@ const createInstancesFromTemplate = (
               rest.type satisfies "number" | "string[]";
               continue;
             }
-            dataSourceByReference.set(name, dataSource);
+            dataSourceByRef.set(name, dataSource);
           }
           props.push({
             id: propId,
@@ -174,7 +174,7 @@ const createInstancesFromTemplate = (
         item.children,
         instances,
         props,
-        dataSourceByReference,
+        dataSourceByRef,
         styleSourceSelections,
         styleSources,
         styles,
@@ -202,7 +202,7 @@ export const generateDataFromEmbedTemplate = (
 ) => {
   const instances: InstancesList = [];
   const props: PropsList = [];
-  const dataSourceByReference = new Map<string, DataSource>();
+  const dataSourceByRef = new Map<string, DataSource>();
   const styleSourceSelections: StyleSourceSelectionsList = [];
   const styleSources: StyleSourcesList = [];
   const styles: StylesList = [];
@@ -211,7 +211,7 @@ export const generateDataFromEmbedTemplate = (
     treeTemplate,
     instances,
     props,
-    dataSourceByReference,
+    dataSourceByRef,
     styleSourceSelections,
     styleSources,
     styles,
@@ -221,7 +221,7 @@ export const generateDataFromEmbedTemplate = (
     children,
     instances,
     props,
-    dataSources: Array.from(dataSourceByReference.values()),
+    dataSources: Array.from(dataSourceByRef.values()),
     styleSourceSelections,
     styleSources,
     styles,

--- a/packages/react-sdk/src/embed-template.ts
+++ b/packages/react-sdk/src/embed-template.ts
@@ -118,16 +118,12 @@ const createInstancesFromTemplate = (
           let dataSource = dataSourceByReference.get(prop.dataSourceReference);
           if (dataSource === undefined) {
             const id = nanoid();
-            const name = prop.dataSourceReference;
-            if (prop.type === "boolean") {
-              const { type, value: defaultValue } = prop;
-              dataSource = { id, name, type, defaultValue };
-            } else if (prop.type === "string") {
-              const { type, value: defaultValue } = prop;
-              dataSource = { id, name, type, defaultValue };
+            const { name: propName, dataSourceReference: name, ...rest } = prop;
+            if (rest.type === "boolean" || rest.type === "string") {
+              dataSource = { id, name, ...rest };
             } else {
               // ensure only number and string[] are not mapped to data sources
-              prop.type satisfies "number" | "string[]";
+              rest.type satisfies "number" | "string[]";
               continue;
             }
             dataSourceByReference.set(name, dataSource);


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1529

- added data sources store
- added dataSource type to props
- insert data sources from template (prop.dataSourceReference allows to bind several props to the same data source)
- convert to static prop on copying (simplification until requirements are clear)

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
