### PR TITLE
Sync pages change

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -249,11 +249,9 @@ export const Builder = ({
   useSetStyleSourceSelections(build.styleSourceSelections);
   useSetInstances(build.instances);
 
-  // Update page url on page change
   useSyncPageUrl();
 
   useSetAssets(assets);
-
   useSetAuthToken(authToken);
   useSetAuthPermit(authPermit);
 

--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -23,9 +23,6 @@ import {
 import { usePublishShortcuts } from "./shared/shortcuts";
 import {
   projectStore,
-  selectedInstanceSelectorStore,
-  selectedPageIdStore,
-  selectedPageStore,
   useIsPreviewMode,
   useSetAssets,
   useSetAuthPermit,
@@ -44,10 +41,9 @@ import { type Settings, useClientSettings } from "./shared/client-settings";
 import { getBuildUrl } from "~/shared/router-utils";
 import { useCopyPaste } from "~/shared/copy-paste";
 import type { Asset } from "@webstudio-is/asset-uploader";
-import { useSearchParams } from "@remix-run/react";
-import { useSyncInitializeOnce } from "~/shared/hook-utils";
 import { BlockingAlerts } from "./features/blocking-alerts";
 import { useStore } from "@nanostores/react";
+import { useSyncPageUrl } from "~/shared/pages";
 
 registerContainers();
 
@@ -243,6 +239,7 @@ export const Builder = ({
   authToken,
   authPermit,
 }: BuilderProps) => {
+  useSetProject(project);
   useSetPages(build.pages);
   useSetBreakpoints(build.breakpoints);
   useSetProps(build.props);
@@ -252,29 +249,14 @@ export const Builder = ({
   useSetStyleSourceSelections(build.styleSourceSelections);
   useSetInstances(build.instances);
 
-  const [searchParams] = useSearchParams();
-  const pageId = searchParams.get("pageId") ?? build.pages.homePage.id;
-
-  useSyncInitializeOnce(() => {
-    selectedPageIdStore.set(pageId);
-    const page = selectedPageStore.get();
-    if (page) {
-      selectedInstanceSelectorStore.set([page.rootInstanceId]);
-    }
-  });
-  useEffect(() => {
-    selectedPageIdStore.set(pageId);
-    const page = selectedPageStore.get();
-    if (page) {
-      selectedInstanceSelectorStore.set([page.rootInstanceId]);
-    }
-  }, [pageId]);
+  // Update page url on page change
+  useSyncPageUrl();
 
   useSetAssets(assets);
 
   useSetAuthToken(authToken);
   useSetAuthPermit(authPermit);
-  useSetProject(project);
+
   const [publish, publishRef] = usePublish();
   useBuilderStore(publish);
   useSyncServer({

--- a/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/pages/pages.tsx
@@ -27,7 +27,7 @@ import { CloseButton, Header } from "../../header";
 import { SettingsPanel } from "./settings-panel";
 import { NewPageSettings, PageSettings } from "./settings";
 import { pagesStore, selectedPageIdStore } from "~/shared/nano-states";
-import { useSwitchPage } from "~/shared/pages";
+import { switchPage } from "~/shared/pages";
 
 type TabContentProps = {
   onSetActiveTab: (tabName: TabName) => void;
@@ -228,8 +228,6 @@ const PagesPanel = ({
 
 export const TabContent = (props: TabContentProps) => {
   const currentPageId = useStore(selectedPageIdStore);
-  const switchPage = useSwitchPage();
-
   const newPageId = "new-page";
   const [editingPageId, setEditingPageId] = useState<string>();
 

--- a/apps/builder/app/builder/features/workspace/canvas-tools/canvas-tools.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/canvas-tools.tsx
@@ -9,7 +9,6 @@ import {
 } from "~/shared/nano-states";
 import { HoveredInstanceOutline, SelectedInstanceOutline } from "./outline";
 import { TextToolbar } from "./text-toolbar";
-import { useSubscribeSwitchPage } from "~/shared/pages";
 import { Label } from "./outline/label";
 import { Outline } from "./outline/outline";
 import { useSubscribeDragAndDropState } from "./use-subscribe-drag-drop-state";
@@ -36,7 +35,6 @@ type CanvasToolsProps = {
 export const CanvasTools = ({ publish }: CanvasToolsProps) => {
   // @todo try to setup cross-frame atoms to avoid this
   useSubscribeDragAndDropState();
-  useSubscribeSwitchPage();
 
   const [isPreviewMode] = useIsPreviewMode();
   const [dragAndDropState] = useDragAndDropState();

--- a/apps/builder/app/canvas/features/webstudio-component/link.ts
+++ b/apps/builder/app/canvas/features/webstudio-component/link.ts
@@ -1,13 +1,7 @@
 import type { MouseEvent } from "react";
-import { findPageByIdOrPath, type Page } from "@webstudio-is/project-build";
+import { findPageByIdOrPath } from "@webstudio-is/project-build";
 import { pagesStore, isPreviewModeStore } from "~/shared/nano-states";
-import { publish } from "~/shared/pubsub";
-
-declare module "~/shared/pubsub" {
-  export interface PubsubMap {
-    switchPage: { pageId: Page["id"] };
-  }
-}
+import { switchPage } from "~/shared/pages";
 
 const isAbsoluteUrl = (href: string) => {
   try {
@@ -31,16 +25,17 @@ export const handleLinkClick = (event: MouseEvent) => {
     return;
   }
 
-  const [withoutHash] = href.split("#");
-
-  const page = findPageByIdOrPath(pages, withoutHash);
-
-  if (page) {
-    publish({ type: "switchPage", payload: { pageId: page.id } });
+  if (isAbsoluteUrl(href)) {
+    window.open(href, "_blank");
     return;
   }
 
-  if (isAbsoluteUrl(href)) {
-    window.open(href, "_blank");
+  const pageHref = new URL(href, "https://any-valid.url");
+
+  const page = findPageByIdOrPath(pages, pageHref.pathname);
+
+  if (page) {
+    switchPage(page.id, pageHref.hash);
+    return;
   }
 };

--- a/apps/builder/app/shared/nano-states/pages.ts
+++ b/apps/builder/app/shared/nano-states/pages.ts
@@ -10,6 +10,8 @@ export const useSetPages = (pages: Pages) => {
 };
 
 export const selectedPageIdStore = atom<undefined | Page["id"]>(undefined);
+export const selectedPageHashStore = atom<string>("");
+
 export const useSetSelectedPageId = (pageId: Page["id"]) => {
   useSyncInitializeOnce(() => {
     selectedPageIdStore.set(pageId);

--- a/apps/builder/app/shared/nano-states/pages.ts
+++ b/apps/builder/app/shared/nano-states/pages.ts
@@ -12,12 +12,6 @@ export const useSetPages = (pages: Pages) => {
 export const selectedPageIdStore = atom<undefined | Page["id"]>(undefined);
 export const selectedPageHashStore = atom<string>("");
 
-export const useSetSelectedPageId = (pageId: Page["id"]) => {
-  useSyncInitializeOnce(() => {
-    selectedPageIdStore.set(pageId);
-  });
-};
-
 export const selectedPageStore = computed(
   [pagesStore, selectedPageIdStore],
   (pages, selectedPageId) => {

--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -81,6 +81,7 @@ export const useSyncPageUrl = () => {
     const searchParamsPageId = searchParams.get("pageId") ?? pages.homePage.id;
     const searchParamsPageHash = searchParams.get("pageHash") ?? "";
 
+    // Do not navigate on popstate change
     if (searchParamsPageId === page.id && searchParamsPageHash === pageHash) {
       return;
     }

--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -15,16 +15,14 @@ import { builderPath } from "~/shared/router-utils";
 import { useSyncInitializeOnce } from "../hook-utils";
 
 export const switchPage = (pageId?: Page["id"], pageHash?: string) => {
-  const project = projectStore.get();
   const pages = pagesStore.get();
 
-  if (project === undefined || pages === undefined) {
+  if (pages === undefined) {
     return;
   }
 
   const page = findPageByIdOrPath(pages, pageId ?? "");
 
-  // selectedInstanceSelectorStore.set(undefined);
   selectedPageHashStore.set(pageHash ?? "");
   selectedPageIdStore.set(page?.id ?? pages.homePage.id);
   selectedInstanceSelectorStore.set([

--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -24,9 +24,12 @@ export const switchPage = (pageId?: Page["id"], pageHash?: string) => {
 
   const page = findPageByIdOrPath(pages, pageId ?? "");
 
-  selectedInstanceSelectorStore.set(undefined);
+  // selectedInstanceSelectorStore.set(undefined);
   selectedPageHashStore.set(pageHash ?? "");
   selectedPageIdStore.set(page?.id ?? pages.homePage.id);
+  selectedInstanceSelectorStore.set([
+    page?.rootInstanceId ?? pages.homePage.rootInstanceId,
+  ]);
 };
 
 const setPageStateFromUrl = () => {

--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -42,6 +42,15 @@ const setPageStateFromUrl = () => {
   switchPage(pageId, pageHash);
 };
 
+/**
+ * Sync
+ *  - searchParams to atoms
+ *    - initial loading
+ *    - popstate
+ *
+ *  - atoms to searchParams
+ *    - on atom change
+ */
 export const useSyncPageUrl = () => {
   const navigate = useNavigate();
   const page = useStore(selectedPageStore);

--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -1,6 +1,6 @@
 import { useStore } from "@nanostores/react";
 import { useNavigate } from "@remix-run/react";
-import type { Page } from "@webstudio-is/project-build";
+import { findPageByIdOrPath, type Page } from "@webstudio-is/project-build";
 import { useEffect } from "react";
 import {
   authTokenStore,
@@ -22,9 +22,11 @@ export const switchPage = (pageId?: Page["id"], pageHash?: string) => {
     return;
   }
 
+  const page = findPageByIdOrPath(pages, pageId ?? "");
+
   selectedInstanceSelectorStore.set(undefined);
   selectedPageHashStore.set(pageHash ?? "");
-  selectedPageIdStore.set(pageId ?? pages.homePage.id);
+  selectedPageIdStore.set(page?.id ?? pages.homePage.id);
 };
 
 const setPageStateFromUrl = () => {
@@ -59,6 +61,15 @@ export const useSyncPageUrl = () => {
     const pages = pagesStore.get();
 
     if (page === undefined || project === undefined || pages === undefined) {
+      return;
+    }
+
+    const searchParams = new URLSearchParams(window.location.search);
+
+    const searchParamsPageId = searchParams.get("pageId") ?? pages.homePage.id;
+    const searchParamsPageHash = searchParams.get("pageHash") ?? "";
+
+    if (searchParamsPageId === page.id && searchParamsPageHash === pageHash) {
       return;
     }
 

--- a/apps/builder/app/shared/pages/use-switch-page.ts
+++ b/apps/builder/app/shared/pages/use-switch-page.ts
@@ -1,41 +1,74 @@
+import { useStore } from "@nanostores/react";
 import { useNavigate } from "@remix-run/react";
 import type { Page } from "@webstudio-is/project-build";
+import { useEffect } from "react";
 import {
   authTokenStore,
   pagesStore,
   projectStore,
+  selectedPageStore,
+  selectedPageIdStore,
+  selectedPageHashStore,
   selectedInstanceSelectorStore,
 } from "~/shared/nano-states";
 import { builderPath } from "~/shared/router-utils";
-import { useSubscribe } from "~/shared/pubsub";
+import { useSyncInitializeOnce } from "../hook-utils";
 
-export const useSwitchPage = () => {
+export const switchPage = (pageId?: Page["id"], pageHash?: string) => {
+  const project = projectStore.get();
+  const pages = pagesStore.get();
+
+  if (project === undefined || pages === undefined) {
+    return;
+  }
+
+  selectedInstanceSelectorStore.set(undefined);
+  selectedPageHashStore.set(pageHash ?? "");
+  selectedPageIdStore.set(pageId ?? pages.homePage.id);
+};
+
+const setPageStateFromUrl = () => {
+  const searchParams = new URLSearchParams(window.location.search);
+  const pages = pagesStore.get();
+
+  const pageId = searchParams.get("pageId") ?? pages?.homePage.id;
+  const pageHash = searchParams.get("pageHash") ?? "";
+
+  switchPage(pageId, pageHash);
+};
+
+export const useSyncPageUrl = () => {
   const navigate = useNavigate();
+  const page = useStore(selectedPageStore);
+  const pageHash = useStore(selectedPageHashStore);
 
-  /**
-   * If no `pageId` provided, switches to default page (home)
-   */
-  return (pageId?: Page["id"]) => {
+  // Get pageId and pageHash from URL
+  useSyncInitializeOnce(() => {
+    setPageStateFromUrl();
+  });
+
+  useEffect(() => {
+    window.addEventListener("popstate", setPageStateFromUrl);
+    return () => {
+      window.removeEventListener("popstate", setPageStateFromUrl);
+    };
+  }, []);
+
+  useEffect(() => {
     const project = projectStore.get();
     const pages = pagesStore.get();
 
-    if (project === undefined || pages === undefined) {
+    if (page === undefined || project === undefined || pages === undefined) {
       return;
     }
-
-    selectedInstanceSelectorStore.set(undefined);
 
     navigate(
       builderPath({
         projectId: project.id,
-        pageId: pageId === pages.homePage.id ? undefined : pageId,
+        pageId: page.id === pages.homePage.id ? undefined : page.id,
         authToken: authTokenStore.get(),
+        pageHash: pageHash === "" ? undefined : pageHash,
       })
     );
-  };
-};
-
-export const useSubscribeSwitchPage = () => {
-  const switchPage = useSwitchPage();
-  useSubscribe("switchPage", ({ pageId }) => switchPage(pageId));
+  }, [navigate, page, pageHash]);
 };

--- a/apps/builder/app/shared/router-utils/path-utils.ts
+++ b/apps/builder/app/shared/router-utils/path-utils.ts
@@ -18,12 +18,18 @@ export const builderPath = ({
   projectId,
   pageId,
   authToken,
+  pageHash,
 }: {
   projectId: string;
   pageId?: string;
   authToken?: string;
+  pageHash?: string;
 }) => {
-  return `/builder/${projectId}${searchParams({ pageId, authToken })}`;
+  return `/builder/${projectId}${searchParams({
+    pageId,
+    authToken,
+    pageHash,
+  })}`;
 };
 
 export const builderUrl = (props: {

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -15,6 +15,7 @@ import {
   styleSourceSelectionsStore,
   assetsStore,
   selectedPageIdStore,
+  selectedPageHashStore,
   selectedInstanceSelectorStore,
   selectedInstanceBrowserStyleStore,
   selectedInstanceUnitSizesStore,
@@ -74,6 +75,7 @@ export const registerContainers = () => {
   clientStores.set("project", projectStore);
   clientStores.set("dataSourceValues", dataSourceValuesStore);
   clientStores.set("selectedPageId", selectedPageIdStore);
+  clientStores.set("selectedPageHash", selectedPageHashStore);
   clientStores.set("selectedInstanceSelector", selectedInstanceSelectorStore);
   clientStores.set(
     "selectedInstanceBrowserStyle",


### PR DESCRIPTION
## Description

Changed pages synchronisation.

We had following path on link click in canvas:

- We intercept it in handleLinkClick and do publish('switchPage', {});
- We subscribe on 'switchPage' at builder and do navigate(builderPath, { pageId});
- We subscribe on useSearchParams extract from there pageId and do selectedPageIdStore.set(pageId)
- On Canvas we subscribe on selectedPageStore and finally render the page

Now we just change
`selectedPageHashStore`, `selectedPageIdStore` in a single function `switchPage`
`location.searchParams` used only for initial and popstate synchronisation.


pageHashStore added for future use, no logic now.



## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
