### PR TITLE
Speed up visual regressions build

### DIFF
--- a/.github/workflows/vis-reg-tests.yml
+++ b/.github/workflows/vis-reg-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: ./.github/actions/ci-setup
 
       - name: Build Storybook for Design System
-        run: pnpm turbo run storybook:build --filter=@webstudio-is/design-system
+        run: pnpm run --filter=@webstudio-is/design-system storybook:build
 
       - name: Lost Pixel
         uses: lost-pixel/lost-pixel@v3.1.0
@@ -47,7 +47,7 @@ jobs:
       - uses: ./.github/actions/ci-setup
 
       - name: Build Storybook for Builder
-        run: pnpm turbo run storybook:build --filter=@webstudio-is/builder
+        run: pnpm run --filter=@webstudio-is/builder storybook:build
 
       - name: Lost Pixel
         uses: lost-pixel/lost-pixel@v3.1.0

--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,6 @@
       "dependsOn": ["build", "^checks"]
     },
     "storybook:build": {
-      "dependsOn": ["build"],
       "outputs": ["storybook-static/**"]
     },
     "size-test": {


### PR DESCRIPTION
Since storybook is able to build from packages sources we no longer need to run build script before storybook.

It can reduce build time for 30-60s

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
