### PR TITLE
Attempt to fix useFetch for all our trpc calls

### DIFF
--- a/apps/builder/app/dashboard/projects/project-dialogs.tsx
+++ b/apps/builder/app/dashboard/projects/project-dialogs.tsx
@@ -9,7 +9,7 @@ import {
   theme,
 } from "@webstudio-is/design-system";
 import { PlusIcon } from "@webstudio-is/icons";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "@remix-run/react";
 import { dashboardProjectPath, builderPath } from "~/shared/router-utils";
 import { createTrpcRemixProxy } from "~/shared/remix/trpc-remix-proxy";

--- a/apps/builder/app/dashboard/projects/project-dialogs.tsx
+++ b/apps/builder/app/dashboard/projects/project-dialogs.tsx
@@ -9,7 +9,7 @@ import {
   theme,
 } from "@webstudio-is/design-system";
 import { PlusIcon } from "@webstudio-is/icons";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "@remix-run/react";
 import { dashboardProjectPath, builderPath } from "~/shared/router-utils";
 import { createTrpcRemixProxy } from "~/shared/remix/trpc-remix-proxy";
@@ -95,40 +95,8 @@ const trpc = createTrpcRemixProxy<DashboardProjectRouter>(dashboardProjectPath);
 
 const useCreateProject = () => {
   const navigate = useNavigate();
-  const { send, data, state } = trpc.create.useMutation();
+  const { send, state } = trpc.create.useMutation();
   const [errors, setErrors] = useState<string>();
-
-  // There's an occasional issue where React skips `useEffect(, [data])`, possibly due to a race condition.
-  // To frequently replicate this issue:
-  // 1. Create 20 projects
-  // 2. Turn on CPU 6x slowdown in Chrome dev tools
-
-  // Upon creating a new project, you'll find that it doesn't redirect to the new project page.
-  // The problem is that `useEffect` with either `data` or `data?.id` as a dependency is not triggered.
-
-  // Some working fixes:
-  // 1. Non-remix fetch - using createTrpcFetchProxy
-  // 2. Use this code inside useEffect:
-  //      if (ref.current !== data?.projectId) { doRedirect(); }; ref.current = data?.projectId;
-  // 3. Use useState as shown below
-  //
-  // Some observations:
-  // The issue seems related to the amount of rendering, possibly due to concurrent React's features.
-  // It's also related to Remix's useFetcher, which may be using setState or something similar
-  // in a way that's not compatible with concurrent React.
-
-  const [projectId, setProjectId] = useState<DashboardProject["id"]>();
-
-  if (projectId !== data?.id) {
-    setProjectId(data?.id);
-  }
-
-  useEffect(() => {
-    if (projectId === undefined) {
-      return;
-    }
-    navigate(builderPath({ projectId }));
-  }, [projectId, navigate]);
 
   const handleSubmit = ({ title }: { title: string }) => {
     const parsed = Title.safeParse(title);
@@ -138,7 +106,11 @@ const useCreateProject = () => {
         : undefined;
     setErrors(errors);
     if (parsed.success) {
-      send({ title });
+      send({ title }, (data) => {
+        if (data?.id) {
+          navigate(builderPath({ projectId: data.id }));
+        }
+      });
     }
   };
 
@@ -156,6 +128,7 @@ const useCreateProject = () => {
 
 export const CreateProject = () => {
   const { handleSubmit, handleOpenChange, state, errors } = useCreateProject();
+
   return (
     <Dialog
       title="New Project"

--- a/apps/builder/app/shared/remix/trpc-remix-proxy.ts
+++ b/apps/builder/app/shared/remix/trpc-remix-proxy.ts
@@ -7,7 +7,7 @@ import type {
 } from "@trpc/server";
 // eslint-disable-next-line import/no-internal-modules
 import { createRecursiveProxy } from "@trpc/server/shared";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 export const createTrpcRemixProxy = <Router extends AnyRouter>(
   getPath: (method: string) => string
@@ -15,14 +15,20 @@ export const createTrpcRemixProxy = <Router extends AnyRouter>(
   [Procedure in keyof Router["_def"]["record"]]: Router["_def"]["record"][Procedure] extends AnyMutationProcedure
     ? {
         useMutation: () => {
-          send: (input: inferRouterInputs<Router>[Procedure]) => void;
+          send: (
+            input: inferRouterInputs<Router>[Procedure],
+            onSuccess?: (data: inferRouterOutputs<Router>[Procedure]) => void
+          ) => void;
           data?: inferRouterOutputs<Router>[Procedure];
           state: "idle" | "loading" | "submitting";
         };
       }
     : {
         useQuery: () => {
-          load: (input: inferRouterInputs<Router>[Procedure]) => void;
+          load: (
+            input: inferRouterInputs<Router>[Procedure],
+            onSuccess?: (data: inferRouterOutputs<Router>[Procedure]) => void
+          ) => void;
           data?: inferRouterOutputs<Router>[Procedure];
           state: "idle" | "loading" | "submitting";
         };
@@ -39,9 +45,39 @@ export const createTrpcRemixProxy = <Router extends AnyRouter>(
 
     const method = path.join(".");
 
+    const previousDataRef = useRef(data);
+    const onSuccessRef = useRef<(data: unknown) => void>();
+
+    // There's an occasional issue where React skips `useEffect(, [data])`, possibly due to a race condition.
+    // To frequently replicate this issue:
+    // 1. Open dashboard
+    // 1. Create 20 projects
+    // 2. Turn on CPU 6x slowdown in Chrome dev tools
+
+    // Upon creating a new project, you'll find that it doesn't redirect to the new project page if dependency doesn't contain `state`.
+    // The problem is that `useEffect` with only `data` or `data?.id` as a dependency is not triggered.
+
+    // Some working fixes:
+    // 1. Non-remix fetch - using createTrpcFetchProxy
+    // 2. Use this code inside useEffect:
+    //      if (ref.current !== data?.projectId) { doRedirect(); }; ref.current = data?.projectId;
+    // 3. Use useState as shown below
+    //
+    // Some observations:
+    // The issue seems related to the amount of rendering, possibly due to concurrent React's features.
+    // It's also related to Remix's useFetcher, which may be using setState or something similar
+    // in a way that's not compatible with concurrent React.
+    useEffect(() => {
+      if (data !== previousDataRef.current) {
+        previousDataRef.current = data;
+        onSuccessRef.current?.(data);
+      }
+    }, [data, state]);
+
     const remixSubmit = useCallback(
-      (input: never) => {
-        return submit(
+      (input: never, onSuccess: (data: unknown) => void) => {
+        onSuccessRef.current = onSuccess;
+        submit(
           // stringify input as otherwise we loose type safety
           // (remix will add key: values as FormData entries or as SearchParams
           { input: JSON.stringify(input) },

--- a/apps/builder/app/shared/share-project/share-project-container.tsx
+++ b/apps/builder/app/shared/share-project/share-project-container.tsx
@@ -16,17 +16,12 @@ const useShareProjectContainer = (projectId: Project["id"]) => {
   const { send: removeToken } = trpc.remove.useMutation();
   const { send: updateToken } = trpc.update.useMutation();
   const [links, setLinks] = useState(data ?? []);
-  useEffect(() => {
-    if (projectId === undefined) {
-      return;
-    }
 
-    load({ projectId });
+  useEffect(() => {
+    load({ projectId }, (data) => {
+      setLinks(data ?? []);
+    });
   }, [load, projectId]);
-
-  useEffect(() => {
-    setLinks(data ?? []);
-  }, [data, setLinks]);
 
   const handleChangeDebounced = useDebouncedCallback((link: LinkOptions) => {
     if (projectId === undefined) {


### PR DESCRIPTION
## Description

I moved the fix to trpc layer to affect other calls as well. Turned out the hook is called many times - as many as there are items in dashboard, so I think relying on state dependency even though it works for completely unknown reasons is better from perf standpoint (I think ... who knows ...)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
