### PR TITLE
Fix spacing issues

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/space/keyboard.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/space/keyboard.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { FocusEvent, KeyboardEvent, MouseEvent } from "react";
+import type { FocusEvent, KeyboardEvent } from "react";
 import type { SpaceStyleProperty } from "./types";
 
 const movementKeys = [
@@ -28,45 +28,47 @@ export const useKeyboardNavigation = ({
   const [activeProperty, setActiveProperty] =
     useState<SpaceStyleProperty>("marginTop");
 
+  const [hoverActiveProperty, setHoverActiveProperty] =
+    useState<SpaceStyleProperty>("marginTop");
+
   const [isActive, setIsActive] = useState(false);
 
-  const hadnleFocus = (event: FocusEvent<HTMLElement>) => {
+  const handleActiveChange = (value: boolean) => {
+    setIsActive(value);
+
+    if (value === false) {
+      setActiveProperty(hoverActiveProperty);
+    }
+  };
+
+  const handleFocus = (event: FocusEvent<Element>) => {
     if (event.currentTarget.matches(":focus-visible")) {
-      setIsActive(true);
+      handleActiveChange(true);
     }
   };
 
   const handleBlur = () => {
-    setIsActive(false);
+    handleActiveChange(false);
   };
 
   const handleHover = (property: SpaceStyleProperty | undefined) => {
-    // switch to mouse navigation if user starts to use mouse
-    setIsActive(false);
-
     // keep active property in sync with hover (makes UX more intuitive)
     if (property) {
-      setActiveProperty(property);
+      setHoverActiveProperty(property);
+      if (isActive === false) {
+        setActiveProperty(property);
+      }
     }
   };
 
-  // switch back to keyboard navigation on mouse leave
-  const handleMouseLeave = (event: MouseEvent<HTMLElement>) => {
-    if (event.currentTarget.matches(":focus-visible")) {
-      setIsActive(true);
-    }
+  const handleMouseMove = () => {
+    handleActiveChange(false);
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
     // ignore events originating from popover input or something
     if (event.target !== event.currentTarget) {
       return;
-    }
-
-    // 1. handle transition from :focus to :focus-visible
-    // 2. switch from mouse navigation back to keyboard navigation if user starts to use keyboard
-    if (event.currentTarget.matches(":focus-visible")) {
-      setIsActive(true);
     }
 
     if (
@@ -77,12 +79,18 @@ export const useKeyboardNavigation = ({
     ) {
       event.preventDefault(); // prevent scrolling
       const key = event.key;
-      setActiveProperty(
-        (property) => movementMap[property][movementKeys.indexOf(key)]
-      );
+
+      handleActiveChange(true);
+
+      if (isActive) {
+        setActiveProperty(
+          (property) => movementMap[property][movementKeys.indexOf(key)]
+        );
+      }
     }
 
     if (event.key === "Enter") {
+      handleActiveChange(true);
       event.preventDefault(); // not sure we need this, but just in case
       onOpen(activeProperty);
     }
@@ -92,11 +100,11 @@ export const useKeyboardNavigation = ({
     activeProperty,
     isActive,
     handleHover,
+    handleMouseMove,
 
     // these are supposed to be put on the root element of the control
-    hadnleFocus,
+    handleFocus,
     handleBlur,
     handleKeyDown,
-    handleMouseLeave,
   };
 };

--- a/apps/builder/app/builder/features/style-panel/sections/space/keyboard.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/space/keyboard.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import type { FocusEvent, KeyboardEvent } from "react";
 import type { SpaceStyleProperty } from "./types";
 
@@ -33,6 +33,8 @@ export const useKeyboardNavigation = ({
 
   const [isActive, setIsActive] = useState(false);
 
+  const isMouseInsideRef = useRef(false);
+
   const handleActiveChange = (value: boolean) => {
     setIsActive(value);
 
@@ -63,6 +65,11 @@ export const useKeyboardNavigation = ({
 
   const handleMouseMove = () => {
     handleActiveChange(false);
+    isMouseInsideRef.current = true;
+  };
+
+  const handleMouseLeave = () => {
+    isMouseInsideRef.current = false;
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
@@ -82,7 +89,7 @@ export const useKeyboardNavigation = ({
 
       handleActiveChange(true);
 
-      if (isActive) {
+      if (isActive || isMouseInsideRef.current) {
         setActiveProperty(
           (property) => movementMap[property][movementKeys.indexOf(key)]
         );
@@ -100,9 +107,9 @@ export const useKeyboardNavigation = ({
     activeProperty,
     isActive,
     handleHover,
-    handleMouseMove,
-
     // these are supposed to be put on the root element of the control
+    handleMouseMove,
+    handleMouseLeave,
     handleFocus,
     handleBlur,
     handleKeyDown,

--- a/apps/builder/app/builder/features/style-panel/sections/space/layout.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/space/layout.tsx
@@ -236,6 +236,7 @@ type LayoutProps = {
   onKeyDown?: ComponentProps<"div">["onKeyDown"];
   onClick?: ComponentProps<"div">["onClick"];
   onMouseLeave?: ComponentProps<"div">["onMouseLeave"];
+  onMouseMove?: ComponentProps<"div">["onMouseMove"];
   onHover: (hoverTarget: HoverTagret | undefined) => void;
   activeProperties?: ReadonlyArray<SpaceStyleProperty>;
   renderCell: (args: { property: SpaceStyleProperty }) => React.ReactNode;
@@ -250,6 +251,7 @@ export const SpaceLayout = forwardRef(
       onClick,
       onHover,
       onMouseLeave,
+      onMouseMove,
       activeProperties,
       renderCell,
     }: LayoutProps,
@@ -272,11 +274,12 @@ export const SpaceLayout = forwardRef(
 
     return (
       <Container
-        onClick={onClick}
         onFocus={onFocus}
         onBlur={onBlur}
+        onClick={onClick}
         onKeyDown={onKeyDown}
         onMouseLeave={onMouseLeave}
+        onMouseMove={onMouseMove}
         tabIndex={0}
         ref={ref}
       >

--- a/apps/builder/app/builder/features/style-panel/sections/space/space.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/space/space.tsx
@@ -1,4 +1,10 @@
-import { type ComponentProps, useState, useRef } from "react";
+import {
+  type ComponentProps,
+  type FocusEvent,
+  useState,
+  useRef,
+  type FocusEventHandler,
+} from "react";
 import type { RenderCategoryProps } from "../../style-sections";
 import { SpaceLayout } from "./layout";
 import { ValueText } from "./value-text";
@@ -10,6 +16,7 @@ import { SpaceTooltip } from "./tooltip";
 import { getStyleSource } from "../../shared/style-info";
 import { CollapsibleSection } from "../../shared/collapsible-section";
 import { useKeyboardNavigation } from "./keyboard";
+import { useDebouncedCallback } from "use-debounce";
 
 const Cell = ({
   isPopoverOpen,
@@ -75,6 +82,48 @@ const Cell = ({
   );
 };
 
+/**
+ * useFocusWithin does't work with popovers, implement it using debounce
+ */
+const useFocusWithinDebounce = (
+  props: {
+    onFocusWithin: FocusEventHandler<Element>;
+    onBlurWithin: FocusEventHandler<Element>;
+  },
+  timeout: number
+) => {
+  const isFocusedRef = useRef(false);
+
+  const handleFocusBlur = useDebouncedCallback(
+    (isFocus: boolean, event: FocusEvent<Element>) => {
+      if (isFocus && isFocusedRef.current === false) {
+        isFocusedRef.current = true;
+        props.onFocusWithin(event);
+        return;
+      }
+      if (isFocus === false && isFocusedRef.current === true) {
+        isFocusedRef.current = false;
+        props.onBlurWithin(event);
+      }
+    },
+    timeout
+  );
+
+  const handleFocus = (event: FocusEvent<Element>) => {
+    // ...event because we debounce handleFocusBlur, and react reuses events
+    handleFocusBlur(true, { ...event });
+  };
+
+  const handleBlur = (event: FocusEvent<Element>) => {
+    handleFocusBlur(false, event);
+  };
+
+  return {
+    onFocus: handleFocus,
+    onBlur: handleBlur,
+  };
+};
+
 export const SpaceSection = ({
   setProperty,
   deleteProperty,
@@ -109,6 +158,14 @@ export const SpaceSection = ({
     onOpen: setOpenProperty,
   });
 
+  const focusProps = useFocusWithinDebounce(
+    {
+      onFocusWithin: keyboardNavigation.handleFocus,
+      onBlurWithin: keyboardNavigation.handleBlur,
+    },
+    100
+  );
+
   // by deafult highlight hovered or scrubbed properties
   let activeProperties = scrubStatus.properties;
 
@@ -127,6 +184,10 @@ export const SpaceSection = ({
     keyboardNavigation.handleHover(target?.property);
   };
 
+  const activeProperty = keyboardNavigation.isActive
+    ? keyboardNavigation.activeProperty
+    : hoverTarget?.property;
+
   return (
     <CollapsibleSection
       label="Space"
@@ -144,10 +205,10 @@ export const SpaceSection = ({
           setOpenProperty(property);
         }}
         onHover={handleHover}
-        onFocus={keyboardNavigation.hadnleFocus}
-        onBlur={keyboardNavigation.handleBlur}
+        onFocus={focusProps.onFocus}
+        onBlur={focusProps.onBlur}
         onKeyDown={keyboardNavigation.handleKeyDown}
-        onMouseLeave={keyboardNavigation.handleMouseLeave}
+        onMouseMove={keyboardNavigation.handleMouseMove}
         activeProperties={activeProperties}
         renderCell={({ property }) => (
           <Cell
@@ -168,7 +229,7 @@ export const SpaceSection = ({
             onHover={handleHover}
             property={property}
             scrubStatus={scrubStatus}
-            isActive={activeProperties.includes(property)}
+            isActive={activeProperty === property}
             currentStyle={currentStyle}
           />
         )}

--- a/apps/builder/app/builder/features/style-panel/sections/space/space.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/space/space.tsx
@@ -209,6 +209,7 @@ export const SpaceSection = ({
         onBlur={focusProps.onBlur}
         onKeyDown={keyboardNavigation.handleKeyDown}
         onMouseMove={keyboardNavigation.handleMouseMove}
+        onMouseLeave={keyboardNavigation.handleMouseLeave}
         activeProperties={activeProperties}
         renderCell={({ property }) => (
           <Cell


### PR DESCRIPTION
## Description

Fixes following spacing issues:

- [x] - Show mutiple tooltips at once
<img width="399" alt="image" src="https://github.com/webstudio-is/webstudio-builder/assets/5077042/001d3e32-f7ce-4a68-9f61-12604a45886e">


- [x] - Show tolltip if mouse leaved the control and no keyboard interaction was made
<img width="273" alt="image" src="https://github.com/webstudio-is/webstudio-builder/assets/5077042/7965bb1f-93e3-4c33-b4f6-d2031a0374e8">


- [x] - Infinite tooltip show/hide on hover
![Screen Recording 2023-06-28 at 15 48 33](https://github.com/webstudio-is/webstudio-builder/assets/5077042/19531e19-1c51-4427-8cb6-f1bb93899f3a)

- [x] - Shift selection now always works after mouse move, before after control got focus shift wasn't worked at all.

- [x] - If mouse inside space area and keyboard nav started use next element of mouse target

## Steps for reproduction

Focus control play with buttons, enters, esc, shift mouse move

## Code Review

- [x] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
