### PR TITLE
Add expression utilities

### DIFF
--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -45,6 +45,7 @@
     "@webstudio-is/project-build": "workspace:^",
     "detect-font": "^0.1.5",
     "html-tags": "^3.2.0",
+    "jsep": "^1.3.8",
     "nanoevents": "^7.0.1",
     "nanoid": "^3.3.6",
     "nanostores": "^0.7.1"

--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "@jest/globals";
+import { executeExpression, validateExpression } from "./expression";
+
+test("allow literals and array expressions", () => {
+  expect(
+    validateExpression(`["", '', 0, true, false, null, undefined]`)
+  ).toEqual(`["", '', 0, true, false, null, undefined]`);
+});
+
+test("allow unary and binary expressions", () => {
+  expect(validateExpression(`[-1, 1 + 1]`)).toEqual(`[-1, 1 + 1]`);
+});
+
+test("forbid member expressions", () => {
+  expect(() => {
+    validateExpression("var1 + obj.param");
+  }).toThrowError(/Cannot access "param" of "obj"/);
+});
+
+test("forbid this expressions", () => {
+  expect(() => {
+    validateExpression("var1 + this");
+  }).toThrowError(/"this" is not supported/);
+});
+
+test("forbid call expressions", () => {
+  expect(() => {
+    validateExpression("var1 + fn1()");
+  }).toThrowError(/Cannot call "fn1"/);
+  expect(() => {
+    validateExpression("var1 + this.fn1()");
+  }).toThrowError(/Cannot call "this.fn1"/);
+});
+
+test("forbid multiple expressions", () => {
+  expect(() => {
+    validateExpression("a b");
+  }).toThrowError(/Cannot use multiple expressions/);
+  expect(() => {
+    validateExpression("a, b");
+  }).toThrowError(/Cannot use multiple expressions/);
+  expect(() => {
+    validateExpression("a; b");
+  }).toThrowError(/Cannot use multiple expressions/);
+});
+
+test("transform identifiers", () => {
+  expect(validateExpression(`a + b`, (id) => `$ws$${id}`)).toEqual(
+    `$ws$a + $ws$b`
+  );
+});
+
+test("execute expression", () => {
+  const variables = new Map();
+  const expressions = new Map([["exp1", "1 + 1"]]);
+  expect(
+    executeExpression("exp1", "$ws$dataSource$", variables, expressions)
+  ).toEqual(2);
+});
+
+test("execute expression dependent on variables", () => {
+  const variables = new Map([["var1", 5]]);
+  const expressions = new Map([["exp1", "$ws$dataSource$var1 + 1"]]);
+  expect(
+    executeExpression("exp1", "$ws$dataSource$", variables, expressions)
+  ).toEqual(6);
+});
+
+test("execute expression dependent on other expressions", () => {
+  const variables = new Map([["var1", 3]]);
+  const expressions = new Map([
+    ["exp1", "$ws$dataSource$exp0 + 1"],
+    ["exp0", "$ws$dataSource$var1 + 2"],
+  ]);
+  expect(
+    executeExpression("exp1", "$ws$dataSource$", variables, expressions)
+  ).toEqual(6);
+});
+
+test("forbid circular expressions", () => {
+  const variables = new Map([["var1", 3]]);
+  const expressions = new Map([
+    ["exp0", "$ws$dataSource$exp2 + 1"],
+    ["exp1", "$ws$dataSource$exp0 + 2"],
+    ["exp2", "$ws$dataSource$exp1 + 3"],
+  ]);
+  expect(() => {
+    executeExpression("exp1", "$ws$dataSource$", variables, expressions);
+  }).toThrowError(/\$ws\$dataSource\$exp2 is not defined/);
+});
+
+test("make sure dependency exists", () => {
+  const variables = new Map();
+  const expressions = new Map([["exp1", "$ws$dataSource$var1 + 1"]]);
+  expect(() => {
+    executeExpression("exp1", "$ws$dataSource$", variables, expressions);
+  }).toThrowError(/Unknown dependency "\$ws\$dataSource\$var1"/);
+});

--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -53,46 +53,40 @@ test("transform identifiers", () => {
 test("execute expression", () => {
   const variables = new Map();
   const expressions = new Map([["exp1", "1 + 1"]]);
-  expect(
-    executeExpression("exp1", "$ws$dataSource$", variables, expressions)
-  ).toEqual(2);
+  expect(executeExpression("exp1", variables, expressions)).toEqual(2);
 });
 
 test("execute expression dependent on variables", () => {
   const variables = new Map([["var1", 5]]);
-  const expressions = new Map([["exp1", "$ws$dataSource$var1 + 1"]]);
-  expect(
-    executeExpression("exp1", "$ws$dataSource$", variables, expressions)
-  ).toEqual(6);
+  const expressions = new Map([["exp1", "var1 + 1"]]);
+  expect(executeExpression("exp1", variables, expressions)).toEqual(6);
 });
 
 test("execute expression dependent on other expressions", () => {
   const variables = new Map([["var1", 3]]);
   const expressions = new Map([
-    ["exp1", "$ws$dataSource$exp0 + 1"],
-    ["exp0", "$ws$dataSource$var1 + 2"],
+    ["exp1", "exp0 + 1"],
+    ["exp0", "var1 + 2"],
   ]);
-  expect(
-    executeExpression("exp1", "$ws$dataSource$", variables, expressions)
-  ).toEqual(6);
+  expect(executeExpression("exp1", variables, expressions)).toEqual(6);
 });
 
 test("forbid circular expressions", () => {
   const variables = new Map([["var1", 3]]);
   const expressions = new Map([
-    ["exp0", "$ws$dataSource$exp2 + 1"],
-    ["exp1", "$ws$dataSource$exp0 + 2"],
-    ["exp2", "$ws$dataSource$exp1 + 3"],
+    ["exp0", "exp2 + 1"],
+    ["exp1", "exp0 + 2"],
+    ["exp2", "exp1 + 3"],
   ]);
   expect(() => {
-    executeExpression("exp1", "$ws$dataSource$", variables, expressions);
-  }).toThrowError(/\$ws\$dataSource\$exp2 is not defined/);
+    executeExpression("exp1", variables, expressions);
+  }).toThrowError(/exp2 is not defined/);
 });
 
 test("make sure dependency exists", () => {
   const variables = new Map();
-  const expressions = new Map([["exp1", "$ws$dataSource$var1 + 1"]]);
+  const expressions = new Map([["exp1", "var1 + 1"]]);
   expect(() => {
-    executeExpression("exp1", "$ws$dataSource$", variables, expressions);
-  }).toThrowError(/Unknown dependency "\$ws\$dataSource\$var1"/);
+    executeExpression("exp1", variables, expressions);
+  }).toThrowError(/Unknown dependency "var1"/);
 });

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -122,7 +122,6 @@ export const executeExpression = (
         deps.add(identifier);
         return identifier;
       }
-
       throw Error(`Unknown dependency "${identifier}"`);
     });
     depsById.set(id, deps);

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -1,0 +1,164 @@
+import jsep from "jsep";
+
+type TransformIdentifier = (id: string) => string;
+
+type Node = jsep.CoreExpression;
+
+const generateCode = (
+  node: Node,
+  failOnForbidden: boolean,
+  transformIdentifier: TransformIdentifier
+): string => {
+  if (node.type === "Identifier") {
+    return transformIdentifier(node.name);
+  }
+  if (node.type === "MemberExpression") {
+    if (failOnForbidden) {
+      const object = generateCode(
+        node.object as Node,
+        false,
+        transformIdentifier
+      );
+      const property = generateCode(
+        node.property as Node,
+        false,
+        transformIdentifier
+      );
+      throw Error(`Cannot access "${property}" of "${object}"`);
+    }
+    const object = generateCode(
+      node.object as Node,
+      failOnForbidden,
+      transformIdentifier
+    );
+    const property = generateCode(
+      node.property as Node,
+      failOnForbidden,
+      transformIdentifier
+    );
+    return `${object}.${property}`;
+  }
+  if (node.type === "Literal") {
+    return node.raw;
+  }
+  if (node.type === "UnaryExpression") {
+    const arg = generateCode(
+      node.argument as Node,
+      failOnForbidden,
+      transformIdentifier
+    );
+    return `${node.operator}${arg}`;
+  }
+  if (node.type === "BinaryExpression") {
+    const left = generateCode(
+      node.left as Node,
+      failOnForbidden,
+      transformIdentifier
+    );
+    const right = generateCode(
+      node.right as Node,
+      failOnForbidden,
+      transformIdentifier
+    );
+    return `${left} ${node.operator} ${right}`;
+  }
+  if (node.type === "ArrayExpression") {
+    const elements = node.elements.map((element) =>
+      generateCode(element as Node, failOnForbidden, transformIdentifier)
+    );
+    return `[${elements.join(", ")}]`;
+  }
+  if (node.type === "CallExpression") {
+    if (failOnForbidden) {
+      const callee = generateCode(
+        node.callee as Node,
+        false,
+        transformIdentifier
+      );
+      throw Error(`Cannot call "${callee}"`);
+    }
+    const callee = generateCode(
+      node.callee as Node,
+      failOnForbidden,
+      transformIdentifier
+    );
+    const args = node.arguments.map((arg) =>
+      generateCode(arg as Node, failOnForbidden, transformIdentifier)
+    );
+    return `${callee}(${args.join(", ")})`;
+  }
+  if (node.type === "ThisExpression") {
+    if (failOnForbidden) {
+      throw Error(`"this" is not supported`);
+    }
+    return "this";
+  }
+  if (node.type === "Compound") {
+    throw Error("Cannot use multiple expressions");
+  }
+  // plugin is not added
+  node.type satisfies "ConditionalExpression";
+  return "";
+};
+
+export const validateExpression = (
+  code: string,
+  transformIdentifier: TransformIdentifier = (id) => id
+) => {
+  const expression = jsep(code) as Node;
+  return generateCode(expression, true, transformIdentifier);
+};
+
+export const executeExpression = (
+  expressionId: string,
+  variablePrefix: string,
+  variables: Map<string, unknown>,
+  expressions: Map<string, string>
+) => {
+  const depsById = new Map<string, Set<string>>();
+  for (const [id, code] of expressions) {
+    const deps = new Set<string>();
+    validateExpression(code, (identifier) => {
+      if (identifier.startsWith(variablePrefix)) {
+        const depId = identifier.slice(variablePrefix.length);
+        if (variables.has(depId) || expressions.has(depId)) {
+          deps.add(depId);
+          return identifier;
+        }
+      }
+      throw Error(`Unknown dependency "${identifier}"`);
+    });
+    depsById.set(id, deps);
+  }
+
+  // sort topologically
+  const sortedExpressions = Array.from(expressions.keys()).sort(
+    (left, right) => {
+      if (depsById.get(left)?.has(right)) {
+        return 1;
+      }
+      if (depsById.get(right)?.has(left)) {
+        return -1;
+      }
+      return 0;
+    }
+  );
+
+  // execute chain of expressions
+  let header = "";
+  for (const [id, value] of variables) {
+    header += `const ${variablePrefix}${id} = ${JSON.stringify(value)};\n`;
+  }
+  for (const id of sortedExpressions) {
+    const code = expressions.get(id);
+    if (code === undefined) {
+      continue;
+    }
+    const executeFn = new Function(`${header}\nreturn (${code});`);
+    const value = executeFn();
+    header += `const ${variablePrefix}${id} = ${JSON.stringify(value)};\n`;
+    if (id === expressionId) {
+      return value;
+    }
+  }
+};

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -20,3 +20,4 @@ export {
   getInstanceIdFromComponentProps,
 } from "./props";
 export { type Params, ReactSdkContext } from "./context";
+export { validateExpression, executeExpression } from "./expression";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1236,6 +1236,9 @@ importers:
       html-tags:
         specifier: ^3.2.0
         version: 3.2.0
+      jsep:
+        specifier: ^1.3.8
+        version: 1.3.8
       nanoevents:
         specifier: ^7.0.1
         version: 7.0.1
@@ -13146,6 +13149,11 @@ packages:
       write-file-atomic: 2.4.3
     transitivePeerDependencies:
       - supports-color
+
+  /jsep@1.3.8:
+    resolution: {integrity: sha512-qofGylTGgYj9gZFsHuyWAN4jr35eJ66qJCK4eKDnldohuUoQFbU3iZn2zjvEbd9wOAhP9Wx5DsAAduTyE1PSWQ==}
+    engines: {node: '>= 10.16.0'}
+    dev: false
 
   /jsesc@0.5.0:
     resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1529

Here added two utilities:

validateExpression to parse syntax and replace identifier. For parsing used jsep package which is very limited subset of js.

executeExpression to execute the chain of expressions. The code is unoptimized and will not cache results between calls. But still should be fast enough because expressions are indented to be quite simple.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
