### PR TITLE
Fix scrub lost unit on negative values

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -105,9 +105,18 @@ const useScrub = ({
 
         // In case of negative values for some properties, we might end up with invalid value.
         if (value.type === "invalid") {
-          // Try return unitless
+          // Try 0 with same unit
+          if (isValidDeclaration(property, `0${unit}`)) {
+            return {
+              type: "unit",
+              unit,
+              value: 0,
+            };
+          }
+
+          // Try unitless (in case of unit above was `number`
           if (isValidDeclaration(property, "0")) {
-            value = {
+            return {
               type: "unit",
               unit: "number",
               value: 0,
@@ -147,6 +156,8 @@ const useScrub = ({
         scrubRef.current?.focus();
 
         const value = validateValue(event.value);
+
+        console.log(value);
 
         onChangeRef.current(value);
       },

--- a/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -111,7 +111,7 @@ const useScrub = ({
               type: "unit",
               unit,
               value: 0,
-            };
+            } as const;
           }
 
           // Try unitless (in case of unit above was `number`
@@ -120,7 +120,7 @@ const useScrub = ({
               type: "unit",
               unit: "number",
               value: 0,
-            };
+            } as const;
           }
         }
       }
@@ -156,8 +156,6 @@ const useScrub = ({
         scrubRef.current?.focus();
 
         const value = validateValue(event.value);
-
-        console.log(value);
 
         onChangeRef.current(value);
       },


### PR DESCRIPTION
## Description

closes #1846

## Steps for reproduction

Drag value scrub to make it eq to 0.
Stop drag.
See unit preserved

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
