### PR TITLE
Fix ending contenteditable mode layout recalc

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
@@ -20,6 +20,7 @@ import {
   type FocusEvent,
   type ReactNode,
 } from "react";
+import { useContentEditable } from "~/shared/dom-hooks";
 
 const menuTriggerVisibilityVar = cssVars.define("menu-trigger-visibility");
 const menuTriggerVisibilityOverrideVar = cssVars.define(
@@ -109,87 +110,6 @@ const Menu = (props: MenuProps) => {
 
 export type ItemSource = "token" | "tag" | "local";
 
-const useEditableText = ({
-  isEditable,
-  isEditing,
-  onChangeEditing,
-  onChangeValue,
-}: {
-  isEditable: boolean;
-  isEditing: boolean;
-  onChangeEditing: (isEditing: boolean) => void;
-  onChangeValue: (value: string) => void;
-}) => {
-  const elementRef = useRef<HTMLDivElement>(null);
-  const lastValueRef = useRef<string>("");
-  const getValue = () => elementRef.current?.textContent ?? "";
-
-  useEffect(() => {
-    const element = elementRef.current;
-    if (element === null) {
-      return;
-    }
-
-    if (isEditing) {
-      element.setAttribute("contenteditable", "plaintext-only");
-      // the next frame is necessary when newly created element
-      // need to get focus, for example after duplicate operation
-      requestAnimationFrame(() => {
-        element.focus();
-        getSelection()?.selectAllChildren(element);
-        lastValueRef.current = getValue();
-      });
-      return;
-    }
-    if (element.hasAttribute("contenteditable")) {
-      element.removeAttribute("contenteditable");
-      // This is needed to force layout to recalc max-width when editing is done,
-      // because otherwise, layout will keep the value from before engaging contenteditable.
-      const { parentElement } = element;
-      if (parentElement) {
-        parentElement.removeChild(element);
-        parentElement.appendChild(element);
-      }
-    }
-  }, [isEditing]);
-
-  const handleFinishEditing = (
-    event: KeyboardEvent<Element> | FocusEvent<Element>
-  ) => {
-    event.preventDefault();
-    if (isEditing) {
-      onChangeEditing(false);
-    }
-    onChangeValue(getValue());
-    lastValueRef.current = "";
-  };
-
-  const handleKeyDown: KeyboardEventHandler = (event) => {
-    if (event.key === "Enter") {
-      handleFinishEditing(event);
-      return;
-    }
-    if (event.key === "Escape" && elementRef.current !== null) {
-      elementRef.current.textContent = lastValueRef.current;
-      handleFinishEditing(event);
-    }
-  };
-
-  const handleDoubleClick = () => {
-    if (isEditable) {
-      onChangeEditing(true);
-    }
-  };
-
-  const handlers = {
-    onKeyDown: handleKeyDown,
-    onBlur: handleFinishEditing,
-    onDoubleClick: handleDoubleClick,
-  };
-
-  return { ref: elementRef, handlers };
-};
-
 type EditableTextProps = {
   label: string;
   isEditable: boolean;
@@ -205,7 +125,7 @@ const EditableText = ({
   onChangeEditing,
   onChangeValue,
 }: EditableTextProps) => {
-  const { ref, handlers } = useEditableText({
+  const { ref, handlers } = useContentEditable({
     isEditable,
     isEditing,
     onChangeEditing,

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
@@ -11,15 +11,7 @@ import {
   Flex,
 } from "@webstudio-is/design-system";
 import { ChevronDownIcon } from "@webstudio-is/icons";
-import {
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  type KeyboardEvent,
-  type KeyboardEventHandler,
-  type FocusEvent,
-  type ReactNode,
-} from "react";
+import { useLayoutEffect, useRef, type ReactNode } from "react";
 import { useContentEditable } from "~/shared/dom-hooks";
 
 const menuTriggerVisibilityVar = cssVars.define("menu-trigger-visibility");

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
@@ -141,8 +141,16 @@ const useEditableText = ({
       });
       return;
     }
-
-    element.removeAttribute("contenteditable");
+    if (element.hasAttribute("contenteditable")) {
+      element.removeAttribute("contenteditable");
+      // This is needed to force layout to recalc max-width when editing is done,
+      // because otherwise, layout will keep the value from before engaging contenteditable.
+      const { parentElement } = element;
+      if (parentElement) {
+        parentElement.removeChild(element);
+        parentElement.appendChild(element);
+      }
+    }
   }, [isEditing]);
 
   const handleFinishEditing = (

--- a/apps/builder/app/shared/dom-hooks/index.ts
+++ b/apps/builder/app/shared/dom-hooks/index.ts
@@ -1,1 +1,2 @@
 export * from "./use-window-resize";
+export * from "./use-content-editable";

--- a/apps/builder/app/shared/dom-hooks/use-content-editable.ts
+++ b/apps/builder/app/shared/dom-hooks/use-content-editable.ts
@@ -31,7 +31,7 @@ export const useContentEditable = ({
     if (element.hasAttribute("contenteditable") === isEditing) {
       return;
     }
-    console.log({ isEditing });
+
     if (isEditing) {
       element.setAttribute("contenteditable", "plaintext-only");
       // the next frame is necessary when newly created element

--- a/apps/builder/app/shared/dom-hooks/use-content-editable.ts
+++ b/apps/builder/app/shared/dom-hooks/use-content-editable.ts
@@ -27,6 +27,11 @@ export const useContentEditable = ({
       return;
     }
 
+    // Nothing changed, do nothing
+    if (element.hasAttribute("contenteditable") === isEditing) {
+      return;
+    }
+    console.log({ isEditing });
     if (isEditing) {
       element.setAttribute("contenteditable", "plaintext-only");
       // the next frame is necessary when newly created element
@@ -38,15 +43,14 @@ export const useContentEditable = ({
       });
       return;
     }
-    if (element.hasAttribute("contenteditable")) {
-      element.removeAttribute("contenteditable");
-      // This is needed to force layout to recalc max-width when editing is done,
-      // because otherwise, layout will keep the value from before engaging contenteditable.
-      const { parentElement } = element;
-      if (parentElement) {
-        parentElement.removeChild(element);
-        parentElement.appendChild(element);
-      }
+
+    element.removeAttribute("contenteditable");
+    // This is needed to force layout to recalc max-width when editing is done,
+    // because otherwise, layout will keep the value from before engaging contenteditable.
+    const { parentElement } = element;
+    if (parentElement) {
+      parentElement.removeChild(element);
+      parentElement.appendChild(element);
     }
   }, [isEditing]);
 

--- a/apps/builder/app/shared/dom-hooks/use-content-editable.ts
+++ b/apps/builder/app/shared/dom-hooks/use-content-editable.ts
@@ -1,0 +1,88 @@
+import {
+  useRef,
+  type FocusEvent,
+  type KeyboardEvent,
+  type KeyboardEventHandler,
+  useEffect,
+} from "react";
+
+export const useContentEditable = ({
+  isEditable,
+  isEditing,
+  onChangeEditing,
+  onChangeValue,
+}: {
+  isEditable: boolean;
+  isEditing: boolean;
+  onChangeEditing: (isEditing: boolean) => void;
+  onChangeValue: (value: string) => void;
+}) => {
+  const elementRef = useRef<HTMLDivElement>(null);
+  const lastValueRef = useRef<string>("");
+  const getValue = () => elementRef.current?.textContent ?? "";
+
+  useEffect(() => {
+    const element = elementRef.current;
+    if (element === null) {
+      return;
+    }
+
+    if (isEditing) {
+      element.setAttribute("contenteditable", "plaintext-only");
+      // the next frame is necessary when newly created element
+      // need to get focus, for example after duplicate operation
+      requestAnimationFrame(() => {
+        element.focus();
+        getSelection()?.selectAllChildren(element);
+        lastValueRef.current = getValue();
+      });
+      return;
+    }
+    if (element.hasAttribute("contenteditable")) {
+      element.removeAttribute("contenteditable");
+      // This is needed to force layout to recalc max-width when editing is done,
+      // because otherwise, layout will keep the value from before engaging contenteditable.
+      const { parentElement } = element;
+      if (parentElement) {
+        parentElement.removeChild(element);
+        parentElement.appendChild(element);
+      }
+    }
+  }, [isEditing]);
+
+  const handleFinishEditing = (
+    event: KeyboardEvent<Element> | FocusEvent<Element>
+  ) => {
+    event.preventDefault();
+    if (isEditing) {
+      onChangeEditing(false);
+    }
+    onChangeValue(getValue());
+    lastValueRef.current = "";
+  };
+
+  const handleKeyDown: KeyboardEventHandler = (event) => {
+    if (event.key === "Enter") {
+      handleFinishEditing(event);
+      return;
+    }
+    if (event.key === "Escape" && elementRef.current !== null) {
+      elementRef.current.textContent = lastValueRef.current;
+      handleFinishEditing(event);
+    }
+  };
+
+  const handleDoubleClick = () => {
+    if (isEditable) {
+      onChangeEditing(true);
+    }
+  };
+
+  const handlers = {
+    onKeyDown: handleKeyDown,
+    onBlur: handleFinishEditing,
+    onDoubleClick: handleDoubleClick,
+  };
+
+  return { ref: elementRef, handlers };
+};


### PR DESCRIPTION
## Description

Bug discovered in this PR https://github.com/webstudio-is/webstudio-builder/pull/1909

When ending contenteditable, parent doesn't recalc the size of contents, so I have to detouch and reinsert the edited element to force it.

## Steps for reproduction

1. start editing style source name and put a LOT of characters
2. exit editing mode
3. before: it would have empty container
4. now: renders and shows ellipsis

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
