### PR TITLE
Scale blurriness fix

### DIFF
--- a/apps/builder/app/builder/features/workspace/workspace.tsx
+++ b/apps/builder/app/builder/features/workspace/workspace.tsx
@@ -58,10 +58,15 @@ const getCanvasStyle = (
     width: canvasWidth,
     height: canvasHeight ?? "100%",
     left: "50%",
-    // Chrome on Windows has a bug and makes everrything slightly blurry if scale(1) is used together with translateX.
+    // Chrome on Windows has a bug and makes everything slightly blurry if scale(1) is used together with translateX.
     // We have done a lot of comparisons between various fixes and they were producing slightly different sharpness,
     // using scale 0.9999 with opacity 0.9999 works best.
     // User Agent Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36
+    // Edition    Windows 11 Home
+    // Version    22H2
+    // Installed on    ‎10/‎18/‎2022
+    // OS build    22621.1848
+    // Experience    Windows Feature Experience Pack 1000.22642.1000.0
     transform: `scale(${scale === 1 ? 0.9999 : scale}%) translateX(-50%)`,
     opacity: 0.9999,
   };

--- a/apps/builder/app/builder/features/workspace/workspace.tsx
+++ b/apps/builder/app/builder/features/workspace/workspace.tsx
@@ -58,7 +58,12 @@ const getCanvasStyle = (
     width: canvasWidth,
     height: canvasHeight ?? "100%",
     left: "50%",
-    transform: `scale(${scale}%) translateX(-50%)`,
+    // Chrome on Windows has a bug and makes everrything slightly blurry if scale(1) is used together with translateX.
+    // We have done a lot of comparisons between various fixes and they were producing slightly different sharpness,
+    // using scale 0.9999 with opacity 0.9999 works best.
+    // User Agent Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36
+    transform: `scale(${scale === 1 ? 0.9999 : scale}%) translateX(-50%)`,
+    opacity: 0.9999,
   };
 };
 


### PR DESCRIPTION
## Description

Chrome on Windows has a bug and makes everything slightly blurry if scale(1) is used together with translateX.
We have done a lot of comparisons between various fixes and they were producing slightly different sharpness,
using scale 0.9999 with opacity 0.9999 works best.
User Agent Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36
Edition    Windows 11 Home
Version    22H2
Installed on    ‎10/‎18/‎2022
OS build    22621.1848
Experience    Windows Feature Experience Pack 1000.22642.1000.0


## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
