### PR TITLE
Compute insert constraints for tree

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
@@ -23,8 +23,10 @@ import {
   scaleStore,
 } from "~/builder/shared/nano-states";
 import {
+  computeInstancesConstraints,
   findClosestDroppableTarget,
-  insertNewComponentInstance,
+  getComponentTemplateData,
+  insertTemplateData,
 } from "~/shared/instance-utils";
 import { MetaIcon } from "~/builder/shared/meta-icon";
 
@@ -176,6 +178,16 @@ export const useDraggable = ({
     if (selectedPage === undefined) {
       return;
     }
+    const templateData = getComponentTemplateData(component);
+    if (templateData === undefined) {
+      return;
+    }
+    const newInstances = new Map(
+      templateData.instances.map((instance) => [instance.id, instance])
+    );
+    const rootInstanceIds = templateData.children
+      .filter((child) => child.type === "id")
+      .map((child) => child.value);
     const instanceSelector = selectedInstanceSelectorStore.get() ?? [
       selectedPage.rootInstanceId,
     ];
@@ -185,7 +197,7 @@ export const useDraggable = ({
       instancesStore.get(),
       // fallback to root as drop target
       instanceSelector,
-      [component]
+      computeInstancesConstraints(metas, newInstances, rootInstanceIds)
     );
     if (dropTarget === undefined) {
       const meta = metas.get(component);
@@ -194,7 +206,7 @@ export const useDraggable = ({
       }
       return;
     }
-    insertNewComponentInstance(component, dropTarget);
+    insertTemplateData(templateData, dropTarget);
   };
 
   return {

--- a/apps/builder/app/shared/copy-paste/plugin-embed-template.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-embed-template.ts
@@ -11,6 +11,7 @@ import {
   breakpointsStore,
 } from "../nano-states";
 import {
+  computeInstancesConstraints,
   findClosestDroppableTarget,
   insertTemplateData,
 } from "../instance-utils";
@@ -54,14 +55,18 @@ export const onPaste = (clipboardData: string): boolean => {
     template,
     baseBreakpoint.id
   );
-  const dragComponents = Array.from(
-    new Set(templateData.instances.map((instance) => instance.component))
+  const metas = registeredComponentMetasStore.get();
+  const newInstances = new Map(
+    templateData.instances.map((instance) => [instance.id, instance])
   );
+  const rootInstanceIds = templateData.children
+    .filter((child) => child.type === "id")
+    .map((child) => child.value);
   const dropTarget = findClosestDroppableTarget(
-    registeredComponentMetasStore.get(),
+    metas,
     instancesStore.get(),
     instanceSelector,
-    dragComponents
+    computeInstancesConstraints(metas, newInstances, rootInstanceIds)
   );
   if (dropTarget === undefined) {
     return false;

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -34,7 +34,11 @@ import {
   findLocalStyleSourcesWithinInstances,
   mergeNewBreakpointsMutable,
 } from "../tree-utils";
-import { deleteInstance, findClosestDroppableTarget } from "../instance-utils";
+import {
+  computeInstancesConstraints,
+  deleteInstance,
+  findClosestDroppableTarget,
+} from "../instance-utils";
 import { getMapValuesBy, getMapValuesByKeysSet } from "../array-utils";
 import { Asset } from "@webstudio-is/asset-uploader";
 
@@ -266,18 +270,20 @@ export const onPaste = (clipboardData: string): boolean => {
     return false;
   }
 
+  const metas = registeredComponentMetasStore.get();
+  const newInstances = new Map(
+    data.instances.map((instance) => [instance.id, instance])
+  );
+  const rootInstanceId = data.instances[0].id;
   // paste to the root if nothing is selected
   const instanceSelector = selectedInstanceSelectorStore.get() ?? [
     selectedPage.rootInstanceId,
   ];
-  const dragComponents = Array.from(
-    new Set(data.instances.map((instance) => instance.component))
-  );
   const dropTarget = findClosestDroppableTarget(
-    registeredComponentMetasStore.get(),
+    metas,
     instancesStore.get(),
     instanceSelector,
-    dragComponents
+    computeInstancesConstraints(metas, newInstances, [rootInstanceId])
   );
   if (dropTarget === undefined) {
     return false;


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio-builder/issues/1950

Here added new utility to compute constraints for tree when insert embed template, paste something or reparent. I previous implementation all constraints were merged which gave us false positives like when paste List>ListItem we got "requiredAncestors: [List]". Here tree layout is considered to exclude such false positives.

For testing try to copy paste List>ListItem

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
