### PR TITLE
Support duplicating instances

### DIFF
--- a/apps/builder/app/shared/copy-paste/plugin-instance.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.test.ts
@@ -70,6 +70,62 @@ const getMapDifference = <Type extends Map<unknown, unknown>>(
   return difference;
 };
 
+describe("paste target", () => {
+  // body0
+  //   box1
+  //   box2
+  const instances: Instances = toMap([
+    createInstance("body0", "Body", [
+      { type: "id", value: "box1" },
+      { type: "id", value: "box2" },
+    ]),
+    createInstance("box1", "Box", []),
+    createInstance("box2", "Box", []),
+  ] satisfies Instance[]);
+
+  test("is inside selected instance", () => {
+    instancesStore.set(instances);
+    selectedInstanceSelectorStore.set(["box1", "body0"]);
+    const clipboardData = onCopy() ?? "";
+    selectedInstanceSelectorStore.set(["box2", "body0"]);
+    onPaste(clipboardData);
+
+    const instancesDifference = getMapDifference(
+      instances,
+      instancesStore.get()
+    );
+    const [newBox1] = instancesDifference.keys();
+    expect(instancesStore.get().get("box2")).toEqual(
+      createInstance("box2", "Box", [{ type: "id", value: newBox1 }])
+    );
+    expect(instancesDifference).toEqual(
+      toMap([createInstance(newBox1, "Box", [])])
+    );
+  });
+
+  test("is after selected instance when same as copied", () => {
+    instancesStore.set(instances);
+    selectedInstanceSelectorStore.set(["box1", "body0"]);
+    onPaste(onCopy() ?? "");
+
+    const instancesDifference = getMapDifference(
+      instances,
+      instancesStore.get()
+    );
+    const [newBox1] = instancesDifference.keys();
+    expect(instancesStore.get().get("body0")).toEqual(
+      createInstance("body0", "Body", [
+        { type: "id", value: "box1" },
+        { type: "id", value: newBox1 },
+        { type: "id", value: "box2" },
+      ])
+    );
+    expect(instancesDifference).toEqual(
+      toMap([createInstance(newBox1, "Box", [])])
+    );
+  });
+});
+
 describe("data sources", () => {
   // body0
   //   box1

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -341,7 +341,7 @@ export const onPaste = (clipboardData: string): boolean => {
   const instanceSelector = selectedInstanceSelectorStore.get() ?? [
     selectedPage.rootInstanceId,
   ];
-  let dropTarget: undefined | DroppableTarget;
+  let potentialDropTarget: undefined | DroppableTarget;
   if (shallowEqual(instanceSelector, data.instanceSelector)) {
     // paste after selected instance
     const instances = instancesStore.get();
@@ -355,21 +355,22 @@ export const onPaste = (clipboardData: string): boolean => {
     const indexWithinChildren = parentInstance.children.findIndex(
       (child) => child.type === "id" && child.value === currentInstanceId
     );
-    dropTarget = {
+    potentialDropTarget = {
       parentSelector: instanceSelector.slice(1),
       position: indexWithinChildren + 1,
     };
   } else {
-    dropTarget = findClosestDroppableTarget(
+    potentialDropTarget = findClosestDroppableTarget(
       metas,
       instancesStore.get(),
       instanceSelector,
       computeInstancesConstraints(metas, newInstances, [rootInstanceId])
     );
   }
-  if (dropTarget === undefined) {
+  if (potentialDropTarget === undefined) {
     return false;
   }
+  const dropTarget = potentialDropTarget;
 
   store.createTransaction(
     [

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -1,3 +1,4 @@
+import { shallowEqual } from "shallow-equal";
 import { nanoid } from "nanoid";
 import store from "immerhin";
 import { z } from "zod";
@@ -43,6 +44,7 @@ import {
   insertStyleSourceSelectionsCopyMutable,
   findLocalStyleSourcesWithinInstances,
   mergeNewBreakpointsMutable,
+  type DroppableTarget,
 } from "../tree-utils";
 import {
   computeInstancesConstraints,
@@ -54,6 +56,7 @@ import { getMapValuesBy, getMapValuesByKeysSet } from "../array-utils";
 const version = "@webstudio/instance/v0.1";
 
 const InstanceData = z.object({
+  instanceSelector: z.array(z.string()),
   breakpoints: z.array(Breakpoint),
   instances: z.array(Instance),
   props: z.array(Prop),
@@ -286,6 +289,7 @@ const getTreeData = (targetInstanceSelector: InstanceSelector) => {
   );
 
   return {
+    instanceSelector: targetInstanceSelector,
     breakpoints: treeBreapoints,
     instances: treeInstances,
     styleSources: treeStyleSources,
@@ -337,12 +341,32 @@ export const onPaste = (clipboardData: string): boolean => {
   const instanceSelector = selectedInstanceSelectorStore.get() ?? [
     selectedPage.rootInstanceId,
   ];
-  const dropTarget = findClosestDroppableTarget(
-    metas,
-    instancesStore.get(),
-    instanceSelector,
-    computeInstancesConstraints(metas, newInstances, [rootInstanceId])
-  );
+  let dropTarget: undefined | DroppableTarget;
+  if (shallowEqual(instanceSelector, data.instanceSelector)) {
+    // paste after selected instance
+    const instances = instancesStore.get();
+    // body is not allowed to copy
+    // so clipboard always have at least two level instance selector
+    const [currentInstanceId, parentInstanceId] = instanceSelector;
+    const parentInstance = instances.get(parentInstanceId);
+    if (parentInstance === undefined) {
+      return false;
+    }
+    const indexWithinChildren = parentInstance.children.findIndex(
+      (child) => child.type === "id" && child.value === currentInstanceId
+    );
+    dropTarget = {
+      parentSelector: instanceSelector.slice(1),
+      position: indexWithinChildren + 1,
+    };
+  } else {
+    dropTarget = findClosestDroppableTarget(
+      metas,
+      instancesStore.get(),
+      instanceSelector,
+      computeInstancesConstraints(metas, newInstances, [rootInstanceId])
+    );
+  }
   if (dropTarget === undefined) {
     return false;
   }

--- a/apps/builder/app/shared/shortcuts/shortcuts.ts
+++ b/apps/builder/app/shared/shortcuts/shortcuts.ts
@@ -6,6 +6,7 @@ import {
   editingItemIdStore,
   selectedInstanceSelectorStore,
 } from "../nano-states";
+import { onCopy, onPaste } from "../copy-paste/plugin-instance";
 
 export const shortcuts = {
   esc: "esc",
@@ -52,6 +53,16 @@ export const useSharedShortcuts = ({
       enableOnFormTags: source === "canvas",
       enableOnContentEditable: false,
     },
+    []
+  );
+
+  useHotkeys(
+    "meta+d, ctrl+d",
+    (event) => {
+      event.preventDefault();
+      onPaste(onCopy() ?? "");
+    },
+    {},
     []
   );
 

--- a/apps/builder/app/shared/store-utils.test.ts
+++ b/apps/builder/app/shared/store-utils.test.ts
@@ -50,4 +50,7 @@ test("shallowComputed provides same reference when object/array values not chang
     { type: "a", value: 4 },
   ]);
   prevList = computedList;
+
+  list.off();
+  filtered.off();
 });


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio-builder/issues/1994

Here changed behavior when copy and paste without changing instance selection. Now it works as duplicating and copy is inserted after selection.

Added cmd+d and ctrl+d shortcut to do this with single press without polluting clipboard.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
