### PR TITLE
Fix text toolbar overflow

### DIFF
--- a/apps/builder/app/builder/features/workspace/canvas-tools/text-toolbar.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/text-toolbar.tsx
@@ -67,7 +67,9 @@ const Toolbar = ({ state, onToggle }: ToolbarProps) => {
       };
       computePosition(reference, floating, {
         placement: "top",
-        middleware: [flip(), shift({ padding: 4 }), offset(12)],
+        // offset should be first for shift and flip
+        // to consider it while detecting overflow
+        middleware: [offset(12), shift({ padding: 4 }), flip()],
       }).then(({ x, y }) => {
         floating.style.transform = `translate(${x}px, ${y}px)`;
       });

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -17,7 +17,7 @@
     "ci:migrate": "migrations migrate --force"
   },
   "dependencies": {
-    "@floating-ui/dom": "^1.0.6",
+    "@floating-ui/dom": "^1.4.4",
     "@fontsource/inter": "^4.5.15",
     "@fontsource/manrope": "^4.5.13",
     "@fontsource/roboto-mono": "^4.5.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
   apps/builder:
     dependencies:
       '@floating-ui/dom':
-        specifier: ^1.0.6
-        version: 1.0.6
+        specifier: ^1.4.4
+        version: 1.4.4
       '@fontsource/inter':
         specifier: ^4.5.15
         version: 4.5.15
@@ -5053,22 +5053,12 @@ packages:
   /@fal-works/esbuild-plugin-global-externals@2.1.2:
     resolution: {integrity: sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==}
 
-  /@floating-ui/core@1.0.2:
-    resolution: {integrity: sha512-Skfy0YS3NJ5nV9us0uuPN0HDk1Q4edljaOhRBJGDWs9EBa7ZVMYBHRFlhLvvmwEoaIM9BlH6QJFn9/uZg0bACg==}
-    dev: false
-
   /@floating-ui/core@1.3.1:
     resolution: {integrity: sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g==}
     dev: false
 
-  /@floating-ui/dom@1.0.6:
-    resolution: {integrity: sha512-kt/tg1oip9OAH1xjCTcx1OpcUpu9rjDw3GKJ/rEhUqhO7QyJWfrHU0DpLTNsH67+JyFL5Kv9X1utsXwKFVtyEQ==}
-    dependencies:
-      '@floating-ui/core': 1.0.2
-    dev: false
-
-  /@floating-ui/dom@1.4.2:
-    resolution: {integrity: sha512-VKmvHVatWnewmGGy+7Mdy4cTJX71Pli6v/Wjb5RQBuq5wjUYx+Ef+kRThi8qggZqDgD8CogCpqhRoVp3+yQk+g==}
+  /@floating-ui/dom@1.4.4:
+    resolution: {integrity: sha512-21hhDEPOiWkGp0Ys4Wi6Neriah7HweToKra626CIK712B5m9qkdz54OP9gVldUg+URnBTpv/j/bi/skmGdstXQ==}
     dependencies:
       '@floating-ui/core': 1.3.1
     dev: false
@@ -5079,7 +5069,7 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@floating-ui/dom': 1.4.2
+      '@floating-ui/dom': 1.4.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false


### PR DESCRIPTION
This fixes an issue with text toolbar below top navigation because of wrong middlewares order. Here used the right order and bumped/deduped floating-ui.

## Code Review

- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
