### PR TITLE
Update style source sizes, make it more compact

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-input.tsx
@@ -73,7 +73,6 @@ const TextFieldContainer = styled("div", {
   gap: theme.spacing[3],
   p: theme.spacing[3],
   borderRadius: theme.borderRadius[4],
-  minHeight: theme.spacing[12],
   minWidth: 0,
   border: `1px solid ${theme.colors.borderMain}`,
   "&:focus-within": {

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
@@ -128,6 +128,7 @@ const EditableText = ({
     <Text
       truncate
       ref={ref}
+      spellCheck={false}
       css={{
         outline: "none",
         textOverflow: isEditing ? "clip" : "ellipsis",
@@ -194,7 +195,6 @@ const StyleSourceButton = styled("button", {
   display: "block",
   boxSizing: "border-box",
   maxWidth: "100%",
-  padding: theme.spacing[3],
   variants: {
     isEditing: {
       true: {
@@ -207,7 +207,7 @@ const StyleSourceButton = styled("button", {
 });
 
 const StyleSourceState = styled(Text, {
-  padding: theme.spacing[4],
+  padding: theme.spacing[3],
   backgroundColor: theme.colors.backgroundStyleSourceToken,
   borderTopRightRadius: theme.borderRadius[3],
   borderBottomRightRadius: theme.borderRadius[3],
@@ -256,7 +256,7 @@ export const StyleSource = ({
       aria-current={selected && state === undefined}
       role="button"
     >
-      <Flex css={{ flexGrow: 1, padding: theme.spacing[2] }}>
+      <Flex css={{ flexGrow: 1, py: theme.spacing[2], px: theme.spacing[3] }}>
         <StyleSourceButton
           disabled={disabled || isEditing}
           isEditing={isEditing}
@@ -272,7 +272,9 @@ export const StyleSource = ({
         </StyleSourceButton>
       </Flex>
       {stateLabel !== undefined && (
-        <StyleSourceState>{stateLabel}</StyleSourceState>
+        <StyleSourceState css={{ lineHeight: 1 }}>
+          {stateLabel}
+        </StyleSourceState>
       )}
       {showMenu && <Menu>{menuItems}</Menu>}
     </StyleSourceContainer>


### PR DESCRIPTION
closes https://github.com/webstudio-is/webstudio-builder/issues/1964

<img width="246" alt="Screenshot 2023-07-25 at 23 56 06" src="https://github.com/webstudio-is/webstudio-builder/assets/52824/298dc656-441c-4733-a0b4-586d267496ca">
<img width="234" alt="Screenshot 2023-07-25 at 23 56 50" src="https://github.com/webstudio-is/webstudio-builder/assets/52824/4b7389e5-9415-4426-bcbc-31c6f341581a">


## Description

1. Just updates spacings


## Code Review

- [ ] hi @taylornowotny , I need you to do
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
