### PR TITLE
Support data source expressions

### DIFF
--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useEffect } from "react";
 import { useStore } from "@nanostores/react";
 import { computed } from "nanostores";
-import type { DataSource, Instances, Page } from "@webstudio-is/project-build";
+import type { Instances, Page } from "@webstudio-is/project-build";
 import {
   type Params,
   type Components,
@@ -33,7 +33,7 @@ import {
   registerComponentMetas,
   registerComponentPropsMetas,
   dataSourceValuesStore,
-  dataSourcesStore,
+  dataSourceVariablesStore,
 } from "~/shared/nano-states";
 import { useDragAndDrop } from "./shared/use-drag-drop";
 import { useCopyPaste } from "~/shared/copy-paste";
@@ -105,23 +105,11 @@ const useElementsTree = (components: Components, params: Params) => {
       propsByInstanceIdStore,
       assetsStore,
       pagesStore: pagesMapStore,
-      dataSourceValuesStore: computed(
-        [dataSourcesStore, dataSourceValuesStore],
-        (dataSources, dataSourceValues) => {
-          const newValues = new Map<DataSource["id"], unknown>();
-          for (const [dataSourceId, dataSource] of dataSources) {
-            newValues.set(dataSourceId, dataSource.value);
-          }
-          for (const [dataSourceId, dataSourceValue] of dataSourceValues) {
-            newValues.set(dataSourceId, dataSourceValue);
-          }
-          return newValues;
-        }
-      ),
+      dataSourceValuesStore,
       onDataSourceUpdate: (dataSourceId, value) => {
-        const dataSourceValues = new Map(dataSourceValuesStore.get());
-        dataSourceValues.set(dataSourceId, value);
-        dataSourceValuesStore.set(dataSourceValues);
+        const dataSourceVariables = new Map(dataSourceVariablesStore.get());
+        dataSourceVariables.set(dataSourceId, value);
+        dataSourceVariablesStore.set(dataSourceVariables);
       },
       Component: WebstudioComponentDev,
       components,

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -104,6 +104,7 @@ export const dataSourceValuesStore = computed(
         }
       }
     } catch (error) {
+      // eslint-disable-next-line no-console
       console.error(error);
     }
     return outputValues;

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -20,6 +20,11 @@ import type {
   StyleSourceSelection,
   StyleSourceSelections,
 } from "@webstudio-is/project-build";
+import {
+  executeExpressions,
+  encodeDataSourceVariable,
+  decodeDataSourceVariable,
+} from "@webstudio-is/react-sdk";
 import type { Style } from "@webstudio-is/css-data";
 import type { DragStartPayload } from "~/canvas/shared/use-drag-drop";
 import { useSyncInitializeOnce } from "../hook-utils";
@@ -62,7 +67,7 @@ export const rootInstanceStore = computed(
 );
 
 export const dataSourcesStore = atom<DataSources>(new Map());
-export const dataSourceValuesStore = atom<Map<DataSource["id"], unknown>>(
+export const dataSourceVariablesStore = atom<Map<DataSource["id"], unknown>>(
   new Map()
 );
 export const useSetDataSources = (
@@ -72,6 +77,38 @@ export const useSetDataSources = (
     dataSourcesStore.set(new Map(dataSources));
   });
 };
+export const dataSourceValuesStore = computed(
+  [dataSourcesStore, dataSourceVariablesStore],
+  (dataSources, dataSourceVariables) => {
+    const outputValues = new Map<DataSource["id"], unknown>();
+    const variables = new Map<string, unknown>();
+    const expressions = new Map<string, string>();
+    for (const [dataSourceId, dataSource] of dataSources) {
+      const name = encodeDataSourceVariable(dataSourceId);
+      if (dataSource.type === "variable") {
+        const value =
+          dataSourceVariables.get(dataSourceId) ?? dataSource.value.value;
+        variables.set(name, value);
+        outputValues.set(dataSourceId, value);
+      }
+      if (dataSource.type === "expression") {
+        expressions.set(name, dataSource.code);
+      }
+    }
+    try {
+      const outputVariables = executeExpressions(variables, expressions);
+      for (const [name, value] of outputVariables) {
+        const id = decodeDataSourceVariable(name);
+        if (id !== undefined) {
+          outputValues.set(id, value);
+        }
+      }
+    } catch (error) {
+      console.error(error);
+    }
+    return outputValues;
+  }
+);
 
 export const propsStore = atom<Props>(new Map());
 export const propsIndexStore = computed(propsStore, (props) => {

--- a/apps/builder/app/shared/sync/sync-stores.ts
+++ b/apps/builder/app/shared/sync/sync-stores.ts
@@ -28,7 +28,7 @@ import {
   synchronizedBreakpointsStores,
   selectedStyleSourceSelectorStore,
   synchronizedComponentsMetaStores,
-  dataSourceValuesStore,
+  dataSourceVariablesStore,
 } from "~/shared/nano-states";
 
 enableMapSet();
@@ -73,7 +73,7 @@ export const registerContainers = () => {
   store.register("assets", assetsStore);
   // synchronize whole states
   clientStores.set("project", projectStore);
-  clientStores.set("dataSourceValues", dataSourceValuesStore);
+  clientStores.set("dataSourceVariables", dataSourceVariablesStore);
   clientStores.set("selectedPageId", selectedPageIdStore);
   clientStores.set("selectedPageHash", selectedPageHashStore);
   clientStores.set("selectedInstanceSelector", selectedInstanceSelectorStore);

--- a/packages/project-build/src/schema/data-sources.ts
+++ b/packages/project-build/src/schema/data-sources.ts
@@ -2,19 +2,38 @@ import { z } from "zod";
 
 const DataSourceId = z.string();
 
-export const DataSource = z.union([
+export const DataSourceVariableValue = z.union([
   z.object({
-    id: DataSourceId,
-    name: z.string(),
+    type: z.literal("number"),
+    // initial value of variable store
+    value: z.number(),
+  }),
+  z.object({
     type: z.literal("string"),
-    // initial value of data source store
     value: z.string(),
   }),
   z.object({
-    id: DataSourceId,
-    name: z.string(),
     type: z.literal("boolean"),
     value: z.boolean(),
+  }),
+  z.object({
+    type: z.literal("string[]"),
+    value: z.array(z.string()),
+  }),
+]);
+
+export const DataSource = z.union([
+  z.object({
+    type: z.literal("variable"),
+    id: DataSourceId,
+    name: z.string(),
+    value: DataSourceVariableValue,
+  }),
+  z.object({
+    type: z.literal("expression"),
+    id: DataSourceId,
+    name: z.string(),
+    code: z.string(),
   }),
 ]);
 

--- a/packages/react-sdk/src/embed-template.test.ts
+++ b/packages/react-sdk/src/embed-template.test.ts
@@ -1,8 +1,12 @@
 import { expect, test } from "@jest/globals";
-import { generateDataFromEmbedTemplate } from "./embed-template";
+import {
+  generateDataFromEmbedTemplate,
+  decodeDataSourceVariable,
+  encodeDataSourceVariable,
+} from "./embed-template";
 import { showAttribute } from "./tree";
 
-const expectString = expect.any(String) as unknown as string;
+const expectString = expect.any(String);
 
 const defaultBreakpointId = "base";
 
@@ -213,7 +217,7 @@ test("generate data for embedding from styles", () => {
   });
 });
 
-test("generate data for embedding from props bound to data sources", () => {
+test("generate data for embedding from props bound to data source variables", () => {
   expect(
     generateDataFromEmbedTemplate(
       [
@@ -224,8 +228,11 @@ test("generate data for embedding from props bound to data sources", () => {
             {
               type: "boolean",
               name: "showOtherBox",
-              dataSourceRef: "showOtherBoxDataSource",
               value: false,
+              dataSourceRef: {
+                type: "variable",
+                name: "showOtherBoxDataSource",
+              },
             },
           ],
           children: [],
@@ -237,8 +244,11 @@ test("generate data for embedding from props bound to data sources", () => {
             {
               type: "boolean",
               name: showAttribute,
-              dataSourceRef: "showOtherBoxDataSource",
               value: false,
+              dataSourceRef: {
+                type: "variable",
+                name: "showOtherBoxDataSource",
+              },
             },
           ],
           children: [],
@@ -273,14 +283,115 @@ test("generate data for embedding from props bound to data sources", () => {
     ],
     dataSources: [
       {
+        type: "variable",
         id: expectString,
         name: "showOtherBoxDataSource",
-        type: "boolean",
-        value: false,
+        value: {
+          type: "boolean",
+          value: false,
+        },
       },
     ],
     styleSourceSelections: [],
     styleSources: [],
     styles: [],
   });
+});
+
+test("generate data for embedding from props bound to data source expressions", () => {
+  expect(
+    generateDataFromEmbedTemplate(
+      [
+        {
+          type: "instance",
+          component: "Box1",
+          props: [
+            {
+              type: "string",
+              name: "state",
+              value: "initial",
+              dataSourceRef: {
+                type: "variable",
+                name: "boxState",
+              },
+            },
+          ],
+          children: [],
+        },
+        {
+          type: "instance",
+          component: "Box2",
+          props: [
+            {
+              type: "boolean",
+              name: showAttribute,
+              value: false,
+              dataSourceRef: {
+                type: "expression",
+                name: "boxStateSuccess",
+                code: `boxState === 'success'`,
+              },
+            },
+          ],
+          children: [],
+        },
+      ],
+      defaultBreakpointId
+    )
+  ).toEqual({
+    children: [
+      { type: "id", value: expectString },
+      { type: "id", value: expectString },
+    ],
+    instances: [
+      { type: "instance", id: expectString, component: "Box1", children: [] },
+      { type: "instance", id: expectString, component: "Box2", children: [] },
+    ],
+    props: [
+      {
+        id: expectString,
+        instanceId: expectString,
+        type: "dataSource",
+        name: "state",
+        value: expectString,
+      },
+      {
+        id: expectString,
+        instanceId: expectString,
+        type: "dataSource",
+        name: showAttribute,
+        value: expectString,
+      },
+    ],
+    dataSources: [
+      {
+        type: "variable",
+        id: expectString,
+        name: "boxState",
+        value: {
+          type: "string",
+          value: "initial",
+        },
+      },
+      {
+        type: "expression",
+        id: expectString,
+        name: "boxStateSuccess",
+        code: expect.stringMatching(/\$ws\$dataSource\$\w+ === 'success'/),
+      },
+    ],
+    styleSourceSelections: [],
+    styleSources: [],
+    styles: [],
+  });
+});
+
+test("encode/decode variable names", () => {
+  expect(encodeDataSourceVariable("my--id")).toEqual(
+    "$ws$dataSource$my__DASH____DASH__id"
+  );
+  expect(decodeDataSourceVariable(encodeDataSourceVariable("my--id"))).toEqual(
+    "my--id"
+  );
+  expect(decodeDataSourceVariable("myVarName")).toEqual(undefined);
 });

--- a/packages/react-sdk/src/embed-template.test.ts
+++ b/packages/react-sdk/src/embed-template.test.ts
@@ -1,9 +1,5 @@
 import { expect, test } from "@jest/globals";
-import {
-  generateDataFromEmbedTemplate,
-  decodeDataSourceVariable,
-  encodeDataSourceVariable,
-} from "./embed-template";
+import { generateDataFromEmbedTemplate } from "./embed-template";
 import { showAttribute } from "./tree";
 
 const expectString = expect.any(String);
@@ -384,14 +380,4 @@ test("generate data for embedding from props bound to data source expressions", 
     styleSources: [],
     styles: [],
   });
-});
-
-test("encode/decode variable names", () => {
-  expect(encodeDataSourceVariable("my--id")).toEqual(
-    "$ws$dataSource$my__DASH____DASH__id"
-  );
-  expect(decodeDataSourceVariable(encodeDataSourceVariable("my--id"))).toEqual(
-    "my--id"
-  );
-  expect(decodeDataSourceVariable("myVarName")).toEqual(undefined);
 });

--- a/packages/react-sdk/src/embed-template.ts
+++ b/packages/react-sdk/src/embed-template.ts
@@ -12,26 +12,7 @@ import {
 } from "@webstudio-is/project-build";
 import { StyleValue, type StyleProperty } from "@webstudio-is/css-data";
 import type { Simplify } from "type-fest";
-import { validateExpression } from "./expression";
-
-const dataSourceVariablePrefix = "$ws$dataSource$";
-
-// data source id is generated with nanoid which has "-" in alphabeta
-// here "-" is encoded with "__DASH__' in variable name
-// https://github.com/ai/nanoid/blob/047686abad8f15aff05f3a2eeedb7c98b6847392/url-alphabet/index.js
-
-export const encodeDataSourceVariable = (id: DataSource["id"]) => {
-  const encoded = id.replaceAll("-", "__DASH__");
-  return `${dataSourceVariablePrefix}${encoded}`;
-};
-
-export const decodeDataSourceVariable = (name: string) => {
-  if (name.startsWith(dataSourceVariablePrefix)) {
-    const encoded = name.slice(dataSourceVariablePrefix.length);
-    return encoded.replaceAll("__DASH__", "-");
-  }
-  return;
-};
+import { encodeDataSourceVariable, validateExpression } from "./expression";
 
 const EmbedTemplateText = z.object({
   type: z.literal("text"),

--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "@jest/globals";
-import { executeExpressions, validateExpression } from "./expression";
+import {
+  decodeDataSourceVariable,
+  encodeDataSourceVariable,
+  executeExpressions,
+  validateExpression,
+} from "./expression";
 
 test("allow literals and array expressions", () => {
   expect(
@@ -98,4 +103,14 @@ test("make sure dependency exists", () => {
   expect(() => {
     executeExpressions(variables, expressions);
   }).toThrowError(/Unknown dependency "var1"/);
+});
+
+test("encode/decode variable names", () => {
+  expect(encodeDataSourceVariable("my--id")).toEqual(
+    "$ws$dataSource$my__DASH____DASH__id"
+  );
+  expect(decodeDataSourceVariable(encodeDataSourceVariable("my--id"))).toEqual(
+    "my--id"
+  );
+  expect(decodeDataSourceVariable("myVarName")).toEqual(undefined);
 });

--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@jest/globals";
-import { executeExpression, validateExpression } from "./expression";
+import { executeExpressions, validateExpression } from "./expression";
 
 test("allow literals and array expressions", () => {
   expect(
@@ -53,13 +53,17 @@ test("transform identifiers", () => {
 test("execute expression", () => {
   const variables = new Map();
   const expressions = new Map([["exp1", "1 + 1"]]);
-  expect(executeExpression("exp1", variables, expressions)).toEqual(2);
+  expect(executeExpressions(variables, expressions)).toEqual(
+    new Map([["exp1", 2]])
+  );
 });
 
 test("execute expression dependent on variables", () => {
   const variables = new Map([["var1", 5]]);
   const expressions = new Map([["exp1", "var1 + 1"]]);
-  expect(executeExpression("exp1", variables, expressions)).toEqual(6);
+  expect(executeExpressions(variables, expressions)).toEqual(
+    new Map([["exp1", 6]])
+  );
 });
 
 test("execute expression dependent on other expressions", () => {
@@ -68,7 +72,12 @@ test("execute expression dependent on other expressions", () => {
     ["exp1", "exp0 + 1"],
     ["exp0", "var1 + 2"],
   ]);
-  expect(executeExpression("exp1", variables, expressions)).toEqual(6);
+  expect(executeExpressions(variables, expressions)).toEqual(
+    new Map([
+      ["exp1", 6],
+      ["exp0", 5],
+    ])
+  );
 });
 
 test("forbid circular expressions", () => {
@@ -79,7 +88,7 @@ test("forbid circular expressions", () => {
     ["exp2", "exp1 + 3"],
   ]);
   expect(() => {
-    executeExpression("exp1", variables, expressions);
+    executeExpressions(variables, expressions);
   }).toThrowError(/exp2 is not defined/);
 });
 
@@ -87,6 +96,6 @@ test("make sure dependency exists", () => {
   const variables = new Map();
   const expressions = new Map([["exp1", "var1 + 1"]]);
   expect(() => {
-    executeExpression("exp1", variables, expressions);
+    executeExpressions(variables, expressions);
   }).toThrowError(/Unknown dependency "var1"/);
 });

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -109,8 +109,7 @@ export const validateExpression = (
   return generateCode(expression, true, transformIdentifier);
 };
 
-export const executeExpression = (
-  expressionId: string,
+export const executeExpressions = (
   variables: Map<string, unknown>,
   expressions: Map<string, string>
 ) => {
@@ -145,6 +144,9 @@ export const executeExpression = (
   for (const [id, value] of variables) {
     header += `const ${id} = ${JSON.stringify(value)};\n`;
   }
+
+  const values = new Map<string, unknown>();
+
   for (const id of sortedExpressions) {
     const code = expressions.get(id);
     if (code === undefined) {
@@ -153,8 +155,8 @@ export const executeExpression = (
     const executeFn = new Function(`${header}\nreturn (${code});`);
     const value = executeFn();
     header += `const ${id} = ${JSON.stringify(value)};\n`;
-    if (id === expressionId) {
-      return value;
-    }
+    values.set(id, value);
   }
+
+  return values;
 };

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -160,3 +160,22 @@ export const executeExpressions = (
 
   return values;
 };
+
+const dataSourceVariablePrefix = "$ws$dataSource$";
+
+// data source id is generated with nanoid which has "-" in alphabeta
+// here "-" is encoded with "__DASH__' in variable name
+// https://github.com/ai/nanoid/blob/047686abad8f15aff05f3a2eeedb7c98b6847392/url-alphabet/index.js
+
+export const encodeDataSourceVariable = (id: string) => {
+  const encoded = id.replaceAll("-", "__DASH__");
+  return `${dataSourceVariablePrefix}${encoded}`;
+};
+
+export const decodeDataSourceVariable = (name: string) => {
+  if (name.startsWith(dataSourceVariablePrefix)) {
+    const encoded = name.slice(dataSourceVariablePrefix.length);
+    return encoded.replaceAll("__DASH__", "-");
+  }
+  return;
+};

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -20,4 +20,4 @@ export {
   getInstanceIdFromComponentProps,
 } from "./props";
 export { type Params, ReactSdkContext } from "./context";
-export { validateExpression, executeExpression } from "./expression";
+export { validateExpression, executeExpressions } from "./expression";

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -20,4 +20,9 @@ export {
   getInstanceIdFromComponentProps,
 } from "./props";
 export { type Params, ReactSdkContext } from "./context";
-export { validateExpression, executeExpressions } from "./expression";
+export {
+  validateExpression,
+  executeExpressions,
+  encodeDataSourceVariable,
+  decodeDataSourceVariable,
+} from "./expression";

--- a/packages/react-sdk/src/tree/root.ts
+++ b/packages/react-sdk/src/tree/root.ts
@@ -46,6 +46,7 @@ const computeExpressions = (
       }
     }
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error(error);
   }
   return outputValues;

--- a/packages/react-sdk/src/tree/root.ts
+++ b/packages/react-sdk/src/tree/root.ts
@@ -12,11 +12,11 @@ import { WebstudioComponent } from "./webstudio-component";
 import { getPropsByInstanceId } from "../props";
 import type { Components } from "../components/components-utils";
 import type { Params } from "../context";
-import { executeExpressions } from "../expression";
 import {
+  executeExpressions,
   encodeDataSourceVariable,
   decodeDataSourceVariable,
-} from "../embed-template";
+} from "../expression";
 
 const computeExpressions = (
   dataSources: [DataSource["id"], DataSource][],

--- a/packages/react-sdk/src/tree/root.ts
+++ b/packages/react-sdk/src/tree/root.ts
@@ -1,12 +1,55 @@
 import { useRef, type ComponentProps } from "react";
-import { atom, type WritableAtom } from "nanostores";
-import type { Build, DataSource, Page } from "@webstudio-is/project-build";
+import {
+  atom,
+  computed,
+  type ReadableAtom,
+  type WritableAtom,
+} from "nanostores";
+import { type Build, type Page, DataSource } from "@webstudio-is/project-build";
 import type { Asset } from "@webstudio-is/asset-uploader";
 import { createElementsTree } from "./create-elements-tree";
 import { WebstudioComponent } from "./webstudio-component";
 import { getPropsByInstanceId } from "../props";
 import type { Components } from "../components/components-utils";
 import type { Params } from "../context";
+import { executeExpressions } from "../expression";
+import {
+  encodeDataSourceVariable,
+  decodeDataSourceVariable,
+} from "../embed-template";
+
+const computeExpressions = (
+  dataSources: [DataSource["id"], DataSource][],
+  dataSourceValues: Map<DataSource["id"], unknown>
+) => {
+  const outputValues = new Map<DataSource["id"], unknown>();
+  const variables = new Map<string, unknown>();
+  const expressions = new Map<string, string>();
+  for (const [dataSourceId, dataSource] of dataSources) {
+    const name = encodeDataSourceVariable(dataSourceId);
+    if (dataSource.type === "variable") {
+      const value =
+        dataSourceValues.get(dataSourceId) ?? dataSource.value.value;
+      variables.set(name, value);
+      outputValues.set(dataSourceId, value);
+    }
+    if (dataSource.type === "expression") {
+      expressions.set(name, dataSource.code);
+    }
+  }
+  try {
+    const outputVariables = executeExpressions(variables, expressions);
+    for (const [name, value] of outputVariables) {
+      const id = decodeDataSourceVariable(name);
+      if (id !== undefined) {
+        outputValues.set(id, value);
+      }
+    }
+  } catch (error) {
+    console.error(error);
+  }
+  return outputValues;
+};
 
 export type Data = {
   page: Page;
@@ -31,21 +74,33 @@ export const InstanceRoot = ({
   Component,
   components,
 }: RootProps): JSX.Element | null => {
-  const dataSourceValuesStoreRef = useRef<
+  const dataSourceVariablesStoreRef = useRef<
     undefined | WritableAtom<Map<DataSource["id"], unknown>>
   >(undefined);
   // initialize store with default data source values
+  if (dataSourceVariablesStoreRef.current === undefined) {
+    const dataSourceVariables = new Map<DataSource["id"], unknown>();
+    for (const [dataSourceId, dataSource] of data.build.dataSources) {
+      dataSourceVariables.set(dataSourceId, dataSource);
+    }
+    dataSourceVariablesStoreRef.current = atom(dataSourceVariables);
+  }
+  const dataSourceVariablesStore = dataSourceVariablesStoreRef.current;
+
+  const dataSourceValuesStoreRef = useRef<
+    undefined | ReadableAtom<Map<DataSource["id"], unknown>>
+  >(undefined);
+  // initialize store with default data source values
   if (dataSourceValuesStoreRef.current === undefined) {
-    dataSourceValuesStoreRef.current = atom(
-      new Map(
-        data.build.dataSources.map(([dataSourceId, dataSource]) => [
-          dataSourceId,
-          dataSource.value,
-        ])
-      )
+    dataSourceValuesStoreRef.current = computed(
+      dataSourceVariablesStore,
+      (dataSourceVariables) => {
+        return computeExpressions(data.build.dataSources, dataSourceVariables);
+      }
     );
   }
   const dataSourceValuesStore = dataSourceValuesStoreRef.current;
+
   return createElementsTree({
     imageBaseUrl: data.params?.imageBaseUrl ?? "/",
     assetBaseUrl: data.params?.assetBaseUrl ?? "/",
@@ -58,9 +113,9 @@ export const InstanceRoot = ({
     pagesStore: atom(new Map(data.pages.map((page) => [page.id, page]))),
     dataSourceValuesStore,
     onDataSourceUpdate: (dataSourceId, value) => {
-      const dataSourceValues = new Map(dataSourceValuesStore.get());
-      dataSourceValues.set(dataSourceId, value);
-      dataSourceValuesStore.set(dataSourceValues);
+      const dataSourceVariables = new Map(dataSourceVariablesStore.get());
+      dataSourceVariables.set(dataSourceId, value);
+      dataSourceVariablesStore.set(dataSourceVariables);
     },
     Component: Component ?? WebstudioComponent,
     components,

--- a/packages/sdk-size-test/package.json
+++ b/packages/sdk-size-test/package.json
@@ -15,7 +15,7 @@
     },
     {
       "path": "functions/*.js",
-      "limit": "217 kB",
+      "limit": "229 kB",
       "gzip": false
     }
   ],

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -3,7 +3,7 @@
   "display": "Default",
   "compilerOptions": {
     "module": "ES2022",
-    "target": "ES2020",
+    "target": "ES2021",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "inlineSources": false,


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1529

Here introduced two types of data sources into "variable" and "expression". First stores the value, the second only executable code.

Execute expressions now output results of all expressions so we could access values globally with "computed" store

Embed template references now allow to define both variable reference and expression.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
