### PR TITLE
Make name and value for domain records equal size

### DIFF
--- a/apps/builder/app/builder/features/topbar/domains.tsx
+++ b/apps/builder/app/builder/features/topbar/domains.tsx
@@ -508,7 +508,7 @@ const DomainItem = (props: {
         <Grid
           gap={2}
           css={{
-            gridTemplateColumns: `${theme.spacing[18]} ${theme.spacing[18]} 1fr`,
+            gridTemplateColumns: `${theme.spacing[18]} 1fr 1fr`,
           }}
         >
           <Text color="subtle" variant={"titles"}>


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio-builder/issues/1906

## Description

Changed the field size to fit more info for domains

## Steps for reproduction

1. open publish dialog
2. add domain, open settings

<img width="313" alt="Screenshot 2023-07-26 at 01 30 58" src="https://github.com/webstudio-is/webstudio-builder/assets/52824/f2f96805-0a9c-44ff-99d4-8938a9ead9bb">


## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)


## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
