### PR TITLE
Allow to disable components detaching

### DIFF
--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useMemo } from "react";
 import { useStore } from "@nanostores/react";
 import { shallowEqual } from "shallow-equal";
+import { toast } from "@webstudio-is/design-system";
 import type { Instance } from "@webstudio-is/project-build";
+import { generateDataFromEmbedTemplate } from "@webstudio-is/react-sdk";
 import {
   hoveredInstanceSelectorStore,
   instancesStore,
@@ -18,9 +20,9 @@ import {
   findClosestDroppableComponentIndex,
   reparentInstance,
   type InsertConstraints,
+  isInstanceDetachable,
 } from "~/shared/instance-utils";
 import { InstanceTree } from "./tree";
-import { generateDataFromEmbedTemplate } from "@webstudio-is/react-sdk";
 
 export const NavigatorTree = () => {
   const selectedInstanceSelector = useStore(selectedInstanceSelectorStore);
@@ -139,6 +141,10 @@ export const NavigatorTree = () => {
       onSelect={handleSelect}
       onHover={hoveredInstanceSelectorStore.set}
       onDragItemChange={(dragInstanceSelector) => {
+        if (isInstanceDetachable(dragInstanceSelector) === false) {
+          toast.error("Cannot drag instance without its parent instance");
+          return;
+        }
         setState((state) => ({
           ...state,
           dragPayload: {

--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -142,7 +142,9 @@ export const NavigatorTree = () => {
       onHover={hoveredInstanceSelectorStore.set}
       onDragItemChange={(dragInstanceSelector) => {
         if (isInstanceDetachable(dragInstanceSelector) === false) {
-          toast.error("Cannot drag instance without its parent instance");
+          toast.error(
+            "This instance can not be moved outside of its parent component."
+          );
           return;
         }
         setState((state) => ({

--- a/apps/builder/app/canvas/shared/use-drag-drop.ts
+++ b/apps/builder/app/canvas/shared/use-drag-drop.ts
@@ -245,7 +245,9 @@ export const useDragAndDrop = () => {
 
     onStart({ data: dragInstanceSelector }) {
       if (isInstanceDetachable(dragInstanceSelector) === false) {
-        toast.error("Cannot drag instance without its parent instance");
+        toast.error(
+          "This instance can not be moved outside of its parent component."
+        );
         return;
       }
       publish({

--- a/apps/builder/app/canvas/shared/use-drag-drop.ts
+++ b/apps/builder/app/canvas/shared/use-drag-drop.ts
@@ -8,6 +8,7 @@ import {
   useDrag,
   useDrop,
   computeIndicatorPlacement,
+  toast,
 } from "@webstudio-is/design-system";
 import {
   instancesStore,
@@ -22,6 +23,7 @@ import {
   insertTemplateData,
   reparentInstance,
   type InsertConstraints,
+  isInstanceDetachable,
 } from "~/shared/instance-utils";
 import {
   getElementByInstanceSelector,
@@ -242,6 +244,10 @@ export const useDragAndDrop = () => {
     },
 
     onStart({ data: dragInstanceSelector }) {
+      if (isInstanceDetachable(dragInstanceSelector) === false) {
+        toast.error("Cannot drag instance without its parent instance");
+        return;
+      }
       publish({
         type: "dragStart",
         payload: {

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -1,6 +1,7 @@
 import { nanoid } from "nanoid";
 import store from "immerhin";
 import { z } from "zod";
+import { toast } from "@webstudio-is/design-system";
 import {
   Breakpoint,
   DataSource,
@@ -48,6 +49,7 @@ import {
   computeInstancesConstraints,
   deleteInstance,
   findClosestDroppableTarget,
+  isInstanceDetachable,
 } from "../instance-utils";
 import { getMapValuesBy, getMapValuesByKeysSet } from "../array-utils";
 
@@ -175,6 +177,11 @@ const getPropTypeAndValue = (value: unknown) => {
 };
 
 const getTreeData = (targetInstanceSelector: InstanceSelector) => {
+  if (isInstanceDetachable(targetInstanceSelector) === false) {
+    toast.error("Cannot copy instance without its parent instance");
+    return;
+  }
+
   // @todo tell user they can't copy or cut root
   if (targetInstanceSelector.length === 1) {
     return;

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -178,7 +178,9 @@ const getPropTypeAndValue = (value: unknown) => {
 
 const getTreeData = (targetInstanceSelector: InstanceSelector) => {
   if (isInstanceDetachable(targetInstanceSelector) === false) {
-    toast.error("Cannot copy instance without its parent instance");
+    toast.error(
+      "This instance can not be moved outside of its parent component."
+    );
     return;
   }
 

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -1,4 +1,5 @@
 import store from "immerhin";
+import { toast } from "@webstudio-is/design-system";
 import {
   type Instance,
   type Instances,
@@ -70,6 +71,21 @@ export const findClosestEditableInstanceSelector = (
     }
     return getAncestorInstanceSelector(instanceSelector, instanceId);
   }
+};
+
+export const isInstanceDetachable = (instanceSelector: InstanceSelector) => {
+  const instances = instancesStore.get();
+  const metas = registeredComponentMetasStore.get();
+  const [instanceId] = instanceSelector;
+  const instance = instances.get(instanceId);
+  if (instance === undefined) {
+    return false;
+  }
+  const meta = metas.get(instance.component);
+  if (meta === undefined) {
+    return false;
+  }
+  return meta.detachable ?? true;
 };
 
 const traverseInstancesConstraints = (
@@ -321,6 +337,10 @@ export const reparentInstance = (
 };
 
 export const deleteInstance = (instanceSelector: InstanceSelector) => {
+  if (isInstanceDetachable(instanceSelector) === false) {
+    toast.error("Cannot delete instance without its parent instance");
+    return;
+  }
   store.createTransaction(
     [
       instancesStore,

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -338,7 +338,9 @@ export const reparentInstance = (
 
 export const deleteInstance = (instanceSelector: InstanceSelector) => {
   if (isInstanceDetachable(instanceSelector) === false) {
-    toast.error("Cannot delete instance without its parent instance");
+    toast.error(
+      "This instance can not be moved outside of its parent component."
+    );
     return;
   }
   store.createTransaction(

--- a/packages/react-sdk/src/components/component-meta.ts
+++ b/packages/react-sdk/src/components/component-meta.ts
@@ -54,6 +54,10 @@ const WsComponentMeta = z.object({
   requiredAncestors: z.optional(z.array(z.string())),
   invalidAncestors: z.optional(z.array(z.string())),
   stylable: z.optional(z.boolean()),
+  // specifies whether the instance can be deleted,
+  // copied or dragged out of its parent instance
+  // true by default
+  detachable: z.optional(z.boolean()),
   label: z.string(),
   description: z.string().optional(),
   icon: z.string(),

--- a/packages/sdk-components-react/src/radix-tooltip.ws.tsx
+++ b/packages/sdk-components-react/src/radix-tooltip.ws.tsx
@@ -14,6 +14,7 @@ import {
 // @todo add [data-state] to button and link
 export const metaTooltipTrigger: WsComponentMeta = {
   category: "hidden",
+  detachable: false,
   invalidAncestors: [],
   type: "container",
   label: "TooltipTrigger",
@@ -23,6 +24,7 @@ export const metaTooltipTrigger: WsComponentMeta = {
 
 export const metaTooltipContent: WsComponentMeta = {
   category: "hidden",
+  detachable: false,
   invalidAncestors: [],
   type: "container",
   label: "TooltipContent",


### PR DESCRIPTION
Here added meta.detachable flag which allows when set to true disable copying, dragging and deleting instances of this component without ts parent instance.

This is necessary to constrain components based on external code and prevent deleting hidden components user cannot add again.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
