### PR TITLE
Support copy pasting of data sources

### DIFF
--- a/apps/builder/app/shared/copy-paste/plugin-instance.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.test.ts
@@ -1,0 +1,230 @@
+import { describe, test, expect } from "@jest/globals";
+import { enableMapSet } from "immer";
+import type {
+  Instance,
+  Instances,
+  Prop,
+  Props,
+  DataSource,
+  DataSources,
+  Page,
+} from "@webstudio-is/project-build";
+import type { Project } from "@webstudio-is/project";
+import { encodeDataSourceVariable } from "@webstudio-is/react-sdk";
+import * as baseComponentMetas from "@webstudio-is/sdk-components-react/metas";
+import { registerContainers } from "../sync";
+import {
+  dataSourcesStore,
+  instancesStore,
+  pagesStore,
+  projectStore,
+  propsStore,
+  registeredComponentMetasStore,
+  selectedInstanceSelectorStore,
+  selectedPageIdStore,
+} from "../nano-states";
+import { onCopy, onPaste } from "./plugin-instance";
+
+enableMapSet();
+registerContainers();
+
+registeredComponentMetasStore.set(new Map(Object.entries(baseComponentMetas)));
+projectStore.set({ id: "my-project" } as Project);
+pagesStore.set({
+  homePage: { id: "home-page", rootInstanceId: "body0" } as Page,
+  pages: [],
+});
+selectedPageIdStore.set("home-page");
+
+const createInstance = (
+  id: Instance["id"],
+  component: string,
+  children: Instance["children"]
+): Instance => {
+  return { type: "instance", id, component, children };
+};
+
+const getIdValuePair = <T extends { id: string }>(item: T) =>
+  [item.id, item] as const;
+
+const toMap = <T extends { id: string }>(list: T[]) =>
+  new Map(list.map(getIdValuePair));
+
+const getMapDifference = <Type extends Map<unknown, unknown>>(
+  left: Type,
+  right: Type
+): Type => {
+  const leftSet = new Set(left.keys());
+  const rightSet = new Set(right.keys());
+  const difference = new Map() as Type;
+  for (const [key, value] of left) {
+    if (rightSet.has(key) === false) {
+      difference.set(key, value);
+    }
+  }
+  for (const [key, value] of right) {
+    if (leftSet.has(key) === false) {
+      difference.set(key, value);
+    }
+  }
+  return difference;
+};
+
+describe("data sources", () => {
+  // body0
+  //   box1
+  //     box2
+  const instances: Instances = toMap([
+    createInstance("body0", "Body", [{ type: "id", value: "box1" }]),
+    createInstance("box1", "Box", [{ type: "id", value: "box2" }]),
+    createInstance("box2", "Box", []),
+  ] satisfies Instance[]);
+  const dataSources: DataSources = toMap([
+    {
+      id: "box1$state",
+      scopeInstanceId: "box1",
+      type: "variable",
+      name: "state",
+      value: { type: "string", value: "initial" },
+    },
+    {
+      id: "box2$stateInitial",
+      scopeInstanceId: "box2",
+      type: "expression",
+      name: "stateInitial",
+      code: `$ws$dataSource$box1$state === 'initial'`,
+    },
+  ] satisfies DataSource[]);
+  const props: Props = toMap([
+    {
+      id: "box1$state",
+      instanceId: "box1",
+      type: "dataSource",
+      name: "state",
+      value: "box1$state",
+    },
+    {
+      id: "box2$state",
+      instanceId: "box2",
+      type: "dataSource",
+      name: "state",
+      value: "box1$state",
+    },
+    {
+      id: "box2$show",
+      instanceId: "box2",
+      type: "dataSource",
+      name: "show",
+      value: "box2$stateInitial",
+    },
+  ] satisfies Prop[]);
+
+  test("are copy pasted when scoped to copied instances", () => {
+    instancesStore.set(instances);
+    propsStore.set(props);
+    dataSourcesStore.set(dataSources);
+    selectedInstanceSelectorStore.set(["box1", "body0"]);
+    const clipboardData = onCopy() ?? "";
+    selectedInstanceSelectorStore.set(["body0"]);
+    onPaste(clipboardData);
+
+    const instancesDifference = getMapDifference(
+      instances,
+      instancesStore.get()
+    );
+    const [newBox1, newBox2] = instancesDifference.keys();
+
+    const dataSourcesDifference = getMapDifference(
+      dataSources,
+      dataSourcesStore.get()
+    );
+    const [newDataSource1, newDataSource2] = dataSourcesDifference.keys();
+    expect(dataSourcesDifference).toEqual(
+      toMap([
+        {
+          ...dataSources.get("box1$state"),
+          id: newDataSource1,
+          scopeInstanceId: newBox1,
+        },
+        {
+          ...dataSources.get("box2$stateInitial"),
+          id: newDataSource2,
+          scopeInstanceId: newBox2,
+          code: `${encodeDataSourceVariable(newDataSource1)} === 'initial'`,
+        },
+      ])
+    );
+
+    const propsDifference = getMapDifference(props, propsStore.get());
+    const [newProp1, newProp2, newProp3] = propsDifference.keys();
+    expect(propsDifference).toEqual(
+      toMap([
+        {
+          ...props.get("box1$state"),
+          id: newProp1,
+          instanceId: newBox1,
+          value: newDataSource1,
+        },
+        {
+          ...props.get("box2$state"),
+          id: newProp2,
+          instanceId: newBox2,
+          value: newDataSource1,
+        },
+        {
+          ...props.get("box2$show"),
+          id: newProp3,
+          instanceId: newBox2,
+          value: newDataSource2,
+        },
+      ])
+    );
+  });
+
+  test("are inlined into props when not scoped to copied instances or depends on not scoped data source", () => {
+    instancesStore.set(instances);
+    propsStore.set(props);
+    dataSourcesStore.set(dataSources);
+    selectedInstanceSelectorStore.set(["box2", "box1", "body0"]);
+    const clipboardData = onCopy() ?? "";
+    selectedInstanceSelectorStore.set(["body0"]);
+    onPaste(clipboardData);
+
+    const instancesDifference = getMapDifference(
+      instances,
+      instancesStore.get()
+    );
+    const [newBox2] = instancesDifference.keys();
+
+    const dataSourcesDifference = getMapDifference(
+      dataSources,
+      dataSourcesStore.get()
+    );
+    expect(dataSourcesDifference).toEqual(new Map());
+
+    const propsDifference = getMapDifference(props, propsStore.get());
+    const [newProp1, newProp2] = propsDifference.keys();
+    expect(propsDifference).toEqual(
+      toMap([
+        {
+          id: newProp1,
+          instanceId: newBox2,
+          type: "string",
+          name: "state",
+          value: "initial",
+        },
+        {
+          id: newProp2,
+          instanceId: newBox2,
+          type: "boolean",
+          name: "show",
+          value: true,
+        },
+      ])
+    );
+  });
+
+  test.todo(
+    "preserve data sources not scoped to new instances within same scope"
+  );
+});

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -257,7 +257,7 @@ export const insertTemplateData = (
         children,
         dropTarget
       );
-      insertPropsCopyMutable(props, insertedProps, new Map());
+      insertPropsCopyMutable(props, insertedProps, new Map(), new Map());
       for (const dataSource of insertedDataSources) {
         dataSources.set(dataSource.id, dataSource);
       }

--- a/apps/builder/app/shared/tree-utils.test.ts
+++ b/apps/builder/app/shared/tree-utils.test.ts
@@ -867,7 +867,7 @@ test("insert props copy with new ids and apply new instance ids", () => {
   const clonedInstanceIds = new Map<Instance["id"], Instance["id"]>([
     ["instance2", "newInstance2"],
   ]);
-  insertPropsCopyMutable(props, copiedProps, clonedInstanceIds);
+  insertPropsCopyMutable(props, copiedProps, clonedInstanceIds, new Map());
   expect(Array.from(props.entries())).toEqual([
     ["prop1", createProp("prop1", "instance1")],
     ["prop2", createProp("prop2", "instance2")],

--- a/apps/builder/app/shared/tree-utils.ts
+++ b/apps/builder/app/shared/tree-utils.ts
@@ -2,6 +2,7 @@ import { nanoid } from "nanoid";
 import {
   Breakpoint,
   Breakpoints,
+  DataSource,
   findTreeInstanceIds,
   findTreeInstanceIdsExcludingSlotDescendants,
   getStyleDeclKey,
@@ -490,7 +491,8 @@ export const insertStyleSourcesCopyMutable = (
 export const insertPropsCopyMutable = (
   props: Props,
   copiedProps: Prop[],
-  copiedInstanceIds: Map<Instance["id"], Instance["id"]>
+  copiedInstanceIds: Map<Instance["id"], Instance["id"]>,
+  copiedDataSourceIds: Map<DataSource["id"], DataSource["id"]>
 ) => {
   for (const prop of copiedProps) {
     const newInstanceId = copiedInstanceIds.get(prop.instanceId);
@@ -505,11 +507,20 @@ export const insertPropsCopyMutable = (
 
     // copy prop before inserting
     const newPropId = nanoid();
-    props.set(newPropId, {
-      ...prop,
-      id: newPropId,
-      instanceId: newInstanceId,
-    });
+    if (prop.type === "dataSource") {
+      props.set(newPropId, {
+        ...prop,
+        id: newPropId,
+        instanceId: newInstanceId,
+        value: copiedDataSourceIds.get(prop.value) ?? prop.value,
+      });
+    } else {
+      props.set(newPropId, {
+        ...prop,
+        id: newPropId,
+        instanceId: newInstanceId,
+      });
+    }
   }
 };
 

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -64,7 +64,7 @@
     "downshift": "^6.1.7",
     "hyphenate-style-name": "^1.0.4",
     "immer": "^9.0.12",
-    "immerhin": "^0.5.0",
+    "immerhin": "^0.6.1",
     "jose": "^4.11.2",
     "lexical": "^0.11.1",
     "match-sorter": "^6.3.1",

--- a/apps/builder/remix.config.js
+++ b/apps/builder/remix.config.js
@@ -28,6 +28,7 @@ module.exports = {
     /mdast-/,
     "unist-util-stringify-position",
     "node-fetch",
+    "immerhin",
   ],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",

--- a/packages/react-sdk/src/expression.test.ts
+++ b/packages/react-sdk/src/expression.test.ts
@@ -4,6 +4,7 @@ import {
   encodeDataSourceVariable,
   executeComputingExpressions,
   executeEffectfulExpression,
+  computeExpressionsDependencies,
   generateComputingExpressions,
   generateEffectfulExpression,
   validateExpression,
@@ -237,5 +238,35 @@ test("execute effectful expression", () => {
   ]);
   expect(executeEffectfulExpression(`var0 = var0 + var1`, variables)).toEqual(
     new Map([["var0", 5]])
+  );
+});
+
+test("compute expressions dependencies", () => {
+  const expressions = new Map([
+    ["exp1", `var1`],
+    ["exp2", `exp1 + exp1`],
+    ["exp3", `exp1 + exp2`],
+    ["exp4", `var1 + exp1`],
+  ]);
+  expect(computeExpressionsDependencies(expressions)).toEqual(
+    new Map([
+      ["exp4", new Set(["var1", "exp1"])],
+      ["exp3", new Set(["var1", "exp1", "exp2"])],
+      ["exp2", new Set(["var1", "exp1"])],
+      ["exp1", new Set(["var1"])],
+    ])
+  );
+});
+
+test("handle cyclic dependencies", () => {
+  const expressions = new Map([
+    ["exp1", `exp2 + var1`],
+    ["exp2", `exp1 + var1`],
+  ]);
+  expect(computeExpressionsDependencies(expressions)).toEqual(
+    new Map([
+      ["exp2", new Set(["var1", "exp1", "exp2"])],
+      ["exp1", new Set(["var1", "exp1", "exp2"])],
+    ])
   );
 });

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -26,6 +26,7 @@ export {
   executeComputingExpressions,
   generateEffectfulExpression,
   executeEffectfulExpression,
+  computeExpressionsDependencies,
   encodeDataSourceVariable,
   encodeVariablesMap,
   decodeDataSourceVariable,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,8 +190,8 @@ importers:
         specifier: ^9.0.12
         version: 9.0.15
       immerhin:
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.1
+        version: 0.6.1
       jose:
         specifier: ^4.11.2
         version: 4.11.2
@@ -11925,8 +11925,8 @@ packages:
     resolution: {integrity: sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==}
     dev: false
 
-  /immerhin@0.5.0:
-    resolution: {integrity: sha512-s0MJ45StYo4mChJmQiz/hcw9a5nQD9VHrQCGj1+FiS1TK62X+AA/7XFUR8YbP9b735mS841aKx5tXQNTmOpUJA==}
+  /immerhin@0.6.1:
+    resolution: {integrity: sha512-HQUPluF2Mx7n/EAj1HHG3NQDyl1aHnxxWHIpWije2oHO1wEjkUlwHoHMPEjkgGu/zMamV8gfkMiQtrGCOmdOOw==}
     dependencies:
       immer: 9.0.15
       nanoid: 3.3.6


### PR DESCRIPTION
Here fixed the case when copy pasted form looses state and give errors on submit.

Immerhin now converted to esm to work in tests.
Added tests for instances copy paste plugin.
The new logic is copy data sources as is if they are bound to copied instances.

The new computeExpressionsDependencies used to detect if expression depends on data sources outside of copied instances scope.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
