### PR TITLE
New build-args types

### DIFF
--- a/packages/sdk-components-react-remix/src/__generated__/form.props.ts
+++ b/packages/sdk-components-react-remix/src/__generated__/form.props.ts
@@ -27,13 +27,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -54,6 +62,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -79,6 +94,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -300,6 +322,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -387,9 +416,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react-remix/src/__generated__/link.props.ts
+++ b/packages/sdk-components-react-remix/src/__generated__/link.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -376,9 +405,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react-remix/src/__generated__/rich-text-link.props.ts
+++ b/packages/sdk-components-react-remix/src/__generated__/rich-text-link.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -376,9 +405,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/blockquote.props.ts
+++ b/packages/sdk-components-react/src/__generated__/blockquote.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -375,9 +404,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/body.props.ts
+++ b/packages/sdk-components-react/src/__generated__/body.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -374,9 +403,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/bold.props.ts
+++ b/packages/sdk-components-react/src/__generated__/bold.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -374,9 +403,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/box.props.ts
+++ b/packages/sdk-components-react/src/__generated__/box.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -374,9 +403,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/button.props.ts
+++ b/packages/sdk-components-react/src/__generated__/button.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -381,9 +410,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/checkbox.props.ts
+++ b/packages/sdk-components-react/src/__generated__/checkbox.props.ts
@@ -27,13 +27,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -54,6 +62,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -79,6 +94,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -300,6 +322,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -380,7 +409,7 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "select",
     type: "string",
-    options: ["enter", "done", "go", "next", "previous", "search", "send"],
+    options: ["search", "enter", "done", "go", "next", "previous", "send"],
   },
   form: { required: false, control: "text", type: "string" },
   formAction: { required: false, control: "text", type: "string" },
@@ -398,8 +427,8 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
-      "text",
       "search",
+      "text",
       "none",
       "tel",
       "url",

--- a/packages/sdk-components-react/src/__generated__/code-text.props.ts
+++ b/packages/sdk-components-react/src/__generated__/code-text.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["inline", "list", "none", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -380,9 +409,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/form.props.ts
+++ b/packages/sdk-components-react/src/__generated__/form.props.ts
@@ -27,13 +27,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -54,6 +62,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -79,6 +94,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -300,6 +322,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -378,9 +407,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/heading.props.ts
+++ b/packages/sdk-components-react/src/__generated__/heading.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -374,9 +403,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/image.props.ts
+++ b/packages/sdk-components-react/src/__generated__/image.props.ts
@@ -26,13 +26,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -53,6 +61,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -78,6 +93,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -299,6 +321,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -388,9 +417,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/input.props.ts
+++ b/packages/sdk-components-react/src/__generated__/input.props.ts
@@ -27,13 +27,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -54,6 +62,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -79,6 +94,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -300,6 +322,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -398,11 +427,11 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "email",
       "tel",
       "url",
-      "search",
       "none",
       "numeric",
       "decimal",

--- a/packages/sdk-components-react/src/__generated__/italic.props.ts
+++ b/packages/sdk-components-react/src/__generated__/italic.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -374,9 +403,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/label.props.ts
+++ b/packages/sdk-components-react/src/__generated__/label.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -376,9 +405,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/link.props.ts
+++ b/packages/sdk-components-react/src/__generated__/link.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -376,9 +405,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/list-item.props.ts
+++ b/packages/sdk-components-react/src/__generated__/list-item.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -374,9 +403,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/list.props.ts
+++ b/packages/sdk-components-react/src/__generated__/list.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -374,9 +403,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/paragraph.props.ts
+++ b/packages/sdk-components-react/src/__generated__/paragraph.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -374,9 +403,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/radio-button.props.ts
+++ b/packages/sdk-components-react/src/__generated__/radio-button.props.ts
@@ -27,13 +27,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -54,6 +62,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -79,6 +94,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -300,6 +322,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -380,7 +409,7 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "select",
     type: "string",
-    options: ["enter", "done", "go", "next", "previous", "search", "send"],
+    options: ["search", "enter", "done", "go", "next", "previous", "send"],
   },
   form: { required: false, control: "text", type: "string" },
   formAction: { required: false, control: "text", type: "string" },
@@ -398,8 +427,8 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
-      "text",
       "search",
+      "text",
       "none",
       "tel",
       "url",

--- a/packages/sdk-components-react/src/__generated__/radix-popover.props.ts
+++ b/packages/sdk-components-react/src/__generated__/radix-popover.props.ts
@@ -45,13 +45,21 @@ export const propsPopoverContent: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -72,6 +80,13 @@ export const propsPopoverContent: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -97,6 +112,13 @@ export const propsPopoverContent: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -318,6 +340,13 @@ export const propsPopoverContent: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -398,9 +427,9 @@ export const propsPopoverContent: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/radix-tooltip.props.ts
+++ b/packages/sdk-components-react/src/__generated__/radix-tooltip.props.ts
@@ -57,13 +57,21 @@ export const propsTooltipContent: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -84,6 +92,13 @@ export const propsTooltipContent: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -109,6 +124,13 @@ export const propsTooltipContent: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -329,6 +351,13 @@ export const propsTooltipContent: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -409,9 +438,9 @@ export const propsTooltipContent: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/rich-text-link.props.ts
+++ b/packages/sdk-components-react/src/__generated__/rich-text-link.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -376,9 +405,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/separator.props.ts
+++ b/packages/sdk-components-react/src/__generated__/separator.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -374,9 +403,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/span.props.ts
+++ b/packages/sdk-components-react/src/__generated__/span.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -374,9 +403,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/subscript.props.ts
+++ b/packages/sdk-components-react/src/__generated__/subscript.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -374,9 +403,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/superscript.props.ts
+++ b/packages/sdk-components-react/src/__generated__/superscript.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -374,9 +403,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/text.props.ts
+++ b/packages/sdk-components-react/src/__generated__/text.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -374,9 +403,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/textarea.props.ts
+++ b/packages/sdk-components-react/src/__generated__/textarea.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -379,9 +408,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/vimeo-play-button.props.ts
+++ b/packages/sdk-components-react/src/__generated__/vimeo-play-button.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -381,9 +410,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/vimeo-preview-image.props.ts
+++ b/packages/sdk-components-react/src/__generated__/vimeo-preview-image.props.ts
@@ -26,13 +26,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -53,6 +61,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -78,6 +93,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -299,6 +321,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -388,9 +417,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/vimeo-spinner.props.ts
+++ b/packages/sdk-components-react/src/__generated__/vimeo-spinner.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -374,9 +403,9 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "none",
-      "search",
       "tel",
       "url",
       "email",

--- a/packages/sdk-components-react/src/__generated__/vimeo.props.ts
+++ b/packages/sdk-components-react/src/__generated__/vimeo.props.ts
@@ -25,13 +25,21 @@ export const props: Record<string, PropMeta> = {
     type: "string",
     options: ["list", "none", "inline", "both"],
   },
-  "aria-busy": {
+  "aria-braillelabel": {
     description:
-      "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
     required: false,
-    control: "boolean",
-    type: "boolean",
+    control: "text",
+    type: "string",
   },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
   "aria-checked": {
     description:
       'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
@@ -52,6 +60,13 @@ export const props: Record<string, PropMeta> = {
     required: false,
     control: "number",
     type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
   },
   "aria-colspan": {
     description:
@@ -77,6 +92,13 @@ export const props: Record<string, PropMeta> = {
   "aria-describedby": {
     description:
       "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
     required: false,
     control: "text",
     type: "string",
@@ -298,6 +320,13 @@ export const props: Record<string, PropMeta> = {
     control: "number",
     type: "number",
   },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
   "aria-rowspan": {
     description:
       "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
@@ -420,10 +449,10 @@ export const props: Record<string, PropMeta> = {
     control: "select",
     type: "string",
     options: [
+      "search",
       "text",
       "url",
       "none",
-      "search",
       "tel",
       "email",
       "numeric",


### PR DESCRIPTION
## Description

Seems like newer props released by mdn
I did nothing just executed build:args

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
