### PR TITLE
Fix toggle group focus interfere, show error in storybook

### DIFF
--- a/packages/design-system/src/components/icon-button.tsx
+++ b/packages/design-system/src/components/icon-button.tsx
@@ -27,6 +27,7 @@ export const IconButton = styled("button", {
 
   "&[data-focused=true], &:focus-visible": {
     outline: `2px solid ${theme.colors.borderFocus}`,
+    outlineOffset: -2,
   },
 
   "&:disabled": {

--- a/packages/design-system/src/components/icon-button.tsx
+++ b/packages/design-system/src/components/icon-button.tsx
@@ -40,7 +40,7 @@ export const IconButton = styled("button", {
     borderColor: "transparent",
     backgroundColor: theme.colors.backgroundActive,
     color: theme.colors.foregroundContrastMain,
-    "&:hover": {
+    "&:hover, &[data-hovered=true]": {
       borderColor: "transparent",
       backgroundColor: theme.colors.backgroundActive,
       color: theme.colors.foregroundContrastMain,
@@ -51,7 +51,7 @@ export const IconButton = styled("button", {
     variant: {
       default: {
         color: theme.colors.foregroundMain,
-        "&:hover": {
+        "&:hover, &[data-hovered=true]": {
           backgroundColor: theme.colors.backgroundHover,
         },
         // According to the design https://www.figma.com/file/sfCE7iLS0k25qCxiifQNLE/%F0%9F%93%9A-Webstudio-Library?node-id=4-3199&t=lpT9jFuaiUnz1Foa-0
@@ -61,7 +61,7 @@ export const IconButton = styled("button", {
           backgroundColor: theme.colors.backgroundPresetMain,
           borderColor: theme.colors.borderMain,
 
-          "&:hover": {
+          "&:hover, &[data-hovered=true]": {
             backgroundColor: theme.colors.backgroundHover,
           },
         },
@@ -75,7 +75,7 @@ export const IconButton = styled("button", {
         backgroundColor: theme.colors.backgroundPresetMain,
         borderColor: theme.colors.borderMain,
         color: theme.colors.foregroundMain,
-        "&:hover": {
+        "&:hover, &[data-hovered=true]": {
           backgroundColor: theme.colors.backgroundPresetHover,
         },
         "&:disabled": {
@@ -87,7 +87,7 @@ export const IconButton = styled("button", {
         backgroundColor: theme.colors.backgroundLocalMain,
         borderColor: theme.colors.borderLocalMain,
         color: theme.colors.foregroundLocalMain,
-        "&:hover": {
+        "&:hover, &[data-hovered=true]": {
           backgroundColor: theme.colors.backgroundLocalHover,
         },
         "&:disabled": {
@@ -99,7 +99,7 @@ export const IconButton = styled("button", {
         backgroundColor: theme.colors.backgroundOverwrittenMain,
         borderColor: theme.colors.borderOverwrittenMain,
         color: theme.colors.foregroundOverwrittenMain,
-        "&:hover": {
+        "&:hover, &[data-hovered=true]": {
           backgroundColor: theme.colors.backgroundOverwrittenHover,
         },
         "&:disabled": {
@@ -111,7 +111,7 @@ export const IconButton = styled("button", {
         backgroundColor: theme.colors.backgroundRemoteMain,
         borderColor: theme.colors.borderRemoteMain,
         color: theme.colors.foregroundRemoteMain,
-        "&:hover": {
+        "&:hover, &[data-hovered=true]": {
           backgroundColor: theme.colors.backgroundRemoteHover,
         },
         "&:disabled": {

--- a/packages/design-system/src/components/toggle-group.stories.tsx
+++ b/packages/design-system/src/components/toggle-group.stories.tsx
@@ -18,16 +18,21 @@ const ToggleGroupButtons = () => {
       <ToggleGroupButton value="one">
         <BorderRadiusIndividualIcon fill="currentColor" />
       </ToggleGroupButton>
-      <ToggleGroupButton value="two">
+      <ToggleGroupButton value="two" data-focused={true}>
         <BorderRadiusIndividualIcon fill="currentColor" />
       </ToggleGroupButton>
-      <ToggleGroupButton value="three">
+      <ToggleGroupButton value="three" data-hovered={true}>
         <BorderRadiusIndividualIcon fill="currentColor" />
       </ToggleGroupButton>
       <ToggleGroupButton value="four">
         <BorderRadiusIndividualIcon fill="currentColor" />
       </ToggleGroupButton>
-      <ToggleGroupButton value="five">
+      <ToggleGroupButton
+        value="five"
+        data-hovered={true}
+        data-focused={true}
+        aria-checked={true}
+      >
         <BorderRadiusIndividualIcon fill="currentColor" />
       </ToggleGroupButton>
       <ToggleGroupButton value="six">

--- a/packages/design-system/src/components/toggle-group.tsx
+++ b/packages/design-system/src/components/toggle-group.tsx
@@ -61,13 +61,20 @@ export const ToggleGroup = styled(BaseToggleGroup, {
   borderRadius: theme.borderRadius[4],
 });
 
+const IconButtonStyled = styled(IconButton, {
+  "&[data-focused=true], &:focus-visible": {
+    // To not overlap focus-ring by the next button
+    zIndex: 0,
+  },
+});
+
 const BaseToggleGroupButton = forwardRef<
   ElementRef<"button">,
   ComponentProps<typeof IconButton>
 >((props, ref) => {
   const { color } = useContext(ToggleGroupContext);
   return (
-    <IconButton
+    <IconButtonStyled
       ref={ref}
       {...props}
       variant={

--- a/packages/design-system/src/components/toggle-group.tsx
+++ b/packages/design-system/src/components/toggle-group.tsx
@@ -91,8 +91,8 @@ const BaseToggleGroupButton = forwardRef<
         height: theme.spacing[11],
         minWidth: theme.spacing[11],
         // accept only 16px icons or text
-        paddingLeft: theme.spacing[3],
-        paddingRight: theme.spacing[3],
+        // paddingLeft: theme.spacing[3],
+        // paddingRight: theme.spacing[3],
         borderRadius: theme.borderRadius[2],
         ...textVariants.labelsTitleCase,
       }}

--- a/packages/design-system/src/components/toggle-group.tsx
+++ b/packages/design-system/src/components/toggle-group.tsx
@@ -90,9 +90,6 @@ const BaseToggleGroupButton = forwardRef<
         width: "auto",
         height: theme.spacing[11],
         minWidth: theme.spacing[11],
-        // accept only 16px icons or text
-        // paddingLeft: theme.spacing[3],
-        // paddingRight: theme.spacing[3],
         borderRadius: theme.borderRadius[2],
         ...textVariants.labelsTitleCase,
       }}


### PR DESCRIPTION
## Description

Error:

- [x] - <img width="112" alt="image" src="https://github.com/webstudio-is/webstudio-builder/assets/5077042/ea3d781d-2f8b-403a-847f-8b01b3675f8e">
- [x] - fixed toggle group button size was 26px must be 24px
- [x] - also made outline offset -2px 


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
