### PR TITLE
StyleInfo unification

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-sections.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-sections.tsx
@@ -1,7 +1,7 @@
 import { Grid } from "@webstudio-is/design-system";
 import { toValue } from "@webstudio-is/css-engine";
 import { styleConfigByName } from "./shared/configs";
-import type { Style, StyleProperty } from "@webstudio-is/css-data";
+import type { StyleProperty } from "@webstudio-is/css-data";
 import type {
   SetProperty,
   DeleteProperty,
@@ -119,11 +119,11 @@ export const renderCategory = ({
 
 export const shouldRenderCategory = (
   { currentStyle, category }: RenderCategoryProps,
-  parentStyle: Style
+  parentStyle: StyleInfo
 ) => {
   switch (category) {
     case "flexChild":
-      return toValue(parentStyle.display).includes("flex");
+      return toValue(parentStyle.display?.value).includes("flex");
     case "gridChild":
       return toValue(currentStyle.display?.value).includes("grid");
   }

--- a/apps/builder/app/builder/features/style-panel/style-settings.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-settings.tsx
@@ -10,7 +10,7 @@ import type { SetProperty, CreateBatchUpdate } from "./shared/use-style-data";
 import type { StyleInfo } from "./shared/style-info";
 import { useStore } from "@nanostores/react";
 import { selectedInstanceSelectorStore } from "~/shared/nano-states";
-import { useInstanceStyleData } from "./shared/style-info";
+import { useStyleInfoByInstanceId } from "./shared/style-info";
 
 export type StyleSettingsProps = {
   currentStyle: StyleInfo;
@@ -26,8 +26,9 @@ const useParentStyle = () => {
     selectedInstanceSelector?.length === 1
       ? undefined
       : selectedInstanceSelector?.slice(1);
-  const parentInstanceStyleData = useInstanceStyleData(parentInstanceSelector);
-  return parentInstanceStyleData;
+  const parentStyleInfo = useStyleInfoByInstanceId(parentInstanceSelector);
+
+  return parentStyleInfo;
 };
 
 export const StyleSettings = ({


### PR DESCRIPTION
## Description

Use same code to get StyleInformation by instanceId as was used for selectedInstanceId.

Works  right only for the ancestors of selected element


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
