### PR TITLE
(fix): Optional chaining for dataSources in react-sdk

### DIFF
--- a/packages/react-sdk/src/tree/root.ts
+++ b/packages/react-sdk/src/tree/root.ts
@@ -70,7 +70,8 @@ export const InstanceRoot = ({
       (dataSourceVariables) => {
         // set vriables with defaults
         const dataSourceValues: DataSourceValues = new Map();
-        for (const [dataSourceId, dataSource] of data.build.dataSources) {
+        const dataSources = data.build?.dataSources || [];
+        for (const [dataSourceId, dataSource] of dataSources) {
           if (dataSource.type === "variable") {
             const value =
               dataSourceVariables.get(dataSourceId) ?? dataSource.value.value;


### PR DESCRIPTION
I was working with the cli, and when executing few projects. I found there are builds without `dataSources` in them and it seems to break when we start the project.

If it's something happens only in older projects. Please free to close.

<img width="1058" alt="Screenshot 2023-07-28 at 02 26 05" src="https://github.com/webstudio-is/webstudio-builder/assets/11075561/21207c31-255d-4148-9a6f-76a995984659">
