### PR TITLE
Allow input color without hex, also fx invalid

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
@@ -152,7 +152,8 @@ const useFixDragOverCanvas = () => {
 export type CssColorPickerValueInput =
   | RgbValue
   | KeywordValue
-  | IntermediateStyleValue;
+  | IntermediateStyleValue
+  | InvalidValue;
 
 type ColorPickerProps = {
   onChange: (value: CssColorPickerValueInput | undefined) => void;
@@ -318,6 +319,7 @@ export const ColorPicker = ({
           styleValue?.type === "rgb" ||
           styleValue?.type === "keyword" ||
           styleValue?.type === "intermediate" ||
+          styleValue?.type === "invalid" ||
           styleValue === undefined
         ) {
           onChange(styleValue);
@@ -331,19 +333,14 @@ export const ColorPicker = ({
       }}
       onHighlight={onHighlight}
       onChangeComplete={({ value }) => {
-        if (
-          value.type === "rgb" ||
-          value.type === "keyword" ||
-          value.type === "invalid"
-        ) {
+        if (value.type === "rgb" || value.type === "keyword") {
           onChangeComplete({ value });
+          return;
         }
-
-        onChangeComplete({
-          value: {
-            type: "invalid",
-            value: toValue(value),
-          },
+        // In case value is parsed to something wrong
+        onChange({
+          type: "invalid",
+          value: toValue(value),
         });
       }}
       onAbort={onAbort}

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts
@@ -84,6 +84,13 @@ export const parseIntermediateOrInvalidValue = (
     }
   }
 
+  // Last chance probably it's a color without #
+  styleInput = parseCssValue(property, `#${value}`);
+
+  if (styleInput.type !== "invalid") {
+    return styleInput;
+  }
+
   // If we are here it means that value can be Valid but our parseCssValue can't handle it
   // or value is invalid
   return {

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts.test.ts
@@ -372,6 +372,66 @@ describe("Colors", () => {
     });
   });
 
+  test("color with value hex", () => {
+    const result = parseIntermediateOrInvalidValue("color", {
+      type: "intermediate",
+      value: "#f00",
+    });
+
+    expect(result).toEqual({
+      type: "rgb",
+      alpha: 1,
+      r: 255,
+      g: 0,
+      b: 0,
+    });
+  });
+
+  test("color with value with long hex", () => {
+    const result = parseIntermediateOrInvalidValue("color", {
+      type: "intermediate",
+      value: "#f0ee0f",
+    });
+
+    expect(result).toEqual({
+      type: "rgb",
+      alpha: 1,
+      r: 240,
+      g: 238,
+      b: 15,
+    });
+  });
+
+  test("color with value hex without #", () => {
+    const result = parseIntermediateOrInvalidValue("color", {
+      type: "intermediate",
+      value: "f00",
+    });
+
+    expect(result).toEqual({
+      type: "rgb",
+      alpha: 1,
+      r: 255,
+      g: 0,
+      b: 0,
+    });
+  });
+
+  test("color with value long hex without #", () => {
+    const result = parseIntermediateOrInvalidValue("color", {
+      type: "intermediate",
+      value: "f0ee0f",
+    });
+
+    expect(result).toEqual({
+      type: "rgb",
+      alpha: 1,
+      r: 240,
+      g: 238,
+      b: 15,
+    });
+  });
+
   test("color with value rgba(0,0,0,0)", () => {
     const result = parseIntermediateOrInvalidValue("color", {
       type: "intermediate",


### PR DESCRIPTION
## Description

closes #1829

## Steps for reproduction

paste non hex color from figma, see it works
enter something like `ereemc` see invalid state

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
