### PR TITLE
Replace useMeasure with resize observer

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -25,7 +25,6 @@ import { usePublishShortcuts } from "./shared/shortcuts";
 import {
   pagesStore,
   projectStore,
-  selectedBreakpointIdStore,
   useIsPreviewMode,
   useSetAssets,
   useSetAuthPermit,
@@ -252,9 +251,7 @@ export const Builder = ({
   useSetInstances(build.instances);
 
   useUnmount(() => {
-    // $todo reset all stores
     pagesStore.set(undefined);
-    selectedBreakpointIdStore.set(undefined);
   });
 
   useSyncPageUrl();

--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -25,6 +25,7 @@ import { usePublishShortcuts } from "./shared/shortcuts";
 import {
   pagesStore,
   projectStore,
+  selectedBreakpointIdStore,
   useIsPreviewMode,
   useSetAssets,
   useSetAuthPermit,
@@ -251,7 +252,9 @@ export const Builder = ({
   useSetInstances(build.instances);
 
   useUnmount(() => {
+    // $todo reset all stores
     pagesStore.set(undefined);
+    selectedBreakpointIdStore.set(undefined);
   });
 
   useSyncPageUrl();

--- a/apps/builder/app/builder/features/breakpoints/use-set-initial-canvas-width.ts
+++ b/apps/builder/app/builder/features/breakpoints/use-set-initial-canvas-width.ts
@@ -59,24 +59,18 @@ export const useSetCanvasWidth = () => {
           selectedBreakpoint,
           workspaceRect.width
         );
-
-        if (canvasWidthStore.get() !== width) {
-          canvasWidthStore.set(width);
-        }
+        canvasWidthStore.set(width);
       }
     };
 
     const unsubscribeBreakpointStore = breakpointsStore.subscribe(update);
-    const unsubscribeRectStore =
-      workspaceRectStore.get() === undefined
-        ? workspaceRectStore.listen((workspaceRect) => {
-            if (workspaceRect === undefined) {
-              return;
-            }
-            unsubscribeRectStore?.();
-            update();
-          })
-        : undefined;
+    const unsubscribeRectStore = workspaceRectStore.listen((workspaceRect) => {
+      if (workspaceRect === undefined) {
+        return;
+      }
+      unsubscribeRectStore?.();
+      update();
+    });
 
     return () => {
       unsubscribeBreakpointStore();

--- a/apps/builder/app/builder/features/workspace/workspace.tsx
+++ b/apps/builder/app/builder/features/workspace/workspace.tsx
@@ -29,7 +29,7 @@ const canvasContainerStyle = css({
   transformOrigin: "0 0",
 });
 
-function useMeasureWorkspace() {
+const useMeasureWorkspace = () => {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -38,7 +38,6 @@ function useMeasureWorkspace() {
       return;
     }
     const observer = new ResizeObserver((entries) => {
-      console.log(entries[0].contentRect);
       workspaceRectStore.set(entries[0].contentRect);
     });
     observer.observe(element);
@@ -48,7 +47,7 @@ function useMeasureWorkspace() {
   }, []);
 
   return ref;
-}
+};
 
 const getCanvasStyle = (
   scale: number,

--- a/apps/builder/app/builder/features/workspace/workspace.tsx
+++ b/apps/builder/app/builder/features/workspace/workspace.tsx
@@ -12,8 +12,7 @@ import {
 } from "~/shared/nano-states";
 import { textEditingInstanceSelectorStore } from "~/shared/nano-states";
 import { CanvasTools } from "./canvas-tools";
-import { useMeasure } from "react-use";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useSetCanvasWidth } from "../breakpoints";
 
 const workspaceStyle = css({
@@ -30,18 +29,26 @@ const canvasContainerStyle = css({
   transformOrigin: "0 0",
 });
 
-const useSetWorkspaceRect = () => {
-  const workspaceRect = useStore(workspaceRectStore);
-  const [ref, rect] = useMeasure<HTMLDivElement>();
+function useMeasureWorkspace() {
+  const ref = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
-    if (rect.width === 0 || rect.height === 0) {
+    const element = ref.current;
+    if (element === null) {
       return;
     }
-    // Little lie to safe the trouble of importing the type it uses everywhere.
-    workspaceRectStore.set(rect as DOMRect);
-  }, [workspaceRect, rect]);
+    const observer = new ResizeObserver((entries) => {
+      console.log(entries[0].contentRect);
+      workspaceRectStore.set(entries[0].contentRect);
+    });
+    observer.observe(element);
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
   return ref;
-};
+}
 
 const getCanvasStyle = (
   scale: number,
@@ -91,7 +98,7 @@ export const Workspace = ({
   publish,
 }: WorkspaceProps) => {
   const canvasStyle = useCanvasStyle();
-  const workspaceRef = useSetWorkspaceRect();
+  const workspaceRef = useMeasureWorkspace();
   useSetCanvasWidth();
   const handleWorkspaceClick = () => {
     selectedInstanceSelectorStore.set(undefined);

--- a/apps/builder/app/builder/features/workspace/workspace.tsx
+++ b/apps/builder/app/builder/features/workspace/workspace.tsx
@@ -37,7 +37,6 @@ const useMeasureWorkspace = () => {
     if (element === null) {
       return;
     }
-    console.log(element);
     const observer = new ResizeObserver((entries) => {
       workspaceRectStore.set(entries[0].contentRect);
     });
@@ -83,7 +82,6 @@ const useCanvasStyle = () => {
   const scale = useStore(scaleStore);
   const workspaceRect = useStore(workspaceRectStore);
   const [canvasWidth] = useCanvasWidth();
-  console.log(workspaceRect, canvasWidth);
   return getCanvasStyle(scale, workspaceRect, canvasWidth);
 };
 

--- a/apps/builder/app/builder/features/workspace/workspace.tsx
+++ b/apps/builder/app/builder/features/workspace/workspace.tsx
@@ -37,6 +37,7 @@ const useMeasureWorkspace = () => {
     if (element === null) {
       return;
     }
+    console.log(element);
     const observer = new ResizeObserver((entries) => {
       workspaceRectStore.set(entries[0].contentRect);
     });
@@ -82,6 +83,7 @@ const useCanvasStyle = () => {
   const scale = useStore(scaleStore);
   const workspaceRect = useStore(workspaceRectStore);
   const [canvasWidth] = useCanvasWidth();
+  console.log(workspaceRect, canvasWidth);
   return getCanvasStyle(scale, workspaceRect, canvasWidth);
 };
 


### PR DESCRIPTION
We are going to get rid of react-use.
Here replaced its useMeasure with resize observer. Sometimes using native api without wrappers gives cleaner logic. Here we avoid using effect as watcher and update store directly from callback.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
