### PR TITLE
Support generating expressions code

### DIFF
--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -119,7 +119,7 @@ test("forbid circular expressions", () => {
   ]);
   expect(() => {
     executeExpressions(variables, expressions);
-  }).toThrowError(/Cannot access 'exp2' before initialization/);
+  }).toThrowError(/Cannot access 'exp0' before initialization/);
 });
 
 test("make sure dependency exists", () => {

--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -63,7 +63,7 @@ test("transform identifiers", () => {
 });
 
 test("generate expressions computation", () => {
-  const variables = new Map([["var1", 3]]);
+  const variables = new Set(["var1"]);
   const expressions = new Map([
     ["exp0", "var1 + 2"],
     ["exp1", "exp0 + 1"],

--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -63,19 +63,25 @@ test("transform identifiers", () => {
 });
 
 test("generate expressions computation", () => {
-  const variables = new Set(["var1"]);
+  const variables = new Set(["var0"]);
   const expressions = new Map([
-    ["exp0", "var1 + 2"],
-    ["exp1", "exp0 + 1"],
+    ["exp3", "exp2 + exp1"],
+    ["exp1", "var0"],
+    ["exp2", "exp1"],
+    ["exp4", "exp2"],
   ]);
   expect(generateExpressionsComputation(variables, expressions))
     .toMatchInlineSnapshot(`
-    "const var1 = _variables.get('var1');
-    const exp0 = (var1 + 2);
-    const exp1 = (exp0 + 1);
+    "const var0 = _variables.get('var0');
+    const exp1 = (var0);
+    const exp2 = (exp1);
+    const exp3 = (exp2 + exp1);
+    const exp4 = (exp2);
     return new Map([
-      ['exp0', exp0],
       ['exp1', exp1],
+      ['exp2', exp2],
+      ['exp3', exp3],
+      ['exp4', exp4],
     ]);"
   `);
 });

--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -3,6 +3,7 @@ import {
   decodeDataSourceVariable,
   encodeDataSourceVariable,
   executeExpressions,
+  generateExpressionsComputation,
   validateExpression,
 } from "./expression";
 
@@ -61,6 +62,24 @@ test("transform identifiers", () => {
   );
 });
 
+test("generate expressions computation", () => {
+  const variables = new Map([["var1", 3]]);
+  const expressions = new Map([
+    ["exp0", "var1 + 2"],
+    ["exp1", "exp0 + 1"],
+  ]);
+  expect(generateExpressionsComputation(variables, expressions))
+    .toMatchInlineSnapshot(`
+    "const var1 = _variables.get('var1');
+    const exp0 = (var1 + 2);
+    const exp1 = (exp0 + 1);
+    return new Map([
+      ['exp0', exp0],
+      ['exp1', exp1],
+    ]);"
+  `);
+});
+
 test("execute expression", () => {
   const variables = new Map();
   const expressions = new Map([["exp1", "1 + 1"]]);
@@ -77,7 +96,7 @@ test("execute expression dependent on variables", () => {
   );
 });
 
-test("execute expression dependent on other expressions", () => {
+test("execute expression dependent on another expressions", () => {
   const variables = new Map([["var1", 3]]);
   const expressions = new Map([
     ["exp1", "exp0 + 1"],
@@ -100,7 +119,7 @@ test("forbid circular expressions", () => {
   ]);
   expect(() => {
     executeExpressions(variables, expressions);
-  }).toThrowError(/exp2 is not defined/);
+  }).toThrowError(/Cannot access 'exp2' before initialization/);
 });
 
 test("make sure dependency exists", () => {

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -119,7 +119,7 @@ const sortTopologically = (
 ) => {
   for (const id of list) {
     if (explored.has(id)) {
-      return sorted;
+      continue;
     }
     explored.add(id);
     const deps = depsById.get(id);

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -136,7 +136,7 @@ const sortTopologically = (
  * and outputing map of results
  */
 export const generateExpressionsComputation = (
-  variables: Map<string, unknown>,
+  variables: Set<string>,
   expressions: Map<string, string>
 ) => {
   const depsById = new Map<string, Set<string>>();
@@ -163,7 +163,7 @@ export const generateExpressionsComputation = (
   // generate code comoputing all expressions
   let generatedCode = "";
 
-  for (const id of variables.keys()) {
+  for (const id of variables) {
     generatedCode += `const ${id} = _variables.get('${id}');\n`;
   }
 
@@ -188,7 +188,10 @@ export const executeExpressions = (
   variables: Map<string, unknown>,
   expressions: Map<string, string>
 ) => {
-  const generatedCode = generateExpressionsComputation(variables, expressions);
+  const generatedCode = generateExpressionsComputation(
+    new Set(variables.keys()),
+    expressions
+  );
   const executeFn = new Function("_variables", generatedCode);
   const values = executeFn(variables) as Map<string, unknown>;
   return values;

--- a/packages/react-sdk/src/expression.ts
+++ b/packages/react-sdk/src/expression.ts
@@ -160,7 +160,7 @@ export const generateExpressionsComputation = (
     depsById
   );
 
-  // generate code comoputing all expressions
+  // generate code computing all expressions
   let generatedCode = "";
 
   for (const id of variables) {

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -22,6 +22,7 @@ export {
 export { type Params, ReactSdkContext } from "./context";
 export {
   validateExpression,
+  generateExpressionsComputation,
   executeExpressions,
   encodeDataSourceVariable,
   decodeDataSourceVariable,


### PR DESCRIPTION
Here added another expression utility to generate function body generateExpressionsComputation.

InstanceRoot now requires computeExpressions(variables) prop which can be generated build time.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
