### PR TITLE
Override browser default tag based styles that use EM units

### DIFF
--- a/packages/react-sdk/src/css/normalize.ts
+++ b/packages/react-sdk/src/css/normalize.ts
@@ -76,7 +76,7 @@ export const li = baseStyle;
 export const ul = baseStyle;
 export const ol = baseStyle;
 
-export const p = [...baseStyle, ...presets.margins];
+export const p = [...baseStyle, ...presets.verticalMargins];
 export const span = baseStyle;
 
 // @todo for now not applied to html, as we don't have html element

--- a/packages/react-sdk/src/css/normalize.ts
+++ b/packages/react-sdk/src/css/normalize.ts
@@ -16,7 +16,7 @@
  */
 
 // webstudio custom opinionated presets
-import { borders, outline } from "./presets";
+import * as presets from "./presets";
 import type { EmbedTemplateStyleDecl } from "../embed-template";
 
 export type Styles = EmbedTemplateStyleDecl[];
@@ -37,13 +37,21 @@ const boxSizing = {
  *   box-sizing: border-box;
   }
 */
-const baseStyle = [boxSizing, ...borders, ...outline] satisfies Styles;
+const baseStyle = [
+  boxSizing,
+  ...presets.borders,
+  ...presets.outline,
+] satisfies Styles;
 
 export const div = baseStyle;
 export const address = baseStyle;
 export const article = baseStyle;
 export const aside = baseStyle;
-export const figure = baseStyle;
+export const blockquote = [
+  ...baseStyle,
+  ...presets.blockquote,
+] satisfies Styles;
+export const figure = [...baseStyle, ...presets.figure] satisfies Styles;
 export const footer = baseStyle;
 export const header = baseStyle;
 export const main = baseStyle;
@@ -52,12 +60,12 @@ export const section = baseStyle;
 export const form = baseStyle;
 export const label = baseStyle;
 
-export const h1 = baseStyle;
-export const h2 = baseStyle;
-export const h3 = baseStyle;
-export const h4 = baseStyle;
-export const h5 = baseStyle;
-export const h6 = baseStyle;
+export const h1 = [...baseStyle, ...presets.h1] satisfies Styles;
+export const h2 = [...baseStyle, ...presets.h2] satisfies Styles;
+export const h3 = [...baseStyle, ...presets.h3] satisfies Styles;
+export const h4 = [...baseStyle, ...presets.h4] satisfies Styles;
+export const h5 = [...baseStyle, ...presets.h5] satisfies Styles;
+export const h6 = [...baseStyle, ...presets.h6] satisfies Styles;
 
 export const i = baseStyle;
 
@@ -68,7 +76,7 @@ export const li = baseStyle;
 export const ul = baseStyle;
 export const ol = baseStyle;
 
-export const p = baseStyle;
+export const p = [...baseStyle, ...presets.p];
 export const span = baseStyle;
 
 // @todo for now not applied to html, as we don't have html element
@@ -94,7 +102,7 @@ export const html = [
     value: { type: "unit", value: 4, unit: "number" },
   },
   boxSizing,
-  ...borders,
+  ...presets.borders,
 ] satisfies Styles;
 
 /**
@@ -136,7 +144,7 @@ export const body = [
     value: { type: "unit", unit: "number", value: 1.2 },
   },
   boxSizing,
-  ...borders,
+  ...presets.borders,
 ] satisfies Styles;
 
 /**
@@ -155,7 +163,8 @@ export const hr = [
     value: { type: "keyword", value: "inherit" },
   },
   boxSizing,
-  ...borders,
+  ...presets.borders,
+  ...presets.hr,
 ] satisfies Styles;
 
 /**
@@ -177,7 +186,7 @@ export const b = [
     value: { type: "keyword", value: "700" },
   },
   boxSizing,
-  ...borders,
+  ...presets.borders,
 ] satisfies Styles;
 export const strong = b;
 
@@ -200,7 +209,7 @@ export const code = [
     value: { type: "unit", value: 1, unit: "em" },
   },
   boxSizing,
-  ...borders,
+  ...presets.borders,
 ] satisfies Styles;
 
 export const kbd = code;
@@ -217,7 +226,7 @@ export const small = [
     value: { type: "unit", value: 80, unit: "%" },
   },
   boxSizing,
-  ...borders,
+  ...presets.borders,
 ] satisfies Styles;
 
 /**
@@ -242,7 +251,7 @@ const subSupBase = [
     value: { type: "keyword", value: "baseline" },
   },
   boxSizing,
-  ...borders,
+  ...presets.borders,
 ] satisfies Styles;
 
 export const sub = [
@@ -277,7 +286,7 @@ export const table = [
     property: "textIndent",
     value: { type: "unit", value: 0, unit: "number" },
   },
-  ...borders,
+  ...presets.borders,
   /* 2 */
   {
     property: "borderTopColor",
@@ -340,7 +349,7 @@ const buttonBase = [
     value: { type: "unit", value: 0, unit: "number" },
   },
   boxSizing,
-  ...borders,
+  ...presets.borders,
 ] satisfies Styles;
 
 export const input = buttonBase;
@@ -427,7 +436,7 @@ export const legend = [
     value: { type: "unit", value: 0, unit: "number" },
   },
   boxSizing,
-  ...borders,
+  ...presets.borders,
 ] satisfies Styles;
 
 /**
@@ -440,7 +449,7 @@ export const progress = [
     value: { type: "keyword", value: "baseline" },
   },
   boxSizing,
-  ...borders,
+  ...presets.borders,
 ] satisfies Styles;
 
 /**
@@ -503,5 +512,5 @@ export const summary = [
     value: { type: "keyword", value: "list-item" },
   },
   boxSizing,
-  ...borders,
+  ...presets.borders,
 ] satisfies Styles;

--- a/packages/react-sdk/src/css/normalize.ts
+++ b/packages/react-sdk/src/css/normalize.ts
@@ -51,7 +51,7 @@ export const blockquote = [
   ...baseStyle,
   ...presets.blockquote,
 ] satisfies Styles;
-export const figure = [...baseStyle, ...presets.figure] satisfies Styles;
+export const figure = [...baseStyle, ...presets.marginReset] satisfies Styles;
 export const footer = baseStyle;
 export const header = baseStyle;
 export const main = baseStyle;
@@ -76,7 +76,7 @@ export const li = baseStyle;
 export const ul = baseStyle;
 export const ol = baseStyle;
 
-export const p = [...baseStyle, ...presets.p];
+export const p = [...baseStyle, ...presets.marginReset];
 export const span = baseStyle;
 
 // @todo for now not applied to html, as we don't have html element
@@ -164,7 +164,7 @@ export const hr = [
   },
   boxSizing,
   ...presets.borders,
-  ...presets.hr,
+  ...presets.marginReset,
 ] satisfies Styles;
 
 /**

--- a/packages/react-sdk/src/css/normalize.ts
+++ b/packages/react-sdk/src/css/normalize.ts
@@ -51,7 +51,7 @@ export const blockquote = [
   ...baseStyle,
   ...presets.blockquote,
 ] satisfies Styles;
-export const figure = [...baseStyle, ...presets.marginReset] satisfies Styles;
+export const figure = [...baseStyle, ...presets.margins] satisfies Styles;
 export const footer = baseStyle;
 export const header = baseStyle;
 export const main = baseStyle;
@@ -76,7 +76,7 @@ export const li = baseStyle;
 export const ul = baseStyle;
 export const ol = baseStyle;
 
-export const p = [...baseStyle, ...presets.marginReset];
+export const p = [...baseStyle, ...presets.margins];
 export const span = baseStyle;
 
 // @todo for now not applied to html, as we don't have html element
@@ -164,7 +164,7 @@ export const hr = [
   },
   boxSizing,
   ...presets.borders,
-  ...presets.marginReset,
+  ...presets.margins,
 ] satisfies Styles;
 
 /**

--- a/packages/react-sdk/src/css/presets.ts
+++ b/packages/react-sdk/src/css/presets.ts
@@ -26,7 +26,7 @@ export const outline: Styles = [
   },
 ];
 
-export const blockquote = [
+export const marginReset = [
   {
     property: "marginTop",
     value: { type: "unit", value: 0, unit: "number" },
@@ -37,12 +37,16 @@ export const blockquote = [
   },
   {
     property: "marginBottom",
-    value: { type: "unit", value: 10, unit: "px" },
+    value: { type: "unit", value: 0, unit: "px" },
   },
   {
     property: "marginLeft",
     value: { type: "unit", value: 0, unit: "number" },
   },
+] satisfies Styles;
+
+export const blockquote = [
+  ...marginReset,
   {
     property: "paddingTop",
     value: { type: "unit", value: 10, unit: "px" },
@@ -59,7 +63,6 @@ export const blockquote = [
     property: "paddingRight",
     value: { type: "unit", value: 20, unit: "px" },
   },
-
   {
     property: "borderLeftWidth",
     value: { type: "unit", value: 5, unit: "px" },
@@ -74,41 +77,16 @@ export const blockquote = [
   },
 ] satisfies Styles;
 
-export const figure = [
-  {
-    property: "marginTop",
-    value: { type: "unit", value: 0, unit: "number" },
-  },
-  {
-    property: "marginRight",
-    value: { type: "unit", value: 0, unit: "number" },
-  },
-  {
-    property: "marginBottom",
-    value: { type: "unit", value: 10, unit: "px" },
-  },
-  {
-    property: "marginLeft",
-    value: { type: "unit", value: 0, unit: "number" },
-  },
-] satisfies Styles;
-
 export const h1 = [
+  ...marginReset,
   {
     property: "fontSize",
     value: { type: "unit", value: 38, unit: "px" },
   },
-  {
-    property: "marginTop",
-    value: { type: "unit", value: 20, unit: "px" },
-  },
-  {
-    property: "marginBottom",
-    value: { type: "unit", value: 10, unit: "px" },
-  },
 ] satisfies Styles;
 
 export const h2 = [
+  ...marginReset,
   {
     property: "fontSize",
     value: { type: "unit", value: 32, unit: "px" },
@@ -116,6 +94,7 @@ export const h2 = [
 ] satisfies Styles;
 
 export const h3 = [
+  ...marginReset,
   {
     property: "fontSize",
     value: { type: "unit", value: 24, unit: "px" },
@@ -123,17 +102,15 @@ export const h3 = [
 ] satisfies Styles;
 
 export const h4 = [
+  ...marginReset,
   {
     property: "fontSize",
     value: { type: "unit", value: 18, unit: "px" },
   },
-  {
-    property: "marginBottom",
-    value: { type: "unit", value: 10, unit: "px" },
-  },
 ] satisfies Styles;
 
 export const h5 = [
+  ...marginReset,
   {
     property: "fontSize",
     value: { type: "unit", value: 14, unit: "px" },
@@ -141,30 +118,9 @@ export const h5 = [
 ] satisfies Styles;
 
 export const h6 = [
+  ...marginReset,
   {
     property: "fontSize",
     value: { type: "unit", value: 12, unit: "px" },
-  },
-] satisfies Styles;
-
-export const p = [
-  {
-    property: "marginTop",
-    value: { type: "unit", value: 0, unit: "number" },
-  },
-  {
-    property: "marginBottom",
-    value: { type: "unit", value: 10, unit: "px" },
-  },
-] satisfies Styles;
-
-export const hr = [
-  {
-    property: "marginTop",
-    value: { type: "unit", value: 8, unit: "px" },
-  },
-  {
-    property: "marginBottom",
-    value: { type: "unit", value: 8, unit: "px" },
   },
 ] satisfies Styles;

--- a/packages/react-sdk/src/css/presets.ts
+++ b/packages/react-sdk/src/css/presets.ts
@@ -25,3 +25,146 @@ export const outline: Styles = [
     value: { type: "unit", value: 1, unit: "px" },
   },
 ];
+
+export const blockquote = [
+  {
+    property: "marginTop",
+    value: { type: "unit", value: 0, unit: "number" },
+  },
+  {
+    property: "marginRight",
+    value: { type: "unit", value: 0, unit: "number" },
+  },
+  {
+    property: "marginBottom",
+    value: { type: "unit", value: 10, unit: "px" },
+  },
+  {
+    property: "marginLeft",
+    value: { type: "unit", value: 0, unit: "number" },
+  },
+  {
+    property: "paddingTop",
+    value: { type: "unit", value: 10, unit: "px" },
+  },
+  {
+    property: "paddingBottom",
+    value: { type: "unit", value: 10, unit: "px" },
+  },
+  {
+    property: "paddingLeft",
+    value: { type: "unit", value: 20, unit: "px" },
+  },
+  {
+    property: "paddingRight",
+    value: { type: "unit", value: 20, unit: "px" },
+  },
+
+  {
+    property: "borderLeftWidth",
+    value: { type: "unit", value: 5, unit: "px" },
+  },
+  {
+    property: "borderLeftStyle",
+    value: { type: "keyword", value: "solid" },
+  },
+  {
+    property: "borderLeftColor",
+    value: { type: "rgb", r: 226, g: 226, b: 226, alpha: 1 },
+  },
+] satisfies Styles;
+
+export const figure = [
+  {
+    property: "marginTop",
+    value: { type: "unit", value: 0, unit: "number" },
+  },
+  {
+    property: "marginRight",
+    value: { type: "unit", value: 0, unit: "number" },
+  },
+  {
+    property: "marginBottom",
+    value: { type: "unit", value: 10, unit: "px" },
+  },
+  {
+    property: "marginLeft",
+    value: { type: "unit", value: 0, unit: "number" },
+  },
+] satisfies Styles;
+
+export const h1 = [
+  {
+    property: "fontSize",
+    value: { type: "unit", value: 38, unit: "px" },
+  },
+  {
+    property: "marginTop",
+    value: { type: "unit", value: 20, unit: "px" },
+  },
+  {
+    property: "marginBottom",
+    value: { type: "unit", value: 10, unit: "px" },
+  },
+] satisfies Styles;
+
+export const h2 = [
+  {
+    property: "fontSize",
+    value: { type: "unit", value: 32, unit: "px" },
+  },
+] satisfies Styles;
+
+export const h3 = [
+  {
+    property: "fontSize",
+    value: { type: "unit", value: 24, unit: "px" },
+  },
+] satisfies Styles;
+
+export const h4 = [
+  {
+    property: "fontSize",
+    value: { type: "unit", value: 18, unit: "px" },
+  },
+  {
+    property: "marginBottom",
+    value: { type: "unit", value: 10, unit: "px" },
+  },
+] satisfies Styles;
+
+export const h5 = [
+  {
+    property: "fontSize",
+    value: { type: "unit", value: 14, unit: "px" },
+  },
+] satisfies Styles;
+
+export const h6 = [
+  {
+    property: "fontSize",
+    value: { type: "unit", value: 12, unit: "px" },
+  },
+] satisfies Styles;
+
+export const p = [
+  {
+    property: "marginTop",
+    value: { type: "unit", value: 0, unit: "number" },
+  },
+  {
+    property: "marginBottom",
+    value: { type: "unit", value: 10, unit: "px" },
+  },
+] satisfies Styles;
+
+export const hr = [
+  {
+    property: "marginTop",
+    value: { type: "unit", value: 8, unit: "px" },
+  },
+  {
+    property: "marginBottom",
+    value: { type: "unit", value: 8, unit: "px" },
+  },
+] satisfies Styles;

--- a/packages/react-sdk/src/css/presets.ts
+++ b/packages/react-sdk/src/css/presets.ts
@@ -29,11 +29,11 @@ export const outline: Styles = [
 export const margins = [
   {
     property: "marginTop",
-    value: { type: "unit", value: 0, unit: "number" },
+    value: { type: "unit", value: 0, unit: "px" },
   },
   {
     property: "marginRight",
-    value: { type: "unit", value: 0, unit: "number" },
+    value: { type: "unit", value: 0, unit: "px" },
   },
   {
     property: "marginBottom",
@@ -41,7 +41,18 @@ export const margins = [
   },
   {
     property: "marginLeft",
-    value: { type: "unit", value: 0, unit: "number" },
+    value: { type: "unit", value: 0, unit: "px" },
+  },
+] satisfies Styles;
+
+export const verticalMargins = [
+  {
+    property: "marginTop",
+    value: { type: "unit", value: 0, unit: "px" },
+  },
+  {
+    property: "marginBottom",
+    value: { type: "unit", value: 0, unit: "px" },
   },
 ] satisfies Styles;
 
@@ -78,7 +89,7 @@ export const blockquote = [
 ] satisfies Styles;
 
 export const h1 = [
-  ...margins,
+  ...verticalMargins,
   {
     property: "fontSize",
     value: { type: "unit", value: 38, unit: "px" },
@@ -86,7 +97,7 @@ export const h1 = [
 ] satisfies Styles;
 
 export const h2 = [
-  ...margins,
+  ...verticalMargins,
   {
     property: "fontSize",
     value: { type: "unit", value: 32, unit: "px" },
@@ -94,7 +105,7 @@ export const h2 = [
 ] satisfies Styles;
 
 export const h3 = [
-  ...margins,
+  ...verticalMargins,
   {
     property: "fontSize",
     value: { type: "unit", value: 24, unit: "px" },
@@ -102,7 +113,7 @@ export const h3 = [
 ] satisfies Styles;
 
 export const h4 = [
-  ...margins,
+  ...verticalMargins,
   {
     property: "fontSize",
     value: { type: "unit", value: 18, unit: "px" },
@@ -110,7 +121,7 @@ export const h4 = [
 ] satisfies Styles;
 
 export const h5 = [
-  ...margins,
+  ...verticalMargins,
   {
     property: "fontSize",
     value: { type: "unit", value: 14, unit: "px" },
@@ -118,7 +129,7 @@ export const h5 = [
 ] satisfies Styles;
 
 export const h6 = [
-  ...margins,
+  ...verticalMargins,
   {
     property: "fontSize",
     value: { type: "unit", value: 12, unit: "px" },

--- a/packages/react-sdk/src/css/presets.ts
+++ b/packages/react-sdk/src/css/presets.ts
@@ -26,7 +26,7 @@ export const outline: Styles = [
   },
 ];
 
-export const marginReset = [
+export const margins = [
   {
     property: "marginTop",
     value: { type: "unit", value: 0, unit: "number" },
@@ -46,7 +46,7 @@ export const marginReset = [
 ] satisfies Styles;
 
 export const blockquote = [
-  ...marginReset,
+  ...margins,
   {
     property: "paddingTop",
     value: { type: "unit", value: 10, unit: "px" },
@@ -78,7 +78,7 @@ export const blockquote = [
 ] satisfies Styles;
 
 export const h1 = [
-  ...marginReset,
+  ...margins,
   {
     property: "fontSize",
     value: { type: "unit", value: 38, unit: "px" },
@@ -86,7 +86,7 @@ export const h1 = [
 ] satisfies Styles;
 
 export const h2 = [
-  ...marginReset,
+  ...margins,
   {
     property: "fontSize",
     value: { type: "unit", value: 32, unit: "px" },
@@ -94,7 +94,7 @@ export const h2 = [
 ] satisfies Styles;
 
 export const h3 = [
-  ...marginReset,
+  ...margins,
   {
     property: "fontSize",
     value: { type: "unit", value: 24, unit: "px" },
@@ -102,7 +102,7 @@ export const h3 = [
 ] satisfies Styles;
 
 export const h4 = [
-  ...marginReset,
+  ...margins,
   {
     property: "fontSize",
     value: { type: "unit", value: 18, unit: "px" },
@@ -110,7 +110,7 @@ export const h4 = [
 ] satisfies Styles;
 
 export const h5 = [
-  ...marginReset,
+  ...margins,
   {
     property: "fontSize",
     value: { type: "unit", value: 14, unit: "px" },
@@ -118,7 +118,7 @@ export const h5 = [
 ] satisfies Styles;
 
 export const h6 = [
-  ...marginReset,
+  ...margins,
   {
     property: "fontSize",
     value: { type: "unit", value: 12, unit: "px" },

--- a/packages/sdk-components-react/src/blockquote.ws.tsx
+++ b/packages/sdk-components-react/src/blockquote.ws.tsx
@@ -5,58 +5,12 @@ import {
   type WsComponentMeta,
   type WsComponentPropsMeta,
 } from "@webstudio-is/react-sdk";
+import { blockquote } from "@webstudio-is/react-sdk/css-normalize";
 import type { defaultTag } from "./blockquote";
 import { props } from "./__generated__/blockquote.props";
 
 const presetStyle = {
-  blockquote: [
-    {
-      property: "marginTop",
-      value: { type: "unit", value: 0, unit: "number" },
-    },
-    {
-      property: "marginRight",
-      value: { type: "unit", value: 0, unit: "number" },
-    },
-    {
-      property: "marginBottom",
-      value: { type: "unit", value: 10, unit: "px" },
-    },
-    {
-      property: "marginLeft",
-      value: { type: "unit", value: 0, unit: "number" },
-    },
-
-    {
-      property: "paddingTop",
-      value: { type: "unit", value: 10, unit: "px" },
-    },
-    {
-      property: "paddingBottom",
-      value: { type: "unit", value: 10, unit: "px" },
-    },
-    {
-      property: "paddingLeft",
-      value: { type: "unit", value: 20, unit: "px" },
-    },
-    {
-      property: "paddingRight",
-      value: { type: "unit", value: 20, unit: "px" },
-    },
-
-    {
-      property: "borderLeftWidth",
-      value: { type: "unit", value: 5, unit: "px" },
-    },
-    {
-      property: "borderLeftStyle",
-      value: { type: "keyword", value: "solid" },
-    },
-    {
-      property: "borderLeftColor",
-      value: { type: "rgb", r: 226, g: 226, b: 226, alpha: 1 },
-    },
-  ],
+  blockquote,
 } satisfies PresetStyle<typeof defaultTag>;
 
 export const meta: WsComponentMeta = {


### PR DESCRIPTION
## Description

EM seems to be challenging to use and people tend to use PX or REM instead ... I changed those values that come with EM by default from browsers to the values Webflow is using.


I am not sure why webflow is doing certain things: e.g. paragraphs have marginTop 0, h1-3 have marginTop 20; marginBottom: 10, h4- have marginTop 10 ; marginBottom 20

These seem to be inconsistent and weird choices.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
