### PR TITLE
Support actions copy paste

### DIFF
--- a/apps/builder/app/shared/copy-paste/plugin-instance.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.test.ts
@@ -117,6 +117,19 @@ describe("data sources", () => {
       name: "show",
       value: "box2$stateInitial",
     },
+    {
+      id: "box2$onChange",
+      instanceId: "box2",
+      type: "action",
+      name: "onChange",
+      value: [
+        {
+          type: "execute",
+          args: ["value"],
+          code: `$ws$dataSource$box1$state = value`,
+        },
+      ],
+    },
   ] satisfies Prop[]);
 
   test("are copy pasted when scoped to copied instances", () => {
@@ -156,7 +169,7 @@ describe("data sources", () => {
     );
 
     const propsDifference = getMapDifference(props, propsStore.get());
-    const [newProp1, newProp2, newProp3] = propsDifference.keys();
+    const [newProp1, newProp2, newProp3, newProp4] = propsDifference.keys();
     expect(propsDifference).toEqual(
       toMap([
         {
@@ -176,6 +189,18 @@ describe("data sources", () => {
           id: newProp3,
           instanceId: newBox2,
           value: newDataSource2,
+        },
+        {
+          ...props.get("box2$onChange"),
+          id: newProp4,
+          instanceId: newBox2,
+          value: [
+            {
+              type: "execute",
+              args: ["value"],
+              code: `${encodeDataSourceVariable(newDataSource1)} = value`,
+            },
+          ],
         },
       ])
     );
@@ -203,7 +228,7 @@ describe("data sources", () => {
     expect(dataSourcesDifference).toEqual(new Map());
 
     const propsDifference = getMapDifference(props, propsStore.get());
-    const [newProp1, newProp2] = propsDifference.keys();
+    const [newProp1, newProp2, newProp3] = propsDifference.keys();
     expect(propsDifference).toEqual(
       toMap([
         {
@@ -219,6 +244,13 @@ describe("data sources", () => {
           type: "boolean",
           name: "show",
           value: true,
+        },
+        {
+          id: newProp3,
+          instanceId: newBox2,
+          type: "action",
+          name: "onChange",
+          value: [],
         },
       ])
     );

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -254,6 +254,51 @@ const getTreeData = (targetInstanceSelector: InstanceSelector) => {
         ...getPropTypeAndValue(value),
       } satisfies Prop;
     }
+    if (prop.type === "action") {
+      return {
+        ...prop,
+        value: prop.value.flatMap((value) => {
+          if (value.type !== "execute") {
+            return [value];
+          }
+          let shouldKeepAction = true;
+          validateExpression(value.code, {
+            effectful: true,
+            transformIdentifier: (identifier) => {
+              if (value.args.includes(identifier)) {
+                return identifier;
+              }
+              const id = decodeDataSourceVariable(identifier);
+              if (id === undefined) {
+                return identifier;
+              }
+              if (treeDataSourceIds.has(id) === false) {
+                shouldKeepAction = false;
+                return identifier;
+              }
+              const identifierDeps = dependencies.get(id);
+              if (identifierDeps) {
+                for (const dependency of identifierDeps) {
+                  const id = decodeDataSourceVariable(dependency);
+                  if (id === undefined) {
+                    continue;
+                  }
+                  if (treeDataSourceIds.has(id) === false) {
+                    shouldKeepAction = false;
+                    return identifier;
+                  }
+                }
+              }
+              return identifier;
+            },
+          });
+          if (shouldKeepAction) {
+            return [value];
+          }
+          return [];
+        }),
+      };
+    }
     return prop;
   });
 
@@ -446,7 +491,36 @@ export const onPaste = (clipboardData: string): boolean => {
 
       insertPropsCopyMutable(
         props,
-        data.props,
+        data.props.map((prop) => {
+          if (prop.type === "action") {
+            return {
+              ...prop,
+              value: prop.value.map((value) => {
+                if (value.type !== "execute") {
+                  return value;
+                }
+                return {
+                  ...value,
+                  code: validateExpression(value.code, {
+                    effectful: true,
+                    transformIdentifier: (id) => {
+                      const dataSourceId = decodeDataSourceVariable(id);
+                      if (dataSourceId === undefined) {
+                        return id;
+                      }
+                      const newId = copiedDataSourceIds.get(dataSourceId);
+                      if (newId === undefined) {
+                        return id;
+                      }
+                      return encodeDataSourceVariable(newId);
+                    },
+                  }),
+                };
+              }),
+            };
+          }
+          return prop;
+        }),
         copiedInstanceIds,
         copiedDataSourceIds
       );


### PR DESCRIPTION
Here added action copy paste support.

When all action dependencies are scoped to copied instance new variable nams are ussed.

When some any dependency is not scoped execution is removed from copied prop.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
