### PR TITLE
Add modern tooltips to space control

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/space/scrub.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/space/scrub.tsx
@@ -148,7 +148,7 @@ const circleGroups = [
   ["marginTop", "marginRight", "marginBottom", "marginLeft"],
 ] as const;
 
-const getModifiersGroup = (
+export const getModifiersGroup = (
   property: SpaceStyleProperty,
   modifiers: { shiftKey: boolean; altKey: boolean }
 ) => {

--- a/apps/builder/app/builder/features/style-panel/sections/space/space.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/space/space.tsx
@@ -64,6 +64,7 @@ const Cell = ({
         property={property}
         style={currentStyle}
         createBatchUpdate={createBatchUpdate}
+        preventOpen={scrubStatus.isActive}
       >
         <ValueText
           css={{

--- a/apps/builder/app/builder/features/style-panel/sections/space/tooltip.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/space/tooltip.tsx
@@ -1,7 +1,7 @@
 import type { SpaceStyleProperty } from "./types";
 import { PropertyTooltip } from "../../shared/property-name";
 import type { StyleInfo } from "../../shared/style-info";
-import type { ReactElement } from "react";
+import { useState, type ReactElement } from "react";
 import { useModifierKeys } from "../../shared/modifier-keys";
 import { getModifiersGroup } from "./scrub";
 import type { CreateBatchUpdate } from "../../shared/use-style-data";
@@ -80,12 +80,16 @@ export const SpaceTooltip = ({
   style,
   children,
   createBatchUpdate,
+  preventOpen,
 }: {
   property: SpaceStyleProperty;
   style: StyleInfo;
   children: ReactElement;
   createBatchUpdate: CreateBatchUpdate;
+  preventOpen: boolean;
 }) => {
+  const [open, setOpen] = useState(false);
+
   const modifiers = useModifierKeys();
 
   const properties = [...getModifiersGroup(property, modifiers)];
@@ -94,8 +98,17 @@ export const SpaceTooltip = ({
     isSameUnorderedArrays(propertyContent.properties, properties)
   );
 
+  const handleOpenChange = (value: boolean) => {
+    if (preventOpen && value === true) {
+      return;
+    }
+    setOpen(value);
+  };
+
   return (
     <PropertyTooltip
+      open={open}
+      onOpenChange={handleOpenChange}
       properties={properties}
       style={style}
       title={propertyContent?.label}

--- a/apps/builder/app/builder/features/style-panel/sections/space/tooltip.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/space/tooltip.tsx
@@ -1,14 +1,12 @@
-import {
-  styled,
-  Tooltip,
-  useEnhancedTooltipProps,
-} from "@webstudio-is/design-system";
+import { styled, useEnhancedTooltipProps } from "@webstudio-is/design-system";
 import type { SpaceStyleProperty } from "./types";
 import { useDebounce } from "use-debounce";
 import { useState } from "react";
+import { PropertyTooltip } from "../../shared/property-name";
+import type { StyleInfo } from "../../shared/style-info";
 
 // trigger is used only for positioning
-const Trigger = styled("div", {
+const PositionTrigger = styled("div", {
   position: "absolute",
   width: "100%",
   height: "100%",
@@ -17,32 +15,80 @@ const Trigger = styled("div", {
   left: 0,
 });
 
-const labels = {
-  paddingTop: "Padding Top",
-  paddingRight: "Padding Right",
-  paddingBottom: "Padding Bottom",
-  paddingLeft: "Padding Left",
-  marginTop: "Margin Top",
-  marginRight: "Margin Right",
-  marginBottom: "Margin Bottom",
-  marginLeft: "Margin Left",
-};
-
 const sides = {
   paddingTop: "top",
   paddingRight: "left",
-  paddingBottom: "top",
-  paddingLeft: "right",
+  paddingBottom: "bottom",
+  paddingLeft: "left",
   marginTop: "top",
   marginRight: "left",
-  marginBottom: "top",
+  marginBottom: "bottom",
   marginLeft: "right",
 } as const;
 
+const propertyContents: {
+  properties: SpaceStyleProperty[];
+  label: string;
+  description: string;
+}[] = [
+  // Padding
+  {
+    properties: ["paddingTop", "paddingBottom"],
+    label: "Vertical Padding",
+    description:
+      "Defines the space between the content of an element and its top and bottom border. Can affect layout height.",
+  },
+
+  {
+    properties: ["paddingLeft", "paddingRight"],
+    label: "Horizontal Padding",
+    description:
+      "Defines the space between the content of an element and its left and right border. Can affect layout width.",
+  },
+
+  {
+    properties: ["paddingTop", "paddingBottom", "paddingLeft", "paddingRight"],
+    label: "Padding",
+    description:
+      "Defines the space between the content of an element and its border. Can affect layout size.",
+  },
+  // Margin
+  {
+    properties: ["marginTop", "marginBottom"],
+    label: "Vertical Margin",
+    description: "Sets the margin at the top and bottom of an element.",
+  },
+
+  {
+    properties: ["marginLeft", "marginRight"],
+    label: "Horizontal Margin",
+    description: "Sets the margin at the left and right of an element.",
+  },
+
+  {
+    properties: ["marginTop", "marginBottom", "marginLeft", "marginRight"],
+    label: "Margin",
+    description: "Sets the margin of an element.",
+  },
+];
+
+const isSameUnorderedArrays = (arrA: string[], arrB: string[]) => {
+  if (arrA.length !== arrB.length) {
+    return false;
+  }
+
+  const union = new Set([...arrA, ...arrB]);
+  return union.size === arrA.length;
+};
+
 export const SpaceTooltip = ({
   property,
+  properties,
+  style,
 }: {
   property: SpaceStyleProperty;
+  properties: SpaceStyleProperty[];
+  style: StyleInfo;
 }) => {
   const { delayDuration } = useEnhancedTooltipProps();
   const [initialOpen, setInitialOpen] = useState(false);
@@ -51,15 +97,20 @@ export const SpaceTooltip = ({
   if (initialOpen === false) {
     setInitialOpen(true);
   }
+  const propertyContent = propertyContents.find((propertyContent) =>
+    isSameUnorderedArrays(propertyContent.properties, properties)
+  );
 
   return (
-    <Tooltip
+    <PropertyTooltip
+      properties={properties}
+      style={style}
+      title={propertyContent?.label}
+      description={propertyContent?.description}
       open={open}
-      content={labels[property]}
       side={sides[property]}
-      disableHoverableContent
     >
-      <Trigger />
-    </Tooltip>
+      <PositionTrigger />
+    </PropertyTooltip>
   );
 };

--- a/apps/builder/app/builder/features/style-panel/shared/modifier-keys.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/modifier-keys.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { shallowEqual } from "shallow-equal";
 
 // Used for combined mouse and keyboard interactions, like scrubbing while holding ALT.
 // If it's just a keyboard interaction, you should already have a keyboard event at hand.
@@ -11,20 +12,33 @@ export const useModifierKeys = () => {
   });
 
   useEffect(() => {
-    const handler = (event: KeyboardEvent) =>
-      setState({
+    const handler = (event: KeyboardEvent | MouseEvent) => {
+      const newState = {
         shiftKey: event.shiftKey,
         altKey: event.altKey,
         ctrlKey: event.ctrlKey,
         metaKey: event.metaKey,
+      };
+
+      setState((prev) => {
+        if (shallowEqual(prev, newState)) {
+          return prev;
+        }
+
+        return newState;
       });
+    };
 
     window.addEventListener("keydown", handler);
     window.addEventListener("keyup", handler);
+    // The use of only the keyup/keydown events may not be sufficient.
+    // on a Mac, when the cmd-shift-4 (printscreen) combination is triggered, there is a possibility of losing the keyup event.
+    window.addEventListener("mousemove", handler);
 
     return () => {
       window.removeEventListener("keydown", handler);
       window.removeEventListener("keyup", handler);
+      window.removeEventListener("mousemove", handler);
     };
   }, []);
 

--- a/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
@@ -133,8 +133,6 @@ const TooltipContent = ({
   const styleSourceNameSet = new Set<string>();
   const instanceSet = new Set<string>();
 
-  const styleSource = getStyleSource(style[properties[0]]);
-
   for (const property of properties) {
     const styleValueInfo = style[property];
 
@@ -170,6 +168,10 @@ const TooltipContent = ({
       instanceSet.add(instanceTitle);
     }
   }
+
+  const styleSourcesList = properties.map((property) =>
+    getStyleSource(style[property])
+  );
 
   return (
     <Flex direction="column" gap="2" css={{ maxWidth: theme.spacing[28] }}>
@@ -225,7 +227,8 @@ const TooltipContent = ({
           </Flex>
         </Flex>
       )}
-      {(styleSource === "local" || styleSource === "overwritten") &&
+      {(styleSourcesList.includes("local") ||
+        styleSourcesList.includes("overwritten")) &&
         onReset !== undefined && (
           <Button
             color="dark"

--- a/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/property-name.tsx
@@ -10,6 +10,7 @@ import {
   Flex,
   Label,
   Tooltip,
+  type TooltipProps,
   Text,
   ScrollArea,
 } from "@webstudio-is/design-system";
@@ -123,32 +124,51 @@ const TooltipContent = ({
   const selectedBreakpoint = useStore(selectedBreakpointStore);
   const instances = useStore(instancesStore);
   const styleSources = useStore(styleSourcesStore);
-  let instance = useStore(selectedInstanceStore);
+  const instance = useStore(selectedInstanceStore);
   const selectedStyleSource = useStore(selectedStyleSourceStore);
-
-  // When we have multiple properties, they must be originating from the same source, so we can just use one.
-  const styleValueInfo = style[properties[0]];
-
-  if (styleValueInfo === undefined) {
-    return null;
-  }
 
   const descriptionWithFallback = description ?? getDescription(properties);
 
-  const styleSource = getStyleSource(styleValueInfo);
-  const sourceName = getSourceName(
-    styleSources,
-    styleValueInfo,
-    selectedStyleSource
-  );
-  const breakpointName = getBreakpointName(
-    styleValueInfo,
-    breakpoints,
-    selectedBreakpoint
-  );
+  const breakpointSet = new Set<string>();
+  const styleSourceNameSet = new Set<string>();
+  const instanceSet = new Set<string>();
 
-  if (styleValueInfo.inherited && styleValueInfo.local === undefined) {
-    instance = instances.get(styleValueInfo.inherited.instanceId);
+  const styleSource = getStyleSource(style[properties[0]]);
+
+  for (const property of properties) {
+    const styleValueInfo = style[property];
+
+    if (styleValueInfo === undefined) {
+      continue;
+    }
+
+    const sourceName = getSourceName(
+      styleSources,
+      styleValueInfo,
+      selectedStyleSource
+    );
+
+    if (sourceName !== undefined) {
+      styleSourceNameSet.add(sourceName);
+    }
+
+    const breakpointName = getBreakpointName(
+      styleValueInfo,
+      breakpoints,
+      selectedBreakpoint
+    );
+
+    breakpointSet.add(`${breakpointName}`);
+
+    let instanceTitle = instance?.label ?? instance?.component;
+    if (styleValueInfo.inherited && styleValueInfo.local === undefined) {
+      const localInstance = instances.get(styleValueInfo.inherited.instanceId);
+      instanceTitle = localInstance?.label ?? localInstance?.component;
+    }
+
+    if (instanceTitle !== undefined) {
+      instanceSet.add(instanceTitle);
+    }
   }
 
   return (
@@ -169,7 +189,7 @@ const TooltipContent = ({
         </Text>
       </ScrollArea>
       {descriptionWithFallback && <Text>{descriptionWithFallback}</Text>}
-      {sourceName && (
+      {styleSourceNameSet.size > 0 && (
         <Flex
           direction="column"
           gap="1"
@@ -177,17 +197,31 @@ const TooltipContent = ({
         >
           <Text color="moreSubtle">Value comes from</Text>
           <Flex gap="1" wrap="wrap">
-            <StyleSourceBadge source="breakpoint" variant="small">
-              {breakpointName}
-            </StyleSourceBadge>
-            <StyleSourceBadge source="token" variant="small">
-              {sourceName}
-            </StyleSourceBadge>
-            {instance && (
-              <StyleSourceBadge source="instance" variant="small">
-                {instance.label || instance.component}
+            {Array.from(breakpointSet).map((breakpointName) => (
+              <StyleSourceBadge
+                key={breakpointName}
+                source="breakpoint"
+                variant="small"
+              >
+                {breakpointName}
               </StyleSourceBadge>
-            )}
+            ))}
+
+            {Array.from(styleSourceNameSet).map((sourceName) => (
+              <StyleSourceBadge key={sourceName} source="token" variant="small">
+                {sourceName}
+              </StyleSourceBadge>
+            ))}
+
+            {Array.from(instanceSet).map((instanceTitle) => (
+              <StyleSourceBadge
+                key={instanceTitle}
+                source="instance"
+                variant="small"
+              >
+                {instanceTitle}
+              </StyleSourceBadge>
+            ))}
           </Flex>
         </Flex>
       )}
@@ -214,6 +248,9 @@ export const PropertyTooltip = ({
   style,
   onReset,
   children,
+  open,
+  onOpenChange,
+  side,
 }: {
   openWithClick?: boolean;
   title?: string;
@@ -222,12 +259,20 @@ export const PropertyTooltip = ({
   style: StyleInfo;
   onReset?: undefined | (() => void);
   children: ReactElement;
+  open?: boolean;
+  onOpenChange?: (isOpen: boolean) => void;
+  side?: TooltipProps["side"];
 }) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpenInternal, setIsOpenInternal] = useState(open ?? false);
+
+  const handleIsOpen = onOpenChange ?? setIsOpenInternal;
+  const isOpen = open ?? isOpenInternal;
+
   return (
     <Tooltip
       open={isOpen}
-      onOpenChange={setIsOpen}
+      onOpenChange={handleIsOpen}
+      side={side}
       // prevent closing tooltip on content click
       onPointerDown={(event) => event.preventDefault()}
       triggerProps={{
@@ -238,7 +283,7 @@ export const PropertyTooltip = ({
             return;
           }
           if (openWithClick) {
-            setIsOpen(true);
+            handleIsOpen(true);
           }
         },
       }}
@@ -248,12 +293,17 @@ export const PropertyTooltip = ({
           description={description}
           properties={properties}
           style={style}
-          onReset={() => {
-            onReset?.();
-            setIsOpen(false);
-          }}
+          onReset={
+            onReset
+              ? () => {
+                  onReset();
+                  handleIsOpen(false);
+                }
+              : undefined
+          }
         />
       }
+      disableHoverableContent={onReset === undefined}
     >
       {children}
     </Tooltip>

--- a/apps/builder/tsconfig.json
+++ b/apps/builder/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  // Extends can't use node's resolution rn https://github.com/dividab/tsconfig-paths/issues/209#issuecomment-1177261091
   "extends": "../../packages/tsconfig/remix.json",
   "include": [
     "remix.env.d.ts",
@@ -8,10 +7,14 @@
     "../../@types/**/*.d.ts"
   ],
   "compilerOptions": {
-    "paths": { "~/*": ["app/*"] },
+    "paths": {
+      "~/*": ["app/*"]
+    },
     "baseUrl": ".",
     "rootDir": "./app",
     "declaration": false,
-    "declarationDir": null
+    "emitDeclarationOnly": false,
+    "declarationDir": null,
+    "noEmit": true
   }
 }

--- a/packages/css-data/src/__generated__/property-value-descriptions.ts
+++ b/packages/css-data/src/__generated__/property-value-descriptions.ts
@@ -323,12 +323,16 @@ export const propertiesGenerated = {
   overscrollBehaviorY: "overscrollBehaviorY",
   paddingBlockEnd: "paddingBlockEnd",
   paddingBlockStart: "paddingBlockStart",
-  paddingBottom: "paddingBottom",
+  paddingBottom:
+    "Defines the space between the content of an element and its bottom border. Can affect layout height.",
   paddingInlineEnd: "paddingInlineEnd",
   paddingInlineStart: "paddingInlineStart",
-  paddingLeft: "paddingLeft",
-  paddingRight: "paddingRight",
-  paddingTop: "paddingTop",
+  paddingLeft:
+    "Defines the space between the content of an element and its left border. Can affect layout width.",
+  paddingRight:
+    "Defines the space between the content of an element and its right border. Can affect layout width.",
+  paddingTop:
+    "Defines the space between the content of an element and its top border. Can affect layout height.",
   pageBreakAfter: "pageBreakAfter",
   pageBreakBefore: "pageBreakBefore",
   pageBreakInside: "Controls whether a page break occurs inside an element.",

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -55,7 +55,11 @@ export {
   SidebarTabsTrigger,
 } from "./components/sidebar-tabs";
 export { Card } from "./components/card";
-export { Tooltip, InputErrorsTooltip } from "./components/tooltip";
+export {
+  Tooltip,
+  InputErrorsTooltip,
+  type TooltipProps,
+} from "./components/tooltip";
 export {
   EnhancedTooltip,
   EnhancedTooltipProvider,

--- a/packages/tsconfig/remix.json
+++ b/packages/tsconfig/remix.json
@@ -3,7 +3,6 @@
   "display": "Remix",
   "extends": "./base.json",
   "compilerOptions": {
-    "noEmit": true,
     "jsx": "react-jsx",
     "target": "ES2021",
     "module": "ES2020",


### PR DESCRIPTION
## Description

Based on discussion, now space section tooltips are shown only on label hovers


Supports alt/shift clicks
- [x] - During hover alt/shift works
- [x] - In case of multiple properties sources now group them
<img width="292" alt="image" src="https://github.com/webstudio-is/webstudio-builder/assets/5077042/029b60a5-9a4e-4d85-ba2e-3db4fbbb344d">



## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
