### PR TITLE
Fix numeric scrub in case of body is scrollable

### DIFF
--- a/packages/design-system/src/components/primitives/numeric-gesture-control.ts
+++ b/packages/design-system/src/components/primitives/numeric-gesture-control.ts
@@ -258,7 +258,7 @@ const requestPointerLock = (
     cursorNode.style.filter = `drop-shadow(${
       state.direction === "horizontal" ? "0 1px" : "1px 0"
     } 1.1px rgba(0,0,0,.4))`;
-    cursorNode.style.position = "absolute";
+    cursorNode.style.position = "fixed";
     cursorNode.style.zIndex = Number.MAX_SAFE_INTEGER.toString();
     cursorNode.style.left = `${event.clientX}px`;
     cursorNode.style.top = `${event.clientY}px`;


### PR DESCRIPTION
## Description

Affects storybook env, in the buider we don't have scorllable body so cursor doesn't cause body to overflow

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
