### PR TITLE
Compute indexes within required ancestors

### DIFF
--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -10,6 +10,7 @@ import {
   executeEffectfulExpression,
   encodeVariablesMap,
   decodeVariablesMap,
+  getIndexesOfTypeWithinRequiredAncestors,
 } from "@webstudio-is/react-sdk";
 import * as baseComponents from "@webstudio-is/sdk-components-react";
 import * as baseComponentMetas from "@webstudio-is/sdk-components-react/metas";
@@ -41,6 +42,7 @@ import {
   dataSourceValuesStore,
   dataSourceVariablesStore,
   registeredComponentsStore,
+  registeredComponentMetasStore,
 } from "~/shared/nano-states";
 import { useDragAndDrop } from "./shared/use-drag-drop";
 import { useCopyPaste } from "~/shared/copy-paste";
@@ -78,6 +80,7 @@ const useElementsTree = (
   instances: Instances,
   params: Params
 ) => {
+  const metas = useStore(registeredComponentMetasStore);
   const page = useStore(selectedPageStore);
   const [isPreviewMode] = useIsPreviewMode();
   const rootInstanceId = page?.rootInstanceId ?? "";
@@ -105,15 +108,22 @@ const useElementsTree = (
     []
   );
 
+  const indexesOfTypeWithinRequiredAncestors = useMemo(() => {
+    return getIndexesOfTypeWithinRequiredAncestors(
+      metas,
+      instances,
+      page ? [page.rootInstanceId] : []
+    );
+  }, [metas, instances, page]);
+
   return useMemo(() => {
     return createElementsTree({
       renderer: isPreviewMode ? "preview" : "canvas",
       imageBaseUrl: params.imageBaseUrl,
       assetBaseUrl: params.assetBaseUrl,
       instances,
-      // fallback to temporary root instance to render scripts
-      // and receive real data from builder
       rootInstanceId,
+      indexesOfTypeWithinRequiredAncestors,
       propsByInstanceIdStore,
       assetsStore,
       pagesStore: pagesMapStore,
@@ -137,6 +147,7 @@ const useElementsTree = (
     components,
     pagesMapStore,
     isPreviewMode,
+    indexesOfTypeWithinRequiredAncestors,
   ]);
 };
 

--- a/packages/react-sdk/src/context.tsx
+++ b/packages/react-sdk/src/context.tsx
@@ -3,6 +3,7 @@ import { createContext } from "react";
 import type { Assets } from "@webstudio-is/asset-uploader";
 import type { DataSource, Instance, Prop } from "@webstudio-is/project-build";
 import type { Pages, PropsByInstanceId } from "./props";
+import type { IndexesOfTypeWithinRequiredAncestors } from "./instance-utils";
 
 export type Params = {
   renderer?: "canvas" | "preview";
@@ -50,6 +51,7 @@ export const ReactSdkContext = createContext<
       prop: Prop["name"],
       value: unknown
     ) => void;
+    indexesOfTypeWithinRequiredAncestors: IndexesOfTypeWithinRequiredAncestors;
   }
 >({
   imageBaseUrl: "/",
@@ -67,4 +69,5 @@ export const ReactSdkContext = createContext<
   setBoundDataSourceValue: () => {
     throw Error("React SDK setBoundDataSourceValue is not implemented");
   },
+  indexesOfTypeWithinRequiredAncestors: new Map(),
 });

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -18,6 +18,7 @@ export {
   usePropUrl,
   usePropAsset,
   getInstanceIdFromComponentProps,
+  useIndexOfTypeWithinRequiredAncestors,
 } from "./props";
 export { type Params, ReactSdkContext } from "./context";
 export {
@@ -33,3 +34,4 @@ export {
   decodeVariablesMap,
 } from "./expression";
 export { renderComponentTemplate } from "./component-renderer";
+export { getIndexesOfTypeWithinRequiredAncestors } from "./instance-utils";

--- a/packages/react-sdk/src/instance-utils.test.ts
+++ b/packages/react-sdk/src/instance-utils.test.ts
@@ -1,0 +1,91 @@
+import { test, expect } from "@jest/globals";
+import type { Instance, Instances } from "@webstudio-is/project-build";
+import { getIndexesOfTypeWithinRequiredAncestors } from "./instance-utils";
+import type { WsComponentMeta } from ".";
+
+const getIdValuePair = <T extends { id: string }>(item: T) =>
+  [item.id, item] as const;
+
+const toMap = <T extends { id: string }>(list: T[]) =>
+  new Map(list.map(getIdValuePair));
+
+const createInstance = (
+  id: Instance["id"],
+  component: string,
+  children: Instance["children"]
+): Instance => {
+  return { type: "instance", id, component, children };
+};
+
+const createMeta = (meta?: Partial<WsComponentMeta>) => {
+  return { type: "container", label: "", icon: "", ...meta } as const;
+};
+
+test("get indexes of type within required ancestors", () => {
+  // body0
+  //   tabs1
+  //     tabs1list
+  //       tabs1box
+  //         tabs1trigger1
+  //         tabs1trigger2
+  //     tabs1content1
+  //       tabs2
+  //         tabs2list
+  //           tabs2trigger1
+  //         tabs2content1
+  //     tabs1content2
+  const instances: Instances = toMap([
+    createInstance("body0", "Body", [{ type: "id", value: "tabs1" }]),
+    // tabs1
+    createInstance("tabs1", "Tabs", [
+      { type: "id", value: "tabs1list" },
+      { type: "id", value: "tabs1content1" },
+      { type: "id", value: "tabs1content2" },
+    ]),
+    createInstance("tabs1list", "TabsList", [
+      { type: "id", value: "tabs1box" },
+    ]),
+    createInstance("tabs1box", "Box", [
+      { type: "id", value: "tabs1trigger1" },
+      { type: "id", value: "tabs1trigger2" },
+    ]),
+    createInstance("tabs1trigger1", "TabsTrigger", []),
+    createInstance("tabs1trigger2", "TabsTrigger", []),
+    createInstance("tabs1content1", "TabsContent", [
+      { type: "id", value: "tabs2" },
+    ]),
+    createInstance("tabs1content2", "TabsContent", []),
+    // tabs2
+    createInstance("tabs2", "Tabs", [
+      { type: "id", value: "tabs2list" },
+      { type: "id", value: "tabs2content1" },
+    ]),
+    createInstance("tabs2list", "TabsList", [
+      { type: "id", value: "tabs2trigger1" },
+    ]),
+    createInstance("tabs2trigger1", "TabsTrigger", []),
+    createInstance("tabs2content1", "TabsContent", []),
+  ] satisfies Instance[]);
+  const metas = new Map<Instance["component"], WsComponentMeta>([
+    ["Body", createMeta()],
+    ["Box", createMeta()],
+    ["Tabs", createMeta()],
+    ["TabsList", createMeta({ requiredAncestors: ["Tabs"] })],
+    ["TabsTrigger", createMeta({ requiredAncestors: ["TabsList"] })],
+    ["TabsContent", createMeta({ requiredAncestors: ["Tabs"] })],
+  ]);
+  expect(
+    getIndexesOfTypeWithinRequiredAncestors(metas, instances, ["body0"])
+  ).toEqual(
+    new Map([
+      ["Tabs:tabs1list", 0],
+      ["TabsList:tabs1trigger1", 0],
+      ["TabsList:tabs1trigger2", 1],
+      ["Tabs:tabs1content1", 0],
+      ["Tabs:tabs1content2", 1],
+      ["Tabs:tabs2list", 0],
+      ["TabsList:tabs2trigger1", 0],
+      ["Tabs:tabs2content1", 0],
+    ])
+  );
+});

--- a/packages/react-sdk/src/instance-utils.ts
+++ b/packages/react-sdk/src/instance-utils.ts
@@ -1,0 +1,73 @@
+import type { Instance, Instances } from "@webstudio-is/project-build";
+import type { WsComponentMeta } from "./components/component-meta";
+
+export type IndexesOfTypeWithinRequiredAncestors = Map<
+  // ancestorInstanceComponent;childInstanceId
+  `${Instance["component"]}:${Instance["id"]}`,
+  number
+>;
+
+export const getIndexesOfTypeWithinRequiredAncestors = (
+  metas: Map<Instance["component"], WsComponentMeta>,
+  instances: Instances,
+  rootIds: Instance["id"][]
+) => {
+  const requiredAncestors = new Set<Instance["component"]>();
+  for (const meta of metas.values()) {
+    if (meta.requiredAncestors) {
+      for (const ancestorComponent of meta.requiredAncestors) {
+        requiredAncestors.add(ancestorComponent);
+      }
+    }
+  }
+
+  const indexes: IndexesOfTypeWithinRequiredAncestors = new Map();
+
+  const traverseInstances = (
+    instances: Instances,
+    instanceId: Instance["id"],
+    latestIndexes = new Map<
+      Instance["component"],
+      Map<Instance["component"], number>
+    >()
+  ) => {
+    const instance = instances.get(instanceId);
+    if (instance === undefined) {
+      return;
+    }
+    const meta = metas.get(instance.component);
+    if (meta === undefined) {
+      return;
+    }
+    if (requiredAncestors.has(instance.component)) {
+      latestIndexes = new Map(latestIndexes);
+      latestIndexes.set(instance.component, new Map());
+    }
+
+    if (meta.requiredAncestors) {
+      for (const ancestorComponent of meta.requiredAncestors) {
+        const ancestorIndexes = latestIndexes.get(ancestorComponent);
+        if (ancestorIndexes === undefined) {
+          continue;
+        }
+        let index = ancestorIndexes.get(instance.component) ?? -1;
+        index += 1;
+        ancestorIndexes.set(instance.component, index);
+        indexes.set(`${ancestorComponent}:${instance.id}`, index);
+      }
+    }
+
+    for (const child of instance.children) {
+      if (child.type === "id") {
+        traverseInstances(instances, child.value, latestIndexes);
+      }
+    }
+  };
+
+  const latestIndexes = new Map();
+  for (const instanceId of rootIds) {
+    traverseInstances(instances, instanceId, latestIndexes);
+  }
+
+  return indexes;
+};

--- a/packages/react-sdk/src/props.ts
+++ b/packages/react-sdk/src/props.ts
@@ -213,3 +213,13 @@ export const getInstanceIdFromComponentProps = (
 ) => {
   return props[idAttribute] as string;
 };
+
+export const useIndexOfTypeWithinRequiredAncestors = (
+  props: Record<string, unknown>,
+  ancestorComponent: Instance["component"]
+) => {
+  const { indexesOfTypeWithinRequiredAncestors } = useContext(ReactSdkContext);
+  const instanceId = getInstanceIdFromComponentProps(props);
+  const key = `${ancestorComponent}:${instanceId}` as const;
+  return indexesOfTypeWithinRequiredAncestors.get(key) ?? -1;
+};

--- a/packages/react-sdk/src/tree/create-elements-tree.tsx
+++ b/packages/react-sdk/src/tree/create-elements-tree.tsx
@@ -15,6 +15,7 @@ import {
 } from "../context";
 import type { Pages, PropsByInstanceId } from "../props";
 import type { WebstudioComponentProps } from "./webstudio-component";
+import type { IndexesOfTypeWithinRequiredAncestors } from "../instance-utils";
 
 type InstanceSelector = Instance["id"][];
 
@@ -30,6 +31,7 @@ export const createElementsTree = ({
   dataSourceValuesStore,
   executeEffectfulExpression,
   onDataSourceUpdate,
+  indexesOfTypeWithinRequiredAncestors,
   Component,
   components,
   scripts,
@@ -46,6 +48,7 @@ export const createElementsTree = ({
   ) => DataSourceValues;
   dataSourceValuesStore: ReadableAtom<DataSourceValues>;
   onDataSourceUpdate: (newValues: DataSourceValues) => void;
+  indexesOfTypeWithinRequiredAncestors: IndexesOfTypeWithinRequiredAncestors;
 
   Component: ForwardRefExoticComponent<
     WebstudioComponentProps & RefAttributes<HTMLElement>
@@ -88,6 +91,7 @@ export const createElementsTree = ({
         renderer,
         imageBaseUrl,
         assetBaseUrl,
+        indexesOfTypeWithinRequiredAncestors,
         executeEffectfulExpression,
         setDataSourceValues: onDataSourceUpdate,
         setBoundDataSourceValue: (instanceId, propName, value) => {

--- a/packages/react-sdk/src/tree/root.ts
+++ b/packages/react-sdk/src/tree/root.ts
@@ -21,6 +21,7 @@ import {
 import { getPropsByInstanceId } from "../props";
 import type { Components } from "../components/components-utils";
 import type { Params, DataSourceValues } from "../context";
+import type { IndexesOfTypeWithinRequiredAncestors } from "../instance-utils";
 
 export type Data = {
   page: Page;
@@ -36,6 +37,7 @@ export type RootPropsData = Omit<Data, "build"> & {
 
 type RootProps = {
   data: RootPropsData;
+  indexesOfTypeWithinRequiredAncestors: IndexesOfTypeWithinRequiredAncestors;
   executeComputingExpressions: (values: DataSourceValues) => DataSourceValues;
   executeEffectfulExpression: (
     expression: string,
@@ -51,6 +53,7 @@ type RootProps = {
 
 export const InstanceRoot = ({
   data,
+  indexesOfTypeWithinRequiredAncestors,
   executeComputingExpressions,
   executeEffectfulExpression,
   Component,
@@ -120,6 +123,7 @@ export const InstanceRoot = ({
     ),
     assetsStore: atom(new Map(data.assets.map((asset) => [asset.id, asset]))),
     pagesStore: atom(new Map(data.pages.map((page) => [page.id, page]))),
+    indexesOfTypeWithinRequiredAncestors,
     executeEffectfulExpression,
     dataSourceValuesStore,
     onDataSourceUpdate,


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/pull/1516

Here added utility to compute indexes within ancestors. This should let us easily co-locate tabs triggers and contents by their inedexes.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
