### PR TITLE
Fix invalid ancestors for deeply nested instances

### DIFF
--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -67,7 +67,7 @@ export const NavigatorTree = () => {
       }
     }
     return Array.from(dragComponents);
-  }, [dragPayload, instances]);
+  }, [dragPayload, instances, metas]);
 
   const findClosestDroppableIndex = useCallback(
     (instanceSelector: InstanceSelector) => {

--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useMemo } from "react";
 import { useStore } from "@nanostores/react";
 import { shallowEqual } from "shallow-equal";
-import type { Instance } from "@webstudio-is/project-build";
+import {
+  findTreeInstanceIds,
+  type Instance,
+} from "@webstudio-is/project-build";
 import {
   hoveredInstanceSelectorStore,
   instancesStore,
@@ -18,6 +21,7 @@ import {
   reparentInstance,
 } from "~/shared/instance-utils";
 import { InstanceTree } from "./tree";
+import { generateDataFromEmbedTemplate } from "@webstudio-is/react-sdk";
 
 export const NavigatorTree = () => {
   const selectedInstanceSelector = useStore(selectedInstanceSelectorStore);
@@ -33,24 +37,40 @@ export const NavigatorTree = () => {
       ? dragPayload.dragInstanceSelector
       : undefined;
 
-  const dragComponent = useMemo(() => {
-    let dragComponent: undefined | string;
+  // collect components of drag component and all its descendants
+  const dragComponents = useMemo(() => {
+    const dragComponents = new Set<Instance["component"]>();
     if (dragPayload?.type === "insert") {
-      dragComponent = dragPayload.dragComponent;
+      const template = metas.get(dragPayload.dragComponent)?.template;
+      if (template) {
+        // ignore breakpoint, here only instances are important
+        // @todo optimize by traversing only instances
+        const { instances } = generateDataFromEmbedTemplate(
+          template,
+          "__placeholder__"
+        );
+        for (const instance of instances) {
+          dragComponents.add(instance.component);
+        }
+      }
     }
     if (dragPayload?.type === "reparent") {
-      dragComponent = instances.get(
+      const instanceIds = findTreeInstanceIds(
+        instances,
         dragPayload.dragInstanceSelector[0]
-      )?.component;
+      );
+      for (const instanceId of instanceIds) {
+        const instance = instances.get(instanceId);
+        if (instance) {
+          dragComponents.add(instance.component);
+        }
+      }
     }
-    return dragComponent;
+    return Array.from(dragComponents);
   }, [dragPayload, instances]);
 
   const findClosestDroppableIndex = useCallback(
     (instanceSelector: InstanceSelector) => {
-      if (dragComponent === undefined) {
-        return -1;
-      }
       const componentSelector: string[] = [];
       for (const instanceId of instanceSelector) {
         const component = instances.get(instanceId)?.component;
@@ -59,11 +79,13 @@ export const NavigatorTree = () => {
         }
         componentSelector.push(component);
       }
-      return findClosestDroppableComponentIndex(metas, componentSelector, [
-        dragComponent,
-      ]);
+      return findClosestDroppableComponentIndex(
+        metas,
+        componentSelector,
+        dragComponents
+      );
     },
-    [instances, metas, dragComponent]
+    [instances, metas, dragComponents]
   );
 
   const isItemHidden = useCallback(

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -270,12 +270,14 @@ export const onPaste = (clipboardData: string) => {
   const instanceSelector = selectedInstanceSelectorStore.get() ?? [
     selectedPage.rootInstanceId,
   ];
-  const dragComponent = data.instances[0].component;
+  const dragComponents = Array.from(
+    new Set(data.instances.map((instance) => instance.component))
+  );
   const dropTarget = findClosestDroppableTarget(
     registeredComponentMetasStore.get(),
     instancesStore.get(),
     instanceSelector,
-    [dragComponent]
+    dragComponents
   );
   if (dropTarget === undefined) {
     return;

--- a/apps/builder/app/shared/copy-paste/plugin-markdown.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-markdown.ts
@@ -206,16 +206,9 @@ export const onPaste = (clipboardData: string) => {
   const instanceSelector = selectedInstanceSelectorStore.get() ?? [
     selectedPage.rootInstanceId,
   ];
-  const instances = instancesStore.get();
-  const dragComponents = [];
-  for (const child of data.children) {
-    if (child.type === "id") {
-      const component = instances.get(child.value)?.component;
-      if (component !== undefined) {
-        dragComponents.push(component);
-      }
-    }
-  }
+  const dragComponents = Array.from(
+    new Set(data.instances.map((instance) => instance.component))
+  );
   const dropTarget = findClosestDroppableTarget(
     registeredComponentMetasStore.get(),
     instancesStore.get(),

--- a/packages/sdk-components-react/src/checkbox.ws.tsx
+++ b/packages/sdk-components-react/src/checkbox.ws.tsx
@@ -21,6 +21,7 @@ const presetStyle = {
 
 export const meta: WsComponentMeta = {
   category: "forms",
+  invalidAncestors: ["Button"],
   type: "control",
   label: "Checkbox",
   icon: CheckboxCheckedIcon,

--- a/packages/sdk-components-react/src/input.ws.tsx
+++ b/packages/sdk-components-react/src/input.ws.tsx
@@ -15,6 +15,7 @@ const presetStyle = {
 
 export const meta: WsComponentMeta = {
   category: "forms",
+  invalidAncestors: ["Button"],
   type: "control",
   label: "Text Input",
   icon: FormTextFieldIcon,

--- a/packages/sdk-components-react/src/label.ws.tsx
+++ b/packages/sdk-components-react/src/label.ws.tsx
@@ -18,6 +18,7 @@ const presetStyle = {
 
 export const meta: WsComponentMeta = {
   category: "forms",
+  invalidAncestors: ["Button"],
   type: "container",
   label: "Input Label",
   icon: TextIcon,

--- a/packages/sdk-components-react/src/radio-button.ws.tsx
+++ b/packages/sdk-components-react/src/radio-button.ws.tsx
@@ -21,6 +21,7 @@ const presetStyle = {
 
 export const meta: WsComponentMeta = {
   category: "forms",
+  invalidAncestors: ["Button"],
   type: "control",
   label: "Radio",
   icon: RadioCheckedIcon,


### PR DESCRIPTION
Fixed the issue with pasting checkbox into button
which is wrapped into label

Prevented inserting label, checkbox, radio button and input into buttons.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
