### PR TITLE
Optimize typechecking

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,4 +45,4 @@ jobs:
 
       - run: pnpm eslint . --ext .ts,.tsx --max-warnings 0 --cache --cache-strategy=content --cache-location=node_modules/.cache/eslint/.eslint-cache
 
-      - run: pnpm turbo run size-test build checks dts
+      - run: pnpm turbo run size-test build checks

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -119,7 +119,7 @@
     "jest": "^29.6.1",
     "react-test-renderer": "^18.2.0",
     "type-fest": "^3.7.1",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   },
   "sideEffects": false,
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "storybook": "^7.0.26",
     "tsx": "^3.12.6",
     "turbo": "^1.8.6",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   },
   "engines": {
     "node": "18",

--- a/packages/asset-uploader/package.json
+++ b/packages/asset-uploader/package.json
@@ -32,7 +32,7 @@
     "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "jest": "^29.6.1",
-    "typescript": "5.1.3",
+    "typescript": "5.1.6",
     "zod": "^3.21.4"
   },
   "exports": {

--- a/packages/asset-uploader/package.json
+++ b/packages/asset-uploader/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "checks": "pnpm typecheck && pnpm test",
     "dev": "build-package --watch",

--- a/packages/authorization-token/package.json
+++ b/packages/authorization-token/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "checks": "pnpm typecheck",
     "dev": "build-package --watch",
     "build": "build-package",

--- a/packages/authorization-token/package.json
+++ b/packages/authorization-token/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   },
   "exports": {
     ".": {

--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "checks": "pnpm typecheck",
     "dev": "build-package --watch",
     "build": "build-package",

--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -26,7 +26,7 @@
     "mdn-data": "2.0.30",
     "tsx": "^3.12.6",
     "type-fest": "^3.7.1",
-    "typescript": "5.1.3",
+    "typescript": "5.1.6",
     "zod": "^3.21.4"
   },
   "peerDependencies": {

--- a/packages/css-engine/package.json
+++ b/packages/css-engine/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "checks": "pnpm typecheck && pnpm test",
     "dev": "build-package --watch",
     "build": "build-package",

--- a/packages/css-engine/package.json
+++ b/packages/css-engine/package.json
@@ -32,7 +32,7 @@
     "@webstudio-is/storybook-config": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "jest": "^29.6.1",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   },
   "exports": {
     "source": "./src/index.ts",

--- a/packages/css-vars/package.json
+++ b/packages/css-vars/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "checks": "pnpm typecheck",
     "dev": "build-package --watch",
     "build": "build-package",

--- a/packages/css-vars/package.json
+++ b/packages/css-vars/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   },
   "exports": {
     "source": "./src/index.ts",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "checks": "pnpm typecheck",
     "dev": "build-package --watch",
     "build": "build-package",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   },
   "exports": {
     ".": {

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -30,7 +30,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tsx": "^3.12.6",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -10,7 +10,7 @@
     "build": "build-package",
     "build-figma-tokens": "tsx ./bin/transform-figma-tokens.ts",
     "dts": "tsc --project tsconfig.dts.json",
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "checks": "pnpm typecheck && pnpm test",
     "storybook:dev": "storybook dev -p 6006",

--- a/packages/design-system/src/components/primitives/dnd/canvas.stories.tsx
+++ b/packages/design-system/src/components/primitives/dnd/canvas.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentMeta } from "@storybook/react";
+import type { Meta } from "@storybook/react";
 import { type CSSProperties, useState, useRef } from "react";
 import { Box } from "../../box";
 import { useDrop, type DropTarget } from "./use-drop";
@@ -361,4 +361,4 @@ export const Canvas = () => {
 
 export default {
   component: Canvas,
-} as ComponentMeta<typeof Canvas>;
+} satisfies Meta<typeof Canvas>;

--- a/packages/design-system/src/components/primitives/dnd/sortable-list.stories.tsx
+++ b/packages/design-system/src/components/primitives/dnd/sortable-list.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentMeta } from "@storybook/react";
+import type { Meta } from "@storybook/react";
 import { useState, useRef } from "react";
 import { Box } from "../../box";
 import { styled } from "../../../stitches.config";
@@ -220,4 +220,4 @@ export default {
       options: ["horizontal", "vertical", "wrap"],
     },
   },
-} as ComponentMeta<typeof SortableList>;
+} satisfies Meta<typeof SortableList>;

--- a/packages/design-system/src/components/tree/tree.stories.tsx
+++ b/packages/design-system/src/components/tree/tree.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentMeta } from "@storybook/react";
+import type { Meta } from "@storybook/react";
 import { useState } from "react";
 import { Tree } from "./tree";
 import { type Item, findItemById, reparent } from "./test-tree-data";
@@ -127,4 +127,4 @@ export const StressTest = () => {
 
 export default {
   component: Tree,
-} as ComponentMeta<typeof Tree>;
+} satisfies Meta<typeof Tree>;

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "checks": "pnpm typecheck",
     "dev": "build-package --watch",
     "build": "build-package",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   },
   "exports": {
     ".": {

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -11,6 +11,6 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-unicorn": "^47.0.0",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   }
 }

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "checks": "pnpm typecheck",
     "dev": "build-package --watch",
     "build": "build-package",

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "checks": "pnpm typecheck && pnpm test",
     "dev": "build-package --watch",

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -24,7 +24,7 @@
     "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "jest": "^29.6.1",
-    "typescript": "5.1.3",
+    "typescript": "5.1.6",
     "zod": "^3.21.4"
   },
   "peerDependencies": {

--- a/packages/form-handlers-mailchannels-test/package.json
+++ b/packages/form-handlers-mailchannels-test/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^3.0.0",
     "@webstudio-is/tsconfig": "workspace:^",
-    "typescript": "5.1.3",
+    "typescript": "5.1.6",
     "wrangler": "^2.18.0"
   }
 }

--- a/packages/form-handlers/package.json
+++ b/packages/form-handlers/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "checks": "pnpm typecheck",
     "dev": "build-package --watch",
     "build": "build-package",

--- a/packages/form-handlers/package.json
+++ b/packages/form-handlers/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   },
   "exports": {
     "source": "./src/index.ts",

--- a/packages/generate-arg-types/package.json
+++ b/packages/generate-arg-types/package.json
@@ -9,7 +9,7 @@
     "dev": "build-package --watch",
     "build": "build-package",
     "dts": "tsc --project tsconfig.dts.json",
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "checks": "pnpm typecheck"
   },
   "dependencies": {

--- a/packages/generate-arg-types/package.json
+++ b/packages/generate-arg-types/package.json
@@ -21,7 +21,7 @@
     "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "tsx": "^3.12.6",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   },
   "files": [
     "lib/*",

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -21,7 +21,7 @@
     "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
     "jest": "^29.6.1",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   },
   "exports": {
     "source": "./src/index.ts",

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -10,7 +10,7 @@
     "build": "build-package",
     "dts": "tsc --project tsconfig.dts.json",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "checks": "pnpm typecheck"
   },
   "devDependencies": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -10,7 +10,7 @@
     "build": "build-package",
     "dts": "tsc --declarationDir lib/types",
     "generate": "rm -fr src/__generated__ && NODE_OPTIONS='--loader=tsx' svgo-jsx svgo-jsx.config.ts && tsx svg-string.ts && prettier --write ./",
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "checks": "pnpm typecheck",
     "storybook:dev": "storybook dev -p 6006",
     "storybook:build": "storybook build"

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -25,7 +25,7 @@
     "react-dom": "^18.2.0",
     "svgo": "^3.0.2",
     "tsx": "^3.12.6",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -30,7 +30,7 @@
     "jest": "^29.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "checks": "pnpm typecheck && pnpm test",
     "dev": "build-package --watch",

--- a/packages/image/src/image-dev.stories.tsx
+++ b/packages/image/src/image-dev.stories.tsx
@@ -1,7 +1,7 @@
 // Story for image development, see https://github.com/webstudio-is/webstudio-builder/issues/387
 
 import type * as React from "react";
-import type { ComponentMeta, ComponentStory } from "@storybook/react";
+import type { Meta, StoryFn } from "@storybook/react";
 import { Image as ImagePrimitive, createImageLoader } from "./";
 
 // to not allow include local assets everywhere, just enable it for this file
@@ -11,7 +11,7 @@ import localLogoImage from "../storybook-assets/logo.webp"; // eslint-disable-li
 
 export default {
   title: "Components/ImageDev",
-} as ComponentMeta<typeof ImagePrimitive>;
+} satisfies Meta<typeof ImagePrimitive>;
 
 type ImageProps = React.ComponentProps<typeof ImagePrimitive>;
 
@@ -34,7 +34,7 @@ const imageLoader = createImageLoader({
     : "",
 });
 
-const ImageBase: ComponentStory<
+const ImageBase: StoryFn<
   React.ForwardRefExoticComponent<
     Omit<ImageProps, "loader"> & {
       style?: React.HTMLAttributes<"img">["style"];
@@ -60,16 +60,14 @@ const ImageBase: ComponentStory<
 /**
  * Load images depending on image width and device per pixel ratio.
  **/
-export const FixedWidthImage: ComponentStory<React.FunctionComponent> = () => (
+export const FixedWidthImage: StoryFn<React.FunctionComponent> = () => (
   <ImageBase src={imageSrc} width="300" height="400" />
 );
 
 /**
  * Preserve ratio using object-fit: cover. Load images depending on image width and device per pixel ratio.
  **/
-export const FixedWidthImageCover: ComponentStory<
-  React.FunctionComponent
-> = () => (
+export const FixedWidthImageCover: StoryFn<React.FunctionComponent> = () => (
   <ImageBase
     src={imageSrc}
     width="300"
@@ -81,15 +79,15 @@ export const FixedWidthImageCover: ComponentStory<
 /**
  * Load images depending on the viewport width.
  **/
-export const UnknownWidthImage: ComponentStory<
-  React.FunctionComponent
-> = () => <ImageBase src={imageSrc} />;
+export const UnknownWidthImage: StoryFn<React.FunctionComponent> = () => (
+  <ImageBase src={imageSrc} />
+);
 
 /**
  * Fit width of the parent container, has own aspect-ratio and object-fit=cover.
  * Load images depending on the viewport width.
  **/
-export const AspectRatioImage: ComponentStory<React.FunctionComponent> = () => (
+export const AspectRatioImage: StoryFn<React.FunctionComponent> = () => (
   <div style={{ width: "50%" }}>
     <ImageBase
       src={imageSrc}
@@ -101,7 +99,7 @@ export const AspectRatioImage: ComponentStory<React.FunctionComponent> = () => (
 /**
  * Fill width and height of the relative parent container, object-fit=cover. Load images depending on the viewport width.
  **/
-export const FillParentImage: ComponentStory<React.FunctionComponent> = () => (
+export const FillParentImage: StoryFn<React.FunctionComponent> = () => (
   <div style={{ width: "50%", aspectRatio: "2/1", position: "relative" }}>
     <ImageBase
       src={imageSrc}
@@ -119,7 +117,7 @@ export const FillParentImage: ComponentStory<React.FunctionComponent> = () => (
  * "sizes" attribute explicitly equal to 100vw allowing to skip the default behavior.
  * See DEFAULT_SIZES in the Image component. Load images depending on the viewport width.
  **/
-export const HeroImage: ComponentStory<React.FunctionComponent> = () => (
+export const HeroImage: StoryFn<React.FunctionComponent> = () => (
   <ImageBase
     src={imageSrc}
     sizes="100vw"

--- a/packages/prisma-client/package.json
+++ b/packages/prisma-client/package.json
@@ -23,7 +23,7 @@
     "@webstudio-is/tsconfig": "workspace:^",
     "prisma": "^4.14.0",
     "tsx": "^3.12.6",
-    "typescript": "5.1.3",
+    "typescript": "5.1.6",
     "zod": "^3.21.4"
   },
   "exports": {

--- a/packages/prisma-client/package.json
+++ b/packages/prisma-client/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "checks": "pnpm typecheck",
     "dev": "prisma generate --watch & build-package --watch --no-generated-as-entries",
     "build": "prisma format && prisma generate && build-package --no-generated-as-entries",

--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -47,6 +47,6 @@
     "@webstudio-is/tsconfig": "workspace:^",
     "jest": "^29.6.1",
     "type-fest": "^3.7.1",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   }
 }

--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -26,7 +26,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "checks": "pnpm typecheck && pnpm test",
     "dev": "build-package --watch",

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "checks": "pnpm typecheck",
     "dev": "build-package --watch",
     "build": "build-package",

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -27,7 +27,7 @@
     "@types/uuid": "^8.3.4",
     "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   },
   "exports": {
     ".": {

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -26,7 +26,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "type-fest": "^3.7.1",
-    "typescript": "5.1.3",
+    "typescript": "5.1.6",
     "zod": "^3.21.4"
   },
   "peerDependencies": {

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -10,7 +10,7 @@
     "build": "build-package",
     "build:args": "generate-arg-types './src/components/*.tsx ./src/app/custom-components/*.tsx !./src/**/*.stories.tsx !./src/**/*.ws.tsx' && prettier --write \"**/*.props.ts\"",
     "dts": "tsc --project tsconfig.dts.json",
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
     "checks": "pnpm typecheck && pnpm test"
   },

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -21,6 +21,6 @@
     "@types/node": "^18.11.18",
     "@webstudio-is/tsconfig": "workspace:^",
     "tsx": "^3.12.6",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   }
 }

--- a/packages/sdk-components-react-remix/package.json
+++ b/packages/sdk-components-react-remix/package.json
@@ -37,7 +37,7 @@
     "build": "build-package",
     "build:args": "generate-arg-types './src/*.tsx !./src/**/*.stories.tsx !./src/**/*.ws.tsx' && prettier --write \"**/*.props.ts\"",
     "dts": "tsc --project tsconfig.dts.json",
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "checks": "pnpm typecheck"
   },
   "peerDependencies": {

--- a/packages/sdk-components-react-remix/package.json
+++ b/packages/sdk-components-react-remix/package.json
@@ -60,6 +60,6 @@
     "@webstudio-is/tsconfig": "workspace:^",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   }
 }

--- a/packages/sdk-components-react/package.json
+++ b/packages/sdk-components-react/package.json
@@ -65,6 +65,6 @@
     "@webstudio-is/tsconfig": "workspace:^",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   }
 }

--- a/packages/sdk-components-react/package.json
+++ b/packages/sdk-components-react/package.json
@@ -37,7 +37,7 @@
     "build": "build-package",
     "build:args": "generate-arg-types './src/*.tsx !./src/*.stories.tsx !./src/*.ws.tsx' && prettier --write \"**/*.props.ts\"",
     "dts": "tsc --project tsconfig.dts.json",
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "checks": "pnpm typecheck",
     "storybook:dev": "storybook dev -p 6006",
     "storybook:build": "storybook build"

--- a/packages/sdk-size-test/package.json
+++ b/packages/sdk-size-test/package.json
@@ -38,6 +38,6 @@
     "@types/react-dom": "^18.0.11",
     "@webstudio-is/tsconfig": "workspace:^",
     "size-limit": "^8.2.4",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   }
 }

--- a/packages/trpc-interface/package.json
+++ b/packages/trpc-interface/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://webstudio.is",
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck": "tsc",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "checks": "pnpm typecheck",
     "dev": "build-package --watch",

--- a/packages/trpc-interface/package.json
+++ b/packages/trpc-interface/package.json
@@ -26,7 +26,7 @@
     "@webstudio-is/jest-config": "workspace:^",
     "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   },
   "exports": {
     "./index.server": {

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -21,6 +21,10 @@
     "noFallthroughCasesInSwitch": true,
     "verbatimModuleSyntax": true,
     "emitDeclarationOnly": true,
-    "declaration": true
+    "declaration": true,
+    // types should be generated to provide additional checks
+    // needed only for generation
+    // there is no other way to enable these checks
+    "declarationDir": "node_modules/.ws-typecheck-tmp"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
     devDependencies:
       '@storybook/react-vite':
         specifier: ^7.0.26
-        version: 7.0.26(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)(vite@4.4.2)
+        version: 7.0.26(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)(vite@4.4.2)
       '@types/css-tree':
         specifier: ^2.3.1
         version: 2.3.1(patch_hash=ac22lciodhaj6xmoeignv36gyq)
@@ -43,8 +43,8 @@ importers:
         specifier: ^1.8.6
         version: 1.8.6
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   apps/builder:
     dependencies:
@@ -294,7 +294,7 @@ importers:
         version: 1.18.1(@remix-run/serve@1.18.1)
       '@storybook/react':
         specifier: ^7.0.26
-        version: 7.0.26(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)
+        version: 7.0.26(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)
       '@testing-library/react-hooks':
         specifier: ^8.0.1
         version: 8.0.1(@types/react@18.0.35)(react-dom@18.2.0)(react-test-renderer@18.2.0)(react@18.2.0)
@@ -350,8 +350,8 @@ importers:
         specifier: ^3.7.1
         version: 3.7.1
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/asset-uploader:
     dependencies:
@@ -405,8 +405,8 @@ importers:
         specifier: ^29.6.1
         version: 29.6.1(@types/node@18.11.18)
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -430,8 +430,8 @@ importers:
         specifier: workspace:^
         version: link:../tsconfig
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/css-data:
     dependencies:
@@ -482,8 +482,8 @@ importers:
         specifier: ^3.7.1
         version: 3.7.1
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -534,8 +534,8 @@ importers:
         specifier: ^29.6.1
         version: 29.6.1(@types/node@18.11.18)
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/css-vars:
     devDependencies:
@@ -546,8 +546,8 @@ importers:
         specifier: workspace:^
         version: link:../tsconfig
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/dashboard:
     dependencies:
@@ -571,8 +571,8 @@ importers:
         specifier: workspace:^
         version: link:../tsconfig
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/design-system:
     dependencies:
@@ -693,7 +693,7 @@ importers:
         version: 29.6.1
       '@storybook/react':
         specifier: ^7.0.26
-        version: 7.0.26(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)
+        version: 7.0.26(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)
       '@testing-library/react-hooks':
         specifier: ^8.0.1
         version: 8.0.1(@types/react@18.0.35)(react-dom@18.2.0)(react-test-renderer@18.2.0)(react@18.2.0)
@@ -728,8 +728,8 @@ importers:
         specifier: ^3.12.6
         version: 3.12.6
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/domain:
     dependencies:
@@ -756,17 +756,17 @@ importers:
         specifier: workspace:^
         version: link:../tsconfig
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/eslint-config-custom:
     dependencies:
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.60.0
-        version: 5.60.0(@typescript-eslint/parser@5.60.0)(eslint@8.43.0)(typescript@5.1.3)
+        version: 5.60.0(@typescript-eslint/parser@5.60.0)(eslint@8.43.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
         specifier: ^5.60.0
-        version: 5.60.0(eslint@8.43.0)(typescript@5.1.3)
+        version: 5.60.0(eslint@8.43.0)(typescript@5.1.6)
       eslint:
         specifier: ^8.43.0
         version: 8.43.0
@@ -783,8 +783,8 @@ importers:
         specifier: ^47.0.0
         version: 47.0.0(eslint@8.43.0)
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/feature-flags:
     devDependencies:
@@ -823,8 +823,8 @@ importers:
         specifier: ^29.6.1
         version: 29.6.1(@types/node@18.11.18)
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -842,8 +842,8 @@ importers:
         specifier: workspace:^
         version: link:../tsconfig
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/form-handlers-mailchannels-test:
     dependencies:
@@ -858,8 +858,8 @@ importers:
         specifier: workspace:^
         version: link:../tsconfig
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
       wrangler:
         specifier: ^2.18.0
         version: 2.18.0
@@ -871,7 +871,7 @@ importers:
         version: 3.2.12
       react-docgen-typescript:
         specifier: ^2.2.2
-        version: 2.2.2(typescript@5.1.3)
+        version: 2.2.2(typescript@5.1.6)
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -886,8 +886,8 @@ importers:
         specifier: ^3.12.6
         version: 3.12.6
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/http-client:
     devDependencies:
@@ -913,8 +913,8 @@ importers:
         specifier: ^29.6.1
         version: 29.6.1(@types/node@18.11.18)
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/icons:
     dependencies:
@@ -950,8 +950,8 @@ importers:
         specifier: ^3.12.6
         version: 3.12.6
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/image:
     dependencies:
@@ -967,7 +967,7 @@ importers:
         version: 29.6.1
       '@storybook/react':
         specifier: ^7.0.26
-        version: 7.0.26(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)
+        version: 7.0.26(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)
       '@types/react':
         specifier: ^18.0.35
         version: 18.0.35
@@ -990,8 +990,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/jest-config:
     dependencies:
@@ -1042,8 +1042,8 @@ importers:
         specifier: ^3.12.6
         version: 3.12.6
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -1088,8 +1088,8 @@ importers:
         specifier: workspace:^
         version: link:../tsconfig
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/project-build:
     dependencies:
@@ -1128,8 +1128,8 @@ importers:
         specifier: ^3.7.1
         version: 3.7.1
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/react-sdk:
     dependencies:
@@ -1210,8 +1210,8 @@ importers:
         specifier: ^3.7.1
         version: 3.7.1
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -1235,8 +1235,8 @@ importers:
         specifier: ^3.12.6
         version: 3.12.6
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/sdk-components-react:
     dependencies:
@@ -1267,7 +1267,7 @@ importers:
     devDependencies:
       '@storybook/react':
         specifier: ^7.0.26
-        version: 7.0.26(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)
+        version: 7.0.26(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)
       '@types/react':
         specifier: ^18.0.35
         version: 18.0.35
@@ -1290,8 +1290,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/sdk-components-react-remix:
     dependencies:
@@ -1333,8 +1333,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/sdk-size-test:
     dependencies:
@@ -1388,8 +1388,8 @@ importers:
         specifier: ^8.2.4
         version: 8.2.4
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/storybook-config:
     dependencies:
@@ -1410,10 +1410,10 @@ importers:
         version: 7.0.26(react-dom@18.2.0)(react@18.2.0)
       '@storybook/react':
         specifier: ^7.0.26
-        version: 7.0.26(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)
+        version: 7.0.26(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)
       '@storybook/react-vite':
         specifier: ^7.0.26
-        version: 7.0.26(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)(vite@4.4.2)
+        version: 7.0.26(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)(vite@4.4.2)
       storybook:
         specifier: ^7.0.26
         version: 7.0.26
@@ -1455,8 +1455,8 @@ importers:
         specifier: workspace:^
         version: link:../tsconfig
       typescript:
-        specifier: 5.1.3
-        version: 5.1.3
+        specifier: 5.1.6
+        version: 5.1.6
 
   packages/tsconfig: {}
 
@@ -5117,7 +5117,7 @@ packages:
       '@types/yargs': 17.0.22
       chalk: 4.1.2
 
-  /@joshwooding/vite-plugin-react-docgen-typescript@0.2.1(typescript@5.1.3)(vite@4.4.2):
+  /@joshwooding/vite-plugin-react-docgen-typescript@0.2.1(typescript@5.1.6)(vite@4.4.2):
     resolution: {integrity: sha512-ou4ZJSXMMWHqGS4g8uNRbC5TiTWxAgQZiVucoUrOCWuPrTbkpJbmVyIi9jU72SBry7gQtuMEDp4YR8EEXAg7VQ==}
     peerDependencies:
       typescript: '>= 4.3.x'
@@ -5129,8 +5129,8 @@ packages:
       glob: 7.2.3
       glob-promise: 4.2.2(glob@7.2.3)
       magic-string: 0.27.0
-      react-docgen-typescript: 2.2.2(typescript@5.1.3)
-      typescript: 5.1.3
+      react-docgen-typescript: 2.2.2(typescript@5.1.6)
+      typescript: 5.1.6
       vite: 4.4.2
 
   /@jridgewell/gen-mapping@0.1.1:
@@ -7514,7 +7514,7 @@ packages:
       - encoding
       - supports-color
 
-  /@storybook/builder-vite@7.0.26(typescript@5.1.3)(vite@4.4.2):
+  /@storybook/builder-vite@7.0.26(typescript@5.1.6)(vite@4.4.2):
     resolution: {integrity: sha512-PRvySwvJEBLTZcUCKIULdxeFZeoDeK5odGFN0oIJhGZlOEI7jzbAcBT9SEZUh+Cv4Pk93XFr5+ZJCm/yrmF8RA==}
     peerDependencies:
       '@preact/preset-vite': '*'
@@ -7549,7 +7549,7 @@ packages:
       remark-external-links: 8.0.0
       remark-slug: 6.1.0
       rollup: 3.26.2
-      typescript: 5.1.3
+      typescript: 5.1.6
       vite: 4.4.2
     transitivePeerDependencies:
       - encoding
@@ -7875,7 +7875,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  /@storybook/react-vite@7.0.26(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)(vite@4.4.2):
+  /@storybook/react-vite@7.0.26(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)(vite@4.4.2):
     resolution: {integrity: sha512-yDkZAvlJ9RcXSuGZy8NdDhI394P7CRme7x6VtpgCi+iPaVW9A5laK7zOe1ewYnAcbKH6g7EJWQWDz2+PqAGiFw==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -7883,10 +7883,10 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
       vite: ^3.0.0 || ^4.0.0
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.2.1(typescript@5.1.3)(vite@4.4.2)
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.2.1(typescript@5.1.6)(vite@4.4.2)
       '@rollup/pluginutils': 4.2.1
-      '@storybook/builder-vite': 7.0.26(typescript@5.1.3)(vite@4.4.2)
-      '@storybook/react': 7.0.26(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)
+      '@storybook/builder-vite': 7.0.26(typescript@5.1.6)(vite@4.4.2)
+      '@storybook/react': 7.0.26(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)
       '@vitejs/plugin-react': 3.1.0(vite@4.4.2)
       ast-types: 0.14.2
       magic-string: 0.27.0
@@ -7901,7 +7901,7 @@ packages:
       - typescript
       - vite-plugin-glimmerx
 
-  /@storybook/react@7.0.26(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3):
+  /@storybook/react@7.0.26(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6):
     resolution: {integrity: sha512-+YK/1vF2Pd/PX7Ss5yPCIh9hee7iMVbu86gdjV9n9r6G244jQ7HLtdA01JKfq92/UgoysSWUjUECrxrUvcsh5w==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -7934,7 +7934,7 @@ packages:
       react-element-to-jsx-string: 15.0.0(react-dom@18.2.0)(react@18.2.0)
       ts-dedent: 2.2.0
       type-fest: 2.19.0
-      typescript: 5.1.3
+      typescript: 5.1.6
       util-deprecate: 1.0.2
     transitivePeerDependencies:
       - encoding
@@ -8418,7 +8418,7 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.0
 
-  /@typescript-eslint/eslint-plugin@5.60.0(@typescript-eslint/parser@5.60.0)(eslint@8.43.0)(typescript@5.1.3):
+  /@typescript-eslint/eslint-plugin@5.60.0(@typescript-eslint/parser@5.60.0)(eslint@8.43.0)(typescript@5.1.6):
     resolution: {integrity: sha512-78B+anHLF1TI8Jn/cD0Q00TBYdMgjdOn980JfAVa9yw5sop8nyTfVOQAv6LWywkOGLclDBtv5z3oxN4w7jxyNg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8430,23 +8430,23 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 5.60.0(eslint@8.43.0)(typescript@5.1.3)
+      '@typescript-eslint/parser': 5.60.0(eslint@8.43.0)(typescript@5.1.6)
       '@typescript-eslint/scope-manager': 5.60.0
-      '@typescript-eslint/type-utils': 5.60.0(eslint@8.43.0)(typescript@5.1.3)
-      '@typescript-eslint/utils': 5.60.0(eslint@8.43.0)(typescript@5.1.3)
+      '@typescript-eslint/type-utils': 5.60.0(eslint@8.43.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 5.60.0(eslint@8.43.0)(typescript@5.1.6)
       debug: 4.3.4
       eslint: 8.43.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@5.1.3)
-      typescript: 5.1.3
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser@5.60.0(eslint@8.43.0)(typescript@5.1.3):
+  /@typescript-eslint/parser@5.60.0(eslint@8.43.0)(typescript@5.1.6):
     resolution: {integrity: sha512-jBONcBsDJ9UoTWrARkRRCgDz6wUggmH5RpQVlt7BimSwaTkTjwypGzKORXbR4/2Hqjk9hgwlon2rVQAjWNpkyQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8458,10 +8458,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.60.0
       '@typescript-eslint/types': 5.60.0
-      '@typescript-eslint/typescript-estree': 5.60.0(typescript@5.1.3)
+      '@typescript-eslint/typescript-estree': 5.60.0(typescript@5.1.6)
       debug: 4.3.4
       eslint: 8.43.0
-      typescript: 5.1.3
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -8474,7 +8474,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.60.0
     dev: false
 
-  /@typescript-eslint/type-utils@5.60.0(eslint@8.43.0)(typescript@5.1.3):
+  /@typescript-eslint/type-utils@5.60.0(eslint@8.43.0)(typescript@5.1.6):
     resolution: {integrity: sha512-X7NsRQddORMYRFH7FWo6sA9Y/zbJ8s1x1RIAtnlj6YprbToTiQnM6vxcMu7iYhdunmoC0rUWlca13D5DVHkK2g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8484,12 +8484,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.60.0(typescript@5.1.3)
-      '@typescript-eslint/utils': 5.60.0(eslint@8.43.0)(typescript@5.1.3)
+      '@typescript-eslint/typescript-estree': 5.60.0(typescript@5.1.6)
+      '@typescript-eslint/utils': 5.60.0(eslint@8.43.0)(typescript@5.1.6)
       debug: 4.3.4
       eslint: 8.43.0
-      tsutils: 3.21.0(typescript@5.1.3)
-      typescript: 5.1.3
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -8499,7 +8499,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /@typescript-eslint/typescript-estree@5.60.0(typescript@5.1.3):
+  /@typescript-eslint/typescript-estree@5.60.0(typescript@5.1.6):
     resolution: {integrity: sha512-R43thAuwarC99SnvrBmh26tc7F6sPa2B3evkXp/8q954kYL6Ro56AwASYWtEEi+4j09GbiNAHqYwNNZuNlARGQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8514,13 +8514,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@5.1.3)
-      typescript: 5.1.3
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils@5.60.0(eslint@8.43.0)(typescript@5.1.3):
+  /@typescript-eslint/utils@5.60.0(eslint@8.43.0)(typescript@5.1.6):
     resolution: {integrity: sha512-ba51uMqDtfLQ5+xHtwlO84vkdjrqNzOnqrnwbMHMRY8Tqeme8C2Q8Fc7LajfGR+e3/4LoYiWXUM6BpIIbHJ4hQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8531,7 +8531,7 @@ packages:
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 5.60.0
       '@typescript-eslint/types': 5.60.0
-      '@typescript-eslint/typescript-estree': 5.60.0(typescript@5.1.3)
+      '@typescript-eslint/typescript-estree': 5.60.0(typescript@5.1.6)
       eslint: 8.43.0
       eslint-scope: 5.1.1
       semver: 7.3.8
@@ -10609,7 +10609,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.60.0(eslint@8.43.0)(typescript@5.1.3)
+      '@typescript-eslint/parser': 5.60.0(eslint@8.43.0)(typescript@5.1.6)
       debug: 3.2.7
       eslint: 8.43.0
       eslint-import-resolver-node: 0.3.7
@@ -10627,7 +10627,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.60.0(eslint@8.43.0)(typescript@5.1.3)
+      '@typescript-eslint/parser': 5.60.0(eslint@8.43.0)(typescript@5.1.6)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -15151,12 +15151,12 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /react-docgen-typescript@2.2.2(typescript@5.1.3):
+  /react-docgen-typescript@2.2.2(typescript@5.1.6):
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dependencies:
-      typescript: 5.1.3
+      typescript: 5.1.6
 
   /react-docgen@6.0.0-alpha.3:
     resolution: {integrity: sha512-DDLvB5EV9As1/zoUsct6Iz2Cupw9FObEGD3DMcIs3EDFIoSKyz8FZtoWj3Wj+oodrU4/NfidN0BL5yrapIcTSA==}
@@ -16782,14 +16782,14 @@ packages:
   /tslib@2.6.0:
     resolution: {integrity: sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==}
 
-  /tsutils@3.21.0(typescript@5.1.3):
+  /tsutils@3.21.0(typescript@5.1.6):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.1.3
+      typescript: 5.1.6
     dev: false
 
   /tsx@3.12.6:
@@ -16938,8 +16938,8 @@ packages:
   /typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  /typescript@5.1.3:
-    resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
+  /typescript@5.1.6:
+    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
     engines: {node: '>=14.17'}
     hasBin: true
 


### PR DESCRIPTION
Before we run two configurations of typescript on CI. Though this leads to very long checks. Here I enabled "typecheck" script to generate dummy .d.ts files to enable additional checks.

```diff
pnpm run -r typecheck (serial)
- 239.13s
+ 262.94s
pnpm turbo run size-test build checks dts --force (parallel locally)
- 2m30.609s
+ 1m47.622s
- pnpm turbo run size-test build checks dts --force (Ci)
- 6m 5s
+ pnpm turbo run size-test build checks --force (Ci)
+ 3m 22s
```