### PR TITLE
(fix): Re-focus the tree-node after completion of editing the name

### DIFF
--- a/apps/builder/app/builder/shared/tree/index.tsx
+++ b/apps/builder/app/builder/shared/tree/index.tsx
@@ -146,7 +146,13 @@ const TreeItem = ({
   const { ref, handlers } = useContentEditable({
     isEditable,
     isEditing,
-    onChangeValue,
+    onChangeValue: (value: string) => {
+      onChangeValue(value);
+      const button = ref.current?.closest(
+        "[data-item-button-id]"
+      ) as HTMLElement;
+      button?.focus();
+    },
     onChangeEditing,
   });
 

--- a/apps/builder/app/builder/shared/tree/index.tsx
+++ b/apps/builder/app/builder/shared/tree/index.tsx
@@ -88,7 +88,7 @@ export const InstanceTree = (
       const isEditing = props.itemData.id === editingItemId;
 
       return (
-        <TreeItemBody {...props} selectionEvent="focus" isEditing={isEditing}>
+        <TreeItemBody {...props} selectionEvent="focus">
           <TreeItem
             isEditable={true}
             isEditing={isEditing}

--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -263,14 +263,12 @@ export const TreeItemBody = <Data extends { id: string }>({
   forceFocus = false,
   selectionEvent = "click",
   onToggle,
-  isEditing = false,
 }: TreeItemRenderProps<Data> & {
   children: React.ReactNode;
   suffix?: React.ReactNode;
   suffixWidth?: string;
   alwaysShowSuffix?: boolean;
   forceFocus?: boolean;
-  isEditing?: boolean;
   selectionEvent?: "click" | "focus";
 }) => {
   const [focusTarget, setFocusTarget] = useState<

--- a/packages/design-system/src/components/tree/tree.tsx
+++ b/packages/design-system/src/components/tree/tree.tsx
@@ -420,8 +420,6 @@ const useKeyboardNavigation = <Data extends { id: string }>({
 
   const hadFocus = useRef(false);
   const prevRoot = useRef(root);
-  const prevEditingItemId = useRef(editingItemId);
-
   useEffect(() => {
     const haveFocus =
       rootRef.current?.contains(document.activeElement) === true;
@@ -441,25 +439,11 @@ const useKeyboardNavigation = <Data extends { id: string }>({
     }
   }, [root, rootRef, selectedItemSelector, setFocus]);
 
-  // When we stop editing an item, we want to focus it back again.
-  // To continue keyboard navigation.
-  useEffect(() => {
-    const isEditingItemChanged =
-      editingItemId === undefined &&
-      prevEditingItemId.current !== editingItemId;
-
-    if (isEditingItemChanged === true && selectedItemSelector !== undefined) {
-      setFocus(selectedItemSelector, "restoring");
-    }
-  }, [editingItemId, selectedItemSelector, setFocus]);
-
   // onBlur doesn't fire when the activeElement is removed from the DOM
   useEffect(() => {
     const haveFocus =
       rootRef.current?.contains(document.activeElement) === true;
     hadFocus.current = haveFocus;
-
-    prevEditingItemId.current = editingItemId;
   });
 
   return {

--- a/packages/design-system/src/components/tree/tree.tsx
+++ b/packages/design-system/src/components/tree/tree.tsx
@@ -420,6 +420,8 @@ const useKeyboardNavigation = <Data extends { id: string }>({
 
   const hadFocus = useRef(false);
   const prevRoot = useRef(root);
+  const prevEditingItemId = useRef(editingItemId);
+
   useEffect(() => {
     const haveFocus =
       rootRef.current?.contains(document.activeElement) === true;
@@ -439,11 +441,25 @@ const useKeyboardNavigation = <Data extends { id: string }>({
     }
   }, [root, rootRef, selectedItemSelector, setFocus]);
 
+  // When we stop editing an item, we want to focus it back again.
+  // To continue keyboard navigation.
+  useEffect(() => {
+    const isEditingItemChanged =
+      editingItemId === undefined &&
+      prevEditingItemId.current !== editingItemId;
+
+    if (isEditingItemChanged === true && selectedItemSelector !== undefined) {
+      setFocus(selectedItemSelector, "restoring");
+    }
+  }, [editingItemId, selectedItemSelector, setFocus]);
+
   // onBlur doesn't fire when the activeElement is removed from the DOM
   useEffect(() => {
     const haveFocus =
       rootRef.current?.contains(document.activeElement) === true;
     hadFocus.current = haveFocus;
+
+    prevEditingItemId.current = editingItemId;
   });
 
   return {


### PR DESCRIPTION
## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. Use keyboard to navigate between the tree elements.
2. Click `Ctrl + E` to enter into edit mode.
3. Edit the name of the tree-node and then press `Enter`.
4. Use the up/down arrows to navigate to other nodes in the tree.

## Code Review

- [ ] hi, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
