### PR TITLE
Fix props filtering

### DIFF
--- a/packages/generate-arg-types/src/arg-types.ts
+++ b/packages/generate-arg-types/src/arg-types.ts
@@ -3,17 +3,6 @@ import { PropMeta } from "./types";
 
 export type FilterPredicate = (prop: PropItem) => boolean;
 
-const isValid = (prop: PropItem) => {
-  if (prop.parent) {
-    // Pass *HTML (both ButtonHTMLAttributes and HTMLAttributes), Aria, and SVG attributes through
-    const matcher = /.?(HTML|SVG|Aria)Attributes/;
-    // @todo: Add a test for this
-    return prop.parent.name.match(matcher) !== null;
-  }
-  // Always allow component's own props
-  return true;
-};
-
 export const propsToArgTypes = (props: Record<string, PropItem>) => {
   const entries = Object.entries(props);
   return entries
@@ -22,10 +11,6 @@ export const propsToArgTypes = (props: Record<string, PropItem>) => {
     })
     .reduce((result, current) => {
       const [propName, prop] = current;
-      // Filter out props
-      if (isValid(prop) === false) {
-        return result;
-      }
 
       const argType = getArgType(prop);
       if (argType != null) {


### PR DESCRIPTION
## Description

isValid check has 0 effect on existing components, but prevents Radix components type generation

Instead of empty types it now generate right type for at least single radix component

```ts
export const props: Record<string, PropMeta> = {
  defaultOpen: { required: false, control: "boolean", type: "boolean" },
  delayDuration: {
    description:
      "The duration from when the pointer enters the trigger until the tooltip gets opened. This will\noverride the prop with the same name passed to Provider.\n@defaultValue 700",
    required: false,
    control: "number",
    type: "number",
  },
  disableHoverableContent: {
    description:
      "When `true`, trying to hover the content will result in the tooltip closing as the pointer leaves the trigger.\n@defaultValue false",
    required: false,
    control: "boolean",
    type: "boolean",
  },
  open: { required: false, control: "boolean", type: "boolean" },
};
```

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
