### PR TITLE
Scope data sources to instances

### DIFF
--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -275,8 +275,16 @@ export const deleteInstance = (instanceSelector: InstanceSelector) => {
       styleSourceSelectionsStore,
       styleSourcesStore,
       stylesStore,
+      dataSourcesStore,
     ],
-    (instances, props, styleSourceSelections, styleSources, styles) => {
+    (
+      instances,
+      props,
+      styleSourceSelections,
+      styleSources,
+      styles,
+      dataSources
+    ) => {
       let targetInstanceId = instanceSelector[0];
       const parentInstanceId = instanceSelector[1];
       const grandparentInstanceId = instanceSelector[2];
@@ -318,10 +326,18 @@ export const deleteInstance = (instanceSelector: InstanceSelector) => {
       for (const instanceId of instanceIds) {
         instances.delete(instanceId);
       }
-      // delete props and styles of deleted instance and its descendants
+      // delete props, data sources and styles of deleted instance and its descendants
       for (const prop of props.values()) {
         if (instanceIds.has(prop.instanceId)) {
           props.delete(prop.id);
+        }
+      }
+      for (const dataSource of dataSources.values()) {
+        if (
+          dataSource.scopeInstanceId !== undefined &&
+          instanceIds.has(dataSource.scopeInstanceId)
+        ) {
+          dataSources.delete(dataSource.id);
         }
       }
       for (const instanceId of instanceIds) {

--- a/packages/project-build/src/schema/data-sources.ts
+++ b/packages/project-build/src/schema/data-sources.ts
@@ -26,12 +26,14 @@ export const DataSource = z.union([
   z.object({
     type: z.literal("variable"),
     id: DataSourceId,
+    scopeInstanceId: z.optional(z.string()),
     name: z.string(),
     value: DataSourceVariableValue,
   }),
   z.object({
     type: z.literal("expression"),
     id: DataSourceId,
+    scopeInstanceId: z.optional(z.string()),
     name: z.string(),
     code: z.string(),
   }),

--- a/packages/react-sdk/src/embed-template.test.ts
+++ b/packages/react-sdk/src/embed-template.test.ts
@@ -281,6 +281,7 @@ test("generate data for embedding from props bound to data source variables", ()
       {
         type: "variable",
         id: expectString,
+        scopeInstanceId: expectString,
         name: "showOtherBoxDataSource",
         value: {
           type: "boolean",
@@ -363,6 +364,7 @@ test("generate data for embedding from props bound to data source expressions", 
       {
         type: "variable",
         id: expectString,
+        scopeInstanceId: expectString,
         name: "boxState",
         value: {
           type: "string",
@@ -372,6 +374,7 @@ test("generate data for embedding from props bound to data source expressions", 
       {
         type: "expression",
         id: expectString,
+        scopeInstanceId: expectString,
         name: "boxStateSuccess",
         code: expect.stringMatching(/\$ws\$dataSource\$\w+ === 'success'/),
       },

--- a/packages/react-sdk/src/embed-template.ts
+++ b/packages/react-sdk/src/embed-template.ts
@@ -136,6 +136,7 @@ const createInstancesFromTemplate = (
               dataSource = {
                 type: "variable",
                 id,
+                scopeInstanceId: instanceId,
                 name: dataSourceRef.name,
                 value: rest,
               };
@@ -144,6 +145,7 @@ const createInstancesFromTemplate = (
               dataSource = {
                 type: "expression",
                 id,
+                scopeInstanceId: instanceId,
                 name: dataSourceRef.name,
                 code: dataSourceRef.code,
               };

--- a/packages/react-sdk/src/embed-template.ts
+++ b/packages/react-sdk/src/embed-template.ts
@@ -136,6 +136,7 @@ const createInstancesFromTemplate = (
               dataSource = {
                 type: "variable",
                 id,
+                // the first instance where data source is appeared in becomes its scope
                 scopeInstanceId: instanceId,
                 name: dataSourceRef.name,
                 value: rest,

--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -37,6 +37,12 @@ test("forbid call expressions", () => {
   }).toThrowError(/Cannot call "this.fn1"/);
 });
 
+test("forbid ternary", () => {
+  expect(() => {
+    validateExpression("var1 ? var2 : var3");
+  }).toThrowError(/Ternary operator is not supported/);
+});
+
 test("forbid multiple expressions", () => {
   expect(() => {
     validateExpression("a b");

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -93,11 +93,13 @@ const generateCode = (
     }
     return "this";
   }
+  if (node.type === "ConditionalExpression") {
+    throw Error("Ternary operator is not supported");
+  }
   if (node.type === "Compound") {
     throw Error("Cannot use multiple expressions");
   }
-  // plugin is not added
-  node.type satisfies "ConditionalExpression";
+  node satisfies never;
   return "";
 };
 

--- a/packages/sdk-size-test/package.json
+++ b/packages/sdk-size-test/package.json
@@ -15,7 +15,7 @@
     },
     {
       "path": "functions/*.js",
-      "limit": "229 kB",
+      "limit": "230 kB",
       "gzip": false
     }
   ],


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/1529

Here embed template will add scope to always be shown only within instance. Before we have data sources UI the only use case is deleting data sources along with instances.

Also found jsep enable ternary by default and forbid for now caz there is no generation implemented anyway.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
