### PR TITLE
Dialog

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/effects/effects.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/effects/effects.tsx
@@ -87,6 +87,18 @@ export const EffectsSection = ({
           setProperty={setProperty}
           deleteProperty={deleteProperty}
         />
+        <PropertyName
+          label={styleConfigByName("backdropFilter").label}
+          properties={["backdropFilter"]}
+          style={style}
+          onReset={() => deleteProperty("backdropFilter")}
+        />
+        <TextControl
+          property={"backdropFilter"}
+          currentStyle={style}
+          setProperty={setProperty}
+          deleteProperty={deleteProperty}
+        />
       </Grid>
     </CollapsibleSection>
   );

--- a/packages/sdk-components-react/package.json
+++ b/packages/sdk-components-react/package.json
@@ -47,6 +47,7 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-popover": "^1.0.6",
     "@radix-ui/react-tooltip": "^1.0.6",
     "@react-aria/utils": "^3.18.0",

--- a/packages/sdk-components-react/src/__generated__/radix-dialog.props.ts
+++ b/packages/sdk-components-react/src/__generated__/radix-dialog.props.ts
@@ -946,3 +946,1418 @@ export const propsDialogContent: Record<string, PropMeta> = {
   },
   vocab: { required: false, control: "text", type: "string" },
 };
+export const propsDialogClose: Record<string, PropMeta> = {
+  about: { required: false, control: "text", type: "string" },
+  accessKey: { required: false, control: "text", type: "string" },
+  "aria-activedescendant": {
+    description:
+      "Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-atomic": {
+    description:
+      "Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-autocomplete": {
+    description:
+      "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be\npresented if they are made.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["list", "none", "inline", "both"],
+  },
+  "aria-braillelabel": {
+    description:
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
+  "aria-checked": {
+    description:
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-colcount": {
+    description:
+      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-colindex": {
+    description:
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-colspan": {
+    description:
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-controls": {
+    description:
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-current": {
+    description:
+      "Indicates the element that represents the current item within a container or set of related elements.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-describedby": {
+    description:
+      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-details": {
+    description:
+      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-disabled": {
+    description:
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-dropeffect": {
+    description:
+      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["link", "none", "copy", "execute", "move", "popup"],
+  },
+  "aria-errormessage": {
+    description:
+      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-expanded": {
+    description:
+      "Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-flowto": {
+    description:
+      "Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,\nallows assistive technology to override the general default of reading in document source order.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-grabbed": {
+    description:
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-haspopup": {
+    description:
+      "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-hidden": {
+    description:
+      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-invalid": {
+    description:
+      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-keyshortcuts": {
+    description:
+      "Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-label": {
+    description:
+      "Defines a string value that labels the current element.\n@see aria-labelledby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-labelledby": {
+    description:
+      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-level": {
+    description:
+      "Defines the hierarchical level of an element within a structure.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-live": {
+    description:
+      "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.",
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["off", "assertive", "polite"],
+  },
+  "aria-modal": {
+    description: "Indicates whether an element is modal when displayed.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-multiline": {
+    description:
+      "Indicates whether a text box accepts multiple lines of input or only a single line.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-multiselectable": {
+    description:
+      "Indicates that the user may select more than one item from the current selectable descendants.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-orientation": {
+    description:
+      "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.",
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["horizontal", "vertical"],
+  },
+  "aria-owns": {
+    description:
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-placeholder": {
+    description:
+      "Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.\nA hint could be a sample value or a brief description of the expected format.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-posinset": {
+    description:
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-pressed": {
+    description:
+      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-readonly": {
+    description:
+      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-relevant": {
+    description:
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: [
+      "text",
+      "additions",
+      "additions removals",
+      "additions text",
+      "all",
+      "removals",
+      "removals additions",
+      "removals text",
+      "text additions",
+      "text removals",
+    ],
+  },
+  "aria-required": {
+    description:
+      "Indicates that user input is required on the element before a form may be submitted.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-roledescription": {
+    description:
+      "Defines a human-readable, author-localized description for the role of an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-rowcount": {
+    description:
+      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-rowindex": {
+    description:
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-rowspan": {
+    description:
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-selected": {
+    description:
+      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-setsize": {
+    description:
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-sort": {
+    description:
+      "Indicates if items in a table or grid are sorted in ascending or descending order.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["none", "ascending", "descending", "other"],
+  },
+  "aria-valuemax": {
+    description: "Defines the maximum allowed value for a range widget.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuemin": {
+    description: "Defines the minimum allowed value for a range widget.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuenow": {
+    description:
+      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuetext": {
+    description:
+      "Defines the human readable text alternative of aria-valuenow for a range widget.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  asChild: { required: false, control: "boolean", type: "boolean" },
+  autoCapitalize: { required: false, control: "text", type: "string" },
+  autoCorrect: { required: false, control: "text", type: "string" },
+  autoFocus: { required: false, control: "boolean", type: "boolean" },
+  autoSave: { required: false, control: "text", type: "string" },
+  className: { required: false, control: "text", type: "string" },
+  color: { required: false, control: "color", type: "string" },
+  content: { required: false, control: "text", type: "string" },
+  contextMenu: { required: false, control: "text", type: "string" },
+  datatype: { required: false, control: "text", type: "string" },
+  defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  dir: { required: false, control: "text", type: "string" },
+  disabled: { required: false, control: "boolean", type: "boolean" },
+  draggable: { required: false, control: "boolean", type: "boolean" },
+  form: { required: false, control: "text", type: "string" },
+  formAction: { required: false, control: "text", type: "string" },
+  formEncType: { required: false, control: "text", type: "string" },
+  formMethod: { required: false, control: "text", type: "string" },
+  formNoValidate: { required: false, control: "boolean", type: "boolean" },
+  formTarget: { required: false, control: "text", type: "string" },
+  hidden: { required: false, control: "boolean", type: "boolean" },
+  id: { required: false, control: "text", type: "string" },
+  inputMode: {
+    description:
+      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+    required: false,
+    control: "select",
+    type: "string",
+    options: [
+      "search",
+      "text",
+      "none",
+      "tel",
+      "url",
+      "email",
+      "numeric",
+      "decimal",
+    ],
+  },
+  is: {
+    description:
+      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  itemID: { required: false, control: "text", type: "string" },
+  itemProp: { required: false, control: "text", type: "string" },
+  itemRef: { required: false, control: "text", type: "string" },
+  itemScope: { required: false, control: "boolean", type: "boolean" },
+  itemType: { required: false, control: "text", type: "string" },
+  lang: { required: false, control: "text", type: "string" },
+  name: { required: false, control: "text", type: "string" },
+  nonce: { required: false, control: "text", type: "string" },
+  placeholder: { required: false, control: "text", type: "string" },
+  prefix: { required: false, control: "text", type: "string" },
+  property: { required: false, control: "text", type: "string" },
+  radioGroup: { required: false, control: "text", type: "string" },
+  rel: { required: false, control: "text", type: "string" },
+  resource: { required: false, control: "text", type: "string" },
+  results: { required: false, control: "number", type: "number" },
+  rev: { required: false, control: "text", type: "string" },
+  role: { required: false, control: "text", type: "string" },
+  security: { required: false, control: "text", type: "string" },
+  slot: { required: false, control: "text", type: "string" },
+  spellCheck: { required: false, control: "boolean", type: "boolean" },
+  suppressContentEditableWarning: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  suppressHydrationWarning: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  tabIndex: { required: false, control: "number", type: "number" },
+  title: { required: false, control: "text", type: "string" },
+  translate: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["yes", "no"],
+  },
+  type: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["button", "submit", "reset"],
+  },
+  typeof: { required: false, control: "text", type: "string" },
+  unselectable: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["on", "off"],
+  },
+  vocab: { required: false, control: "text", type: "string" },
+};
+export const propsDialogTitle: Record<string, PropMeta> = {
+  about: { required: false, control: "text", type: "string" },
+  accessKey: { required: false, control: "text", type: "string" },
+  "aria-activedescendant": {
+    description:
+      "Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-atomic": {
+    description:
+      "Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-autocomplete": {
+    description:
+      "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be\npresented if they are made.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["list", "none", "inline", "both"],
+  },
+  "aria-braillelabel": {
+    description:
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
+  "aria-checked": {
+    description:
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-colcount": {
+    description:
+      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-colindex": {
+    description:
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-colspan": {
+    description:
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-controls": {
+    description:
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-current": {
+    description:
+      "Indicates the element that represents the current item within a container or set of related elements.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-describedby": {
+    description:
+      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-details": {
+    description:
+      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-disabled": {
+    description:
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-dropeffect": {
+    description:
+      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["link", "none", "copy", "execute", "move", "popup"],
+  },
+  "aria-errormessage": {
+    description:
+      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-expanded": {
+    description:
+      "Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-flowto": {
+    description:
+      "Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,\nallows assistive technology to override the general default of reading in document source order.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-grabbed": {
+    description:
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-haspopup": {
+    description:
+      "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-hidden": {
+    description:
+      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-invalid": {
+    description:
+      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-keyshortcuts": {
+    description:
+      "Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-label": {
+    description:
+      "Defines a string value that labels the current element.\n@see aria-labelledby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-labelledby": {
+    description:
+      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-level": {
+    description:
+      "Defines the hierarchical level of an element within a structure.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-live": {
+    description:
+      "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.",
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["off", "assertive", "polite"],
+  },
+  "aria-modal": {
+    description: "Indicates whether an element is modal when displayed.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-multiline": {
+    description:
+      "Indicates whether a text box accepts multiple lines of input or only a single line.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-multiselectable": {
+    description:
+      "Indicates that the user may select more than one item from the current selectable descendants.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-orientation": {
+    description:
+      "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.",
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["horizontal", "vertical"],
+  },
+  "aria-owns": {
+    description:
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-placeholder": {
+    description:
+      "Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.\nA hint could be a sample value or a brief description of the expected format.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-posinset": {
+    description:
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-pressed": {
+    description:
+      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-readonly": {
+    description:
+      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-relevant": {
+    description:
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: [
+      "text",
+      "additions",
+      "additions removals",
+      "additions text",
+      "all",
+      "removals",
+      "removals additions",
+      "removals text",
+      "text additions",
+      "text removals",
+    ],
+  },
+  "aria-required": {
+    description:
+      "Indicates that user input is required on the element before a form may be submitted.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-roledescription": {
+    description:
+      "Defines a human-readable, author-localized description for the role of an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-rowcount": {
+    description:
+      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-rowindex": {
+    description:
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-rowspan": {
+    description:
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-selected": {
+    description:
+      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-setsize": {
+    description:
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-sort": {
+    description:
+      "Indicates if items in a table or grid are sorted in ascending or descending order.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["none", "ascending", "descending", "other"],
+  },
+  "aria-valuemax": {
+    description: "Defines the maximum allowed value for a range widget.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuemin": {
+    description: "Defines the minimum allowed value for a range widget.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuenow": {
+    description:
+      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuetext": {
+    description:
+      "Defines the human readable text alternative of aria-valuenow for a range widget.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  asChild: { required: false, control: "boolean", type: "boolean" },
+  autoCapitalize: { required: false, control: "text", type: "string" },
+  autoCorrect: { required: false, control: "text", type: "string" },
+  autoFocus: { required: false, control: "boolean", type: "boolean" },
+  autoSave: { required: false, control: "text", type: "string" },
+  className: { required: false, control: "text", type: "string" },
+  color: { required: false, control: "color", type: "string" },
+  content: { required: false, control: "text", type: "string" },
+  contextMenu: { required: false, control: "text", type: "string" },
+  datatype: { required: false, control: "text", type: "string" },
+  defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  dir: { required: false, control: "text", type: "string" },
+  draggable: { required: false, control: "boolean", type: "boolean" },
+  hidden: { required: false, control: "boolean", type: "boolean" },
+  id: { required: false, control: "text", type: "string" },
+  inputMode: {
+    description:
+      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+    required: false,
+    control: "select",
+    type: "string",
+    options: [
+      "search",
+      "text",
+      "none",
+      "tel",
+      "url",
+      "email",
+      "numeric",
+      "decimal",
+    ],
+  },
+  is: {
+    description:
+      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  itemID: { required: false, control: "text", type: "string" },
+  itemProp: { required: false, control: "text", type: "string" },
+  itemRef: { required: false, control: "text", type: "string" },
+  itemScope: { required: false, control: "boolean", type: "boolean" },
+  itemType: { required: false, control: "text", type: "string" },
+  lang: { required: false, control: "text", type: "string" },
+  nonce: { required: false, control: "text", type: "string" },
+  placeholder: { required: false, control: "text", type: "string" },
+  prefix: { required: false, control: "text", type: "string" },
+  property: { required: false, control: "text", type: "string" },
+  radioGroup: { required: false, control: "text", type: "string" },
+  rel: { required: false, control: "text", type: "string" },
+  resource: { required: false, control: "text", type: "string" },
+  results: { required: false, control: "number", type: "number" },
+  rev: { required: false, control: "text", type: "string" },
+  role: { required: false, control: "text", type: "string" },
+  security: { required: false, control: "text", type: "string" },
+  slot: { required: false, control: "text", type: "string" },
+  spellCheck: { required: false, control: "boolean", type: "boolean" },
+  suppressContentEditableWarning: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  suppressHydrationWarning: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  tabIndex: { required: false, control: "number", type: "number" },
+  title: { required: false, control: "text", type: "string" },
+  translate: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["yes", "no"],
+  },
+  typeof: { required: false, control: "text", type: "string" },
+  unselectable: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["on", "off"],
+  },
+  vocab: { required: false, control: "text", type: "string" },
+};
+export const propsDialogDescription: Record<string, PropMeta> = {
+  about: { required: false, control: "text", type: "string" },
+  accessKey: { required: false, control: "text", type: "string" },
+  "aria-activedescendant": {
+    description:
+      "Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-atomic": {
+    description:
+      "Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-autocomplete": {
+    description:
+      "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be\npresented if they are made.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["list", "none", "inline", "both"],
+  },
+  "aria-braillelabel": {
+    description:
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
+  "aria-checked": {
+    description:
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-colcount": {
+    description:
+      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-colindex": {
+    description:
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-colspan": {
+    description:
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-controls": {
+    description:
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-current": {
+    description:
+      "Indicates the element that represents the current item within a container or set of related elements.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-describedby": {
+    description:
+      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-details": {
+    description:
+      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-disabled": {
+    description:
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-dropeffect": {
+    description:
+      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["link", "none", "copy", "execute", "move", "popup"],
+  },
+  "aria-errormessage": {
+    description:
+      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-expanded": {
+    description:
+      "Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-flowto": {
+    description:
+      "Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,\nallows assistive technology to override the general default of reading in document source order.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-grabbed": {
+    description:
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-haspopup": {
+    description:
+      "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-hidden": {
+    description:
+      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-invalid": {
+    description:
+      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-keyshortcuts": {
+    description:
+      "Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-label": {
+    description:
+      "Defines a string value that labels the current element.\n@see aria-labelledby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-labelledby": {
+    description:
+      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-level": {
+    description:
+      "Defines the hierarchical level of an element within a structure.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-live": {
+    description:
+      "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.",
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["off", "assertive", "polite"],
+  },
+  "aria-modal": {
+    description: "Indicates whether an element is modal when displayed.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-multiline": {
+    description:
+      "Indicates whether a text box accepts multiple lines of input or only a single line.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-multiselectable": {
+    description:
+      "Indicates that the user may select more than one item from the current selectable descendants.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-orientation": {
+    description:
+      "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.",
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["horizontal", "vertical"],
+  },
+  "aria-owns": {
+    description:
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-placeholder": {
+    description:
+      "Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.\nA hint could be a sample value or a brief description of the expected format.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-posinset": {
+    description:
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-pressed": {
+    description:
+      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-readonly": {
+    description:
+      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-relevant": {
+    description:
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: [
+      "text",
+      "additions",
+      "additions removals",
+      "additions text",
+      "all",
+      "removals",
+      "removals additions",
+      "removals text",
+      "text additions",
+      "text removals",
+    ],
+  },
+  "aria-required": {
+    description:
+      "Indicates that user input is required on the element before a form may be submitted.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-roledescription": {
+    description:
+      "Defines a human-readable, author-localized description for the role of an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-rowcount": {
+    description:
+      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-rowindex": {
+    description:
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-rowspan": {
+    description:
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-selected": {
+    description:
+      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-setsize": {
+    description:
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-sort": {
+    description:
+      "Indicates if items in a table or grid are sorted in ascending or descending order.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["none", "ascending", "descending", "other"],
+  },
+  "aria-valuemax": {
+    description: "Defines the maximum allowed value for a range widget.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuemin": {
+    description: "Defines the minimum allowed value for a range widget.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuenow": {
+    description:
+      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuetext": {
+    description:
+      "Defines the human readable text alternative of aria-valuenow for a range widget.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  asChild: { required: false, control: "boolean", type: "boolean" },
+  autoCapitalize: { required: false, control: "text", type: "string" },
+  autoCorrect: { required: false, control: "text", type: "string" },
+  autoFocus: { required: false, control: "boolean", type: "boolean" },
+  autoSave: { required: false, control: "text", type: "string" },
+  className: { required: false, control: "text", type: "string" },
+  color: { required: false, control: "color", type: "string" },
+  content: { required: false, control: "text", type: "string" },
+  contextMenu: { required: false, control: "text", type: "string" },
+  datatype: { required: false, control: "text", type: "string" },
+  defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  dir: { required: false, control: "text", type: "string" },
+  draggable: { required: false, control: "boolean", type: "boolean" },
+  hidden: { required: false, control: "boolean", type: "boolean" },
+  id: { required: false, control: "text", type: "string" },
+  inputMode: {
+    description:
+      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+    required: false,
+    control: "select",
+    type: "string",
+    options: [
+      "search",
+      "text",
+      "none",
+      "tel",
+      "url",
+      "email",
+      "numeric",
+      "decimal",
+    ],
+  },
+  is: {
+    description:
+      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  itemID: { required: false, control: "text", type: "string" },
+  itemProp: { required: false, control: "text", type: "string" },
+  itemRef: { required: false, control: "text", type: "string" },
+  itemScope: { required: false, control: "boolean", type: "boolean" },
+  itemType: { required: false, control: "text", type: "string" },
+  lang: { required: false, control: "text", type: "string" },
+  nonce: { required: false, control: "text", type: "string" },
+  placeholder: { required: false, control: "text", type: "string" },
+  prefix: { required: false, control: "text", type: "string" },
+  property: { required: false, control: "text", type: "string" },
+  radioGroup: { required: false, control: "text", type: "string" },
+  rel: { required: false, control: "text", type: "string" },
+  resource: { required: false, control: "text", type: "string" },
+  results: { required: false, control: "number", type: "number" },
+  rev: { required: false, control: "text", type: "string" },
+  role: { required: false, control: "text", type: "string" },
+  security: { required: false, control: "text", type: "string" },
+  slot: { required: false, control: "text", type: "string" },
+  spellCheck: { required: false, control: "boolean", type: "boolean" },
+  suppressContentEditableWarning: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  suppressHydrationWarning: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  tabIndex: { required: false, control: "number", type: "number" },
+  title: { required: false, control: "text", type: "string" },
+  translate: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["yes", "no"],
+  },
+  typeof: { required: false, control: "text", type: "string" },
+  unselectable: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["on", "off"],
+  },
+  vocab: { required: false, control: "text", type: "string" },
+};

--- a/packages/sdk-components-react/src/__generated__/radix-dialog.props.ts
+++ b/packages/sdk-components-react/src/__generated__/radix-dialog.props.ts
@@ -1,0 +1,948 @@
+import type { PropMeta } from "@webstudio-is/generate-arg-types";
+
+export const propsDialog: Record<string, PropMeta> = {
+  defaultOpen: { required: false, control: "boolean", type: "boolean" },
+  isOpen: {
+    required: true,
+    control: "radio",
+    type: "string",
+    options: ["open", "initial", "closed"],
+  },
+  modal: { required: false, control: "boolean", type: "boolean" },
+  open: { required: false, control: "boolean", type: "boolean" },
+};
+export const propsDialogTrigger: Record<string, PropMeta> = {};
+export const propsDialogOverlay: Record<string, PropMeta> = {
+  about: { required: false, control: "text", type: "string" },
+  accessKey: { required: false, control: "text", type: "string" },
+  "aria-activedescendant": {
+    description:
+      "Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-atomic": {
+    description:
+      "Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-autocomplete": {
+    description:
+      "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be\npresented if they are made.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["list", "none", "inline", "both"],
+  },
+  "aria-braillelabel": {
+    description:
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
+  "aria-checked": {
+    description:
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-colcount": {
+    description:
+      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-colindex": {
+    description:
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-colspan": {
+    description:
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-controls": {
+    description:
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-current": {
+    description:
+      "Indicates the element that represents the current item within a container or set of related elements.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-describedby": {
+    description:
+      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-details": {
+    description:
+      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-disabled": {
+    description:
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-dropeffect": {
+    description:
+      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["link", "none", "copy", "execute", "move", "popup"],
+  },
+  "aria-errormessage": {
+    description:
+      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-expanded": {
+    description:
+      "Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-flowto": {
+    description:
+      "Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,\nallows assistive technology to override the general default of reading in document source order.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-grabbed": {
+    description:
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-haspopup": {
+    description:
+      "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-hidden": {
+    description:
+      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-invalid": {
+    description:
+      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-keyshortcuts": {
+    description:
+      "Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-label": {
+    description:
+      "Defines a string value that labels the current element.\n@see aria-labelledby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-labelledby": {
+    description:
+      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-level": {
+    description:
+      "Defines the hierarchical level of an element within a structure.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-live": {
+    description:
+      "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.",
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["off", "assertive", "polite"],
+  },
+  "aria-modal": {
+    description: "Indicates whether an element is modal when displayed.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-multiline": {
+    description:
+      "Indicates whether a text box accepts multiple lines of input or only a single line.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-multiselectable": {
+    description:
+      "Indicates that the user may select more than one item from the current selectable descendants.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-orientation": {
+    description:
+      "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.",
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["horizontal", "vertical"],
+  },
+  "aria-owns": {
+    description:
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-placeholder": {
+    description:
+      "Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.\nA hint could be a sample value or a brief description of the expected format.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-posinset": {
+    description:
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-pressed": {
+    description:
+      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-readonly": {
+    description:
+      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-relevant": {
+    description:
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: [
+      "text",
+      "additions",
+      "additions removals",
+      "additions text",
+      "all",
+      "removals",
+      "removals additions",
+      "removals text",
+      "text additions",
+      "text removals",
+    ],
+  },
+  "aria-required": {
+    description:
+      "Indicates that user input is required on the element before a form may be submitted.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-roledescription": {
+    description:
+      "Defines a human-readable, author-localized description for the role of an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-rowcount": {
+    description:
+      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-rowindex": {
+    description:
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-rowspan": {
+    description:
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-selected": {
+    description:
+      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-setsize": {
+    description:
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-sort": {
+    description:
+      "Indicates if items in a table or grid are sorted in ascending or descending order.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["none", "ascending", "descending", "other"],
+  },
+  "aria-valuemax": {
+    description: "Defines the maximum allowed value for a range widget.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuemin": {
+    description: "Defines the minimum allowed value for a range widget.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuenow": {
+    description:
+      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuetext": {
+    description:
+      "Defines the human readable text alternative of aria-valuenow for a range widget.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  asChild: { required: false, control: "boolean", type: "boolean" },
+  autoCapitalize: { required: false, control: "text", type: "string" },
+  autoCorrect: { required: false, control: "text", type: "string" },
+  autoFocus: { required: false, control: "boolean", type: "boolean" },
+  autoSave: { required: false, control: "text", type: "string" },
+  className: { required: false, control: "text", type: "string" },
+  color: { required: false, control: "color", type: "string" },
+  content: { required: false, control: "text", type: "string" },
+  contextMenu: { required: false, control: "text", type: "string" },
+  datatype: { required: false, control: "text", type: "string" },
+  defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  dir: { required: false, control: "text", type: "string" },
+  draggable: { required: false, control: "boolean", type: "boolean" },
+  hidden: { required: false, control: "boolean", type: "boolean" },
+  id: { required: false, control: "text", type: "string" },
+  inputMode: {
+    description:
+      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+    required: false,
+    control: "select",
+    type: "string",
+    options: [
+      "search",
+      "text",
+      "none",
+      "tel",
+      "url",
+      "email",
+      "numeric",
+      "decimal",
+    ],
+  },
+  is: {
+    description:
+      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  itemID: { required: false, control: "text", type: "string" },
+  itemProp: { required: false, control: "text", type: "string" },
+  itemRef: { required: false, control: "text", type: "string" },
+  itemScope: { required: false, control: "boolean", type: "boolean" },
+  itemType: { required: false, control: "text", type: "string" },
+  lang: { required: false, control: "text", type: "string" },
+  nonce: { required: false, control: "text", type: "string" },
+  placeholder: { required: false, control: "text", type: "string" },
+  prefix: { required: false, control: "text", type: "string" },
+  property: { required: false, control: "text", type: "string" },
+  radioGroup: { required: false, control: "text", type: "string" },
+  rel: { required: false, control: "text", type: "string" },
+  resource: { required: false, control: "text", type: "string" },
+  results: { required: false, control: "number", type: "number" },
+  rev: { required: false, control: "text", type: "string" },
+  role: { required: false, control: "text", type: "string" },
+  security: { required: false, control: "text", type: "string" },
+  slot: { required: false, control: "text", type: "string" },
+  spellCheck: { required: false, control: "boolean", type: "boolean" },
+  suppressContentEditableWarning: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  suppressHydrationWarning: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  tabIndex: { required: false, control: "number", type: "number" },
+  title: { required: false, control: "text", type: "string" },
+  translate: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["yes", "no"],
+  },
+  typeof: { required: false, control: "text", type: "string" },
+  unselectable: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["on", "off"],
+  },
+  vocab: { required: false, control: "text", type: "string" },
+};
+export const propsDialogContent: Record<string, PropMeta> = {
+  about: { required: false, control: "text", type: "string" },
+  accessKey: { required: false, control: "text", type: "string" },
+  "aria-activedescendant": {
+    description:
+      "Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-atomic": {
+    description:
+      "Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-autocomplete": {
+    description:
+      "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be\npresented if they are made.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["list", "none", "inline", "both"],
+  },
+  "aria-braillelabel": {
+    description:
+      "Defines a string value that labels the current element, which is intended to be converted into Braille.\n@see aria-label.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-brailleroledescription": {
+    description:
+      "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.\n@see aria-roledescription.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-busy": { required: false, control: "boolean", type: "boolean" },
+  "aria-checked": {
+    description:
+      'Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.',
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-colcount": {
+    description:
+      "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-colindex": {
+    description:
+      "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-colindextext": {
+    description:
+      "Defines a human readable text alternative of aria-colindex.\n@see aria-rowindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-colspan": {
+    description:
+      "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-controls": {
+    description:
+      "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-current": {
+    description:
+      "Indicates the element that represents the current item within a container or set of related elements.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-describedby": {
+    description:
+      "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-description": {
+    description:
+      "Defines a string value that describes or annotates the current element.\n@see related aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-details": {
+    description:
+      "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-disabled": {
+    description:
+      "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-dropeffect": {
+    description:
+      "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["link", "none", "copy", "execute", "move", "popup"],
+  },
+  "aria-errormessage": {
+    description:
+      "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-expanded": {
+    description:
+      "Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-flowto": {
+    description:
+      "Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,\nallows assistive technology to override the general default of reading in document source order.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-grabbed": {
+    description:
+      'Indicates an element\'s "grabbed" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1',
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-haspopup": {
+    description:
+      "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-hidden": {
+    description:
+      "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-invalid": {
+    description:
+      "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-keyshortcuts": {
+    description:
+      "Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-label": {
+    description:
+      "Defines a string value that labels the current element.\n@see aria-labelledby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-labelledby": {
+    description:
+      "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-level": {
+    description:
+      "Defines the hierarchical level of an element within a structure.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-live": {
+    description:
+      "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.",
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["off", "assertive", "polite"],
+  },
+  "aria-modal": {
+    description: "Indicates whether an element is modal when displayed.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-multiline": {
+    description:
+      "Indicates whether a text box accepts multiple lines of input or only a single line.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-multiselectable": {
+    description:
+      "Indicates that the user may select more than one item from the current selectable descendants.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-orientation": {
+    description:
+      "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.",
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["horizontal", "vertical"],
+  },
+  "aria-owns": {
+    description:
+      "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-placeholder": {
+    description:
+      "Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.\nA hint could be a sample value or a brief description of the expected format.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-posinset": {
+    description:
+      "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-pressed": {
+    description:
+      'Indicates the current "pressed" state of toggle buttons.\n@see aria-checked\n@see aria-selected.',
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-readonly": {
+    description:
+      "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-relevant": {
+    description:
+      "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: [
+      "text",
+      "additions",
+      "additions removals",
+      "additions text",
+      "all",
+      "removals",
+      "removals additions",
+      "removals text",
+      "text additions",
+      "text removals",
+    ],
+  },
+  "aria-required": {
+    description:
+      "Indicates that user input is required on the element before a form may be submitted.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-roledescription": {
+    description:
+      "Defines a human-readable, author-localized description for the role of an element.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-rowcount": {
+    description:
+      "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-rowindex": {
+    description:
+      "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-rowindextext": {
+    description:
+      "Defines a human readable text alternative of aria-rowindex.\n@see aria-colindextext.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  "aria-rowspan": {
+    description:
+      "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-selected": {
+    description:
+      'Indicates the current "selected" state of various widgets.\n@see aria-checked\n@see aria-pressed.',
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  "aria-setsize": {
+    description:
+      "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-sort": {
+    description:
+      "Indicates if items in a table or grid are sorted in ascending or descending order.",
+    required: false,
+    control: "select",
+    type: "string",
+    options: ["none", "ascending", "descending", "other"],
+  },
+  "aria-valuemax": {
+    description: "Defines the maximum allowed value for a range widget.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuemin": {
+    description: "Defines the minimum allowed value for a range widget.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuenow": {
+    description:
+      "Defines the current value for a range widget.\n@see aria-valuetext.",
+    required: false,
+    control: "number",
+    type: "number",
+  },
+  "aria-valuetext": {
+    description:
+      "Defines the human readable text alternative of aria-valuenow for a range widget.",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  asChild: { required: false, control: "boolean", type: "boolean" },
+  autoCapitalize: { required: false, control: "text", type: "string" },
+  autoCorrect: { required: false, control: "text", type: "string" },
+  autoFocus: { required: false, control: "boolean", type: "boolean" },
+  autoSave: { required: false, control: "text", type: "string" },
+  className: { required: false, control: "text", type: "string" },
+  color: { required: false, control: "color", type: "string" },
+  content: { required: false, control: "text", type: "string" },
+  contextMenu: { required: false, control: "text", type: "string" },
+  datatype: { required: false, control: "text", type: "string" },
+  defaultChecked: { required: false, control: "boolean", type: "boolean" },
+  dir: { required: false, control: "text", type: "string" },
+  draggable: { required: false, control: "boolean", type: "boolean" },
+  hidden: { required: false, control: "boolean", type: "boolean" },
+  id: { required: false, control: "text", type: "string" },
+  inputMode: {
+    description:
+      "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+    required: false,
+    control: "select",
+    type: "string",
+    options: [
+      "search",
+      "text",
+      "none",
+      "tel",
+      "url",
+      "email",
+      "numeric",
+      "decimal",
+    ],
+  },
+  is: {
+    description:
+      "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+    required: false,
+    control: "text",
+    type: "string",
+  },
+  itemID: { required: false, control: "text", type: "string" },
+  itemProp: { required: false, control: "text", type: "string" },
+  itemRef: { required: false, control: "text", type: "string" },
+  itemScope: { required: false, control: "boolean", type: "boolean" },
+  itemType: { required: false, control: "text", type: "string" },
+  lang: { required: false, control: "text", type: "string" },
+  nonce: { required: false, control: "text", type: "string" },
+  placeholder: { required: false, control: "text", type: "string" },
+  prefix: { required: false, control: "text", type: "string" },
+  property: { required: false, control: "text", type: "string" },
+  radioGroup: { required: false, control: "text", type: "string" },
+  rel: { required: false, control: "text", type: "string" },
+  resource: { required: false, control: "text", type: "string" },
+  results: { required: false, control: "number", type: "number" },
+  rev: { required: false, control: "text", type: "string" },
+  role: { required: false, control: "text", type: "string" },
+  security: { required: false, control: "text", type: "string" },
+  slot: { required: false, control: "text", type: "string" },
+  spellCheck: { required: false, control: "boolean", type: "boolean" },
+  suppressContentEditableWarning: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  suppressHydrationWarning: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+  tabIndex: { required: false, control: "number", type: "number" },
+  title: { required: false, control: "text", type: "string" },
+  translate: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["yes", "no"],
+  },
+  typeof: { required: false, control: "text", type: "string" },
+  unselectable: {
+    required: false,
+    control: "radio",
+    type: "string",
+    options: ["on", "off"],
+  },
+  vocab: { required: false, control: "text", type: "string" },
+};

--- a/packages/sdk-components-react/src/components.ts
+++ b/packages/sdk-components-react/src/components.ts
@@ -37,4 +37,7 @@ export {
   DialogContent,
   DialogTrigger,
   DialogOverlay,
+  DialogClose,
+  DialogDescription,
+  DialogTitle,
 } from "./radix-dialog";

--- a/packages/sdk-components-react/src/components.ts
+++ b/packages/sdk-components-react/src/components.ts
@@ -32,3 +32,9 @@ export { VimeoPlayButton } from "./vimeo-play-button";
 export { VimeoSpinner } from "./vimeo-spinner";
 export { Tooltip, TooltipContent, TooltipTrigger } from "./radix-tooltip";
 export { Popover, PopoverContent, PopoverTrigger } from "./radix-popover";
+export {
+  Dialog,
+  DialogContent,
+  DialogTrigger,
+  DialogOverlay,
+} from "./radix-dialog";

--- a/packages/sdk-components-react/src/metas.ts
+++ b/packages/sdk-components-react/src/metas.ts
@@ -47,4 +47,7 @@ export {
   metaDialogContent as DialogContent,
   metaDialogTrigger as DialogTrigger,
   metaDialogOverlay as DialogOverlay,
+  metaDialogClose as DialogClose,
+  metaDialogDescription as DialogDescription,
+  metaDialogTitle as DialogTitle,
 } from "./radix-dialog.ws";

--- a/packages/sdk-components-react/src/metas.ts
+++ b/packages/sdk-components-react/src/metas.ts
@@ -41,3 +41,10 @@ export {
   metaPopoverContent as PopoverContent,
   metaPopoverTrigger as PopoverTrigger,
 } from "./radix-popover.ws";
+
+export {
+  metaDialog as Dialog,
+  metaDialogContent as DialogContent,
+  metaDialogTrigger as DialogTrigger,
+  metaDialogOverlay as DialogOverlay,
+} from "./radix-dialog.ws";

--- a/packages/sdk-components-react/src/props.ts
+++ b/packages/sdk-components-react/src/props.ts
@@ -40,3 +40,9 @@ export {
   propsMetaPopoverContent as PopoverContent,
   propsMetaPopoverTrigger as PopoverTrigger,
 } from "./radix-popover.ws";
+export {
+  propsMetaDialog as Dialog,
+  propsMetaDialogContent as DialogContent,
+  propsMetaDialogTrigger as DialogTrigger,
+  propsMetaDialogOverlay as DialogOverlay,
+} from "./radix-dialog.ws";

--- a/packages/sdk-components-react/src/props.ts
+++ b/packages/sdk-components-react/src/props.ts
@@ -45,4 +45,7 @@ export {
   propsMetaDialogContent as DialogContent,
   propsMetaDialogTrigger as DialogTrigger,
   propsMetaDialogOverlay as DialogOverlay,
+  propsMetaDialogClose as DialogClose,
+  propsMetaDialogDescription as DialogDescription,
+  propsMetaDialogTitle as DialogTitle,
 } from "./radix-dialog.ws";

--- a/packages/sdk-components-react/src/radix-dialog.tsx
+++ b/packages/sdk-components-react/src/radix-dialog.tsx
@@ -86,3 +86,6 @@ export const DialogOverlay = forwardRef<
 });
 
 export const DialogContent = DialogPrimitive.Content;
+export const DialogClose = DialogPrimitive.Close;
+export const DialogTitle = DialogPrimitive.Title;
+export const DialogDescription = DialogPrimitive.Description;

--- a/packages/sdk-components-react/src/radix-dialog.tsx
+++ b/packages/sdk-components-react/src/radix-dialog.tsx
@@ -5,7 +5,6 @@ import * as DialogPrimitive from "@radix-ui/react-dialog";
 import {
   splitPropsWithWebstudioAttributes,
   type WebstudioAttributes,
-  type WebstudioComponentProps,
 } from "@webstudio-is/react-sdk";
 
 import {
@@ -14,7 +13,6 @@ import {
   type ComponentPropsWithoutRef,
   Children,
   type ReactNode,
-  type ReactElement,
 } from "react";
 
 /**
@@ -38,7 +36,7 @@ export const Dialog = forwardRef<
   WebstudioAttributes &
     ComponentPropsWithoutRef<typeof DialogPrimitive.Root> &
     BuilderDialogProps
->(({ open: openProp, isOpen, children, ...props }, ref) => {
+>(({ open: openProp, isOpen, ...props }, ref) => {
   const [webstudioAttributes, restProps] =
     splitPropsWithWebstudioAttributes(props);
 
@@ -46,27 +44,9 @@ export const Dialog = forwardRef<
     openProp ??
     (isOpen === "open" ? true : isOpen === "closed" ? false : undefined);
 
-  const dialogTriggers: ReactElement[] = [];
-  const dialogContent: ReactNode[] = [];
-
-  Children.forEach(children, (child) => {
-    if (child !== null && typeof child === "object" && "props" in child) {
-      const instanceProps: WebstudioComponentProps = child.props;
-
-      if (instanceProps.instance.component === "DialogTrigger") {
-        dialogTriggers.push(child);
-        return;
-      }
-    }
-    dialogContent.push(child);
-  });
-
   return (
     <div ref={ref} style={DisplayContentsStyle} {...webstudioAttributes}>
-      <DialogPrimitive.Root open={open} {...restProps}>
-        {dialogTriggers}
-        <DialogPrimitive.Portal>{dialogContent}</DialogPrimitive.Portal>
-      </DialogPrimitive.Root>
+      <DialogPrimitive.Root open={open} {...restProps} />
     </div>
   );
 });
@@ -94,6 +74,15 @@ export const DialogTrigger = forwardRef<
   );
 });
 
-export const DialogOverlay = DialogPrimitive.Overlay;
+export const DialogOverlay = forwardRef<
+  ElementRef<"div">,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>((props, ref) => {
+  return (
+    <DialogPrimitive.DialogPortal>
+      <DialogPrimitive.Overlay ref={ref} {...props} />
+    </DialogPrimitive.DialogPortal>
+  );
+});
 
 export const DialogContent = DialogPrimitive.Content;

--- a/packages/sdk-components-react/src/radix-dialog.tsx
+++ b/packages/sdk-components-react/src/radix-dialog.tsx
@@ -1,0 +1,99 @@
+/* eslint-disable react/display-name */
+// We can't use .displayName until this is merged https://github.com/styleguidist/react-docgen-typescript/pull/449
+
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import {
+  splitPropsWithWebstudioAttributes,
+  type WebstudioAttributes,
+  type WebstudioComponentProps,
+} from "@webstudio-is/react-sdk";
+
+import {
+  forwardRef,
+  type ElementRef,
+  type ComponentPropsWithoutRef,
+  Children,
+  type ReactNode,
+  type ReactElement,
+} from "react";
+
+/**
+ * We don't have support for boolean or undefined nor in UI not at Data variables,
+ * instead of binding on "open" prop we bind variable on a isOpen prop to be able to show Dialog in the builder
+ **/
+type BuilderDialogProps = {
+  isOpen: "initial" | "open" | "closed";
+};
+
+/**
+ * Dialog and DialogTrigger are HTML-less components.
+ * To make them work in our system, we wrap their attributes with a div that has a display: contents property.
+ *
+ * These divs function like fragments, with all web studio-related attributes attached to them.
+ */
+const DisplayContentsStyle = { display: "contents" };
+
+export const Dialog = forwardRef<
+  ElementRef<"div">,
+  WebstudioAttributes &
+    ComponentPropsWithoutRef<typeof DialogPrimitive.Root> &
+    BuilderDialogProps
+>(({ open: openProp, isOpen, children, ...props }, ref) => {
+  const [webstudioAttributes, restProps] =
+    splitPropsWithWebstudioAttributes(props);
+
+  const open =
+    openProp ??
+    (isOpen === "open" ? true : isOpen === "closed" ? false : undefined);
+
+  const dialogTriggers: ReactElement[] = [];
+  const dialogContent: ReactNode[] = [];
+
+  Children.forEach(children, (child) => {
+    if (child !== null && typeof child === "object" && "props" in child) {
+      const instanceProps: WebstudioComponentProps = child.props;
+
+      if (instanceProps.instance.component === "DialogTrigger") {
+        dialogTriggers.push(child);
+        return;
+      }
+    }
+    dialogContent.push(child);
+  });
+
+  return (
+    <div ref={ref} style={DisplayContentsStyle} {...webstudioAttributes}>
+      <DialogPrimitive.Root open={open} {...restProps}>
+        {dialogTriggers}
+        <DialogPrimitive.Portal>{dialogContent}</DialogPrimitive.Portal>
+      </DialogPrimitive.Root>
+    </div>
+  );
+});
+
+/**
+ * We're not exposing the 'asChild' property for the Trigger.
+ * Instead, we're enforcing 'asChild=true' for the Trigger and making it style-less.
+ * This avoids situations where the Trigger inadvertently passes all styles to its child,
+ * which would prevent us from displaying styles properly in the builder.
+ */
+export const DialogTrigger = forwardRef<
+  ElementRef<"div">,
+  WebstudioAttributes & { children: ReactNode }
+>(({ children, ...props }, ref) => {
+  const firstChild = Children.toArray(children)[0];
+  const [webstudioAttributes, restProps] =
+    splitPropsWithWebstudioAttributes(props);
+
+  return (
+    <div ref={ref} style={DisplayContentsStyle} {...webstudioAttributes}>
+      <DialogPrimitive.Trigger asChild={true} {...restProps}>
+        {firstChild ?? <button>Add button or link</button>}
+      </DialogPrimitive.Trigger>
+    </div>
+  );
+});
+
+export const DialogOverlay = DialogPrimitive.Overlay;
+
+export const DialogContent = DialogPrimitive.Content;

--- a/packages/sdk-components-react/src/radix-dialog.ws.tsx
+++ b/packages/sdk-components-react/src/radix-dialog.ws.tsx
@@ -23,6 +23,7 @@ export const metaDialogTrigger: WsComponentMeta = {
   label: "DialogTrigger",
   icon: RadioCheckedIcon,
   stylable: false,
+  detachable: false,
 };
 
 export const metaDialogContent: WsComponentMeta = {
@@ -31,6 +32,7 @@ export const metaDialogContent: WsComponentMeta = {
   type: "container",
   label: "DialogContent",
   icon: RadioCheckedIcon,
+  detachable: false,
 };
 
 export const metaDialogOverlay: WsComponentMeta = {
@@ -39,6 +41,7 @@ export const metaDialogOverlay: WsComponentMeta = {
   type: "container",
   label: "DialogOverlay",
   icon: RadioCheckedIcon,
+  detachable: false,
 };
 
 export const metaDialogTitle: WsComponentMeta = {

--- a/packages/sdk-components-react/src/radix-dialog.ws.tsx
+++ b/packages/sdk-components-react/src/radix-dialog.ws.tsx
@@ -89,46 +89,51 @@ export const metaDialog: WsComponentMeta = {
           component: "DialogOverlay",
           label: "Dialog Overlay",
           props: [],
-          children: [],
-          // fixed inset-0 z-50 bg-background/80 backdrop-blur-sm
+          /**
+           * fixed inset-0 z-50 bg-background/80 backdrop-blur-sm
+           * flex
+           **/
           styles: [
             tc.fixed(),
             tc.inset(0),
             tc.z(50),
             tc.bg("background", 80),
             tc.backdropBlur("sm"),
-          ].flat(),
-        },
-        {
-          type: "instance",
-          component: "DialogContent",
-          label: "Dialog Content",
-          props: [],
-          /**
-           * fixed w-full z-50
-           * grid gap-4 max-w-lg
-           * left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%]
-           * border bg-background p-6 shadow-lg
-           **/
-          styles: [
-            tc.fixed(),
-            tc.w("full"),
-            tc.z(50),
-            // tc.grid(), we don't have grid use flex instead
+            // To allow positioning Content
             tc.flex(),
-            tc.gap(4),
-            tc.maxW("lg"),
-            tc.centerAbsolute(),
-            tc.border(),
-            tc.bg("background"),
-            tc.p(6),
-            tc.shadow("lg"),
           ].flat(),
           children: [
             {
               type: "instance",
-              component: "Text",
-              children: [{ type: "text", value: "The text you can edit" }],
+              component: "DialogContent",
+              label: "Dialog Content",
+              props: [],
+              /**
+               * fixed w-full z-50
+               * grid gap-4 max-w-lg
+               * m-auto
+               * border bg-background p-6 shadow-lg
+               **/
+              styles: [
+                tc.w("full"),
+                tc.z(50),
+                // tc.grid(), we don't have grid use flex instead
+                tc.flex(),
+                tc.gap(4),
+                tc.m("auto"),
+                tc.maxW("lg"),
+                tc.border(),
+                tc.bg("background"),
+                tc.p(6),
+                tc.shadow("lg"),
+              ].flat(),
+              children: [
+                {
+                  type: "instance",
+                  component: "Text",
+                  children: [{ type: "text", value: "The text you can edit" }],
+                },
+              ],
             },
           ],
         },

--- a/packages/sdk-components-react/src/radix-dialog.ws.tsx
+++ b/packages/sdk-components-react/src/radix-dialog.ws.tsx
@@ -159,6 +159,63 @@ export const metaDialog: WsComponentMeta = {
               children: [
                 {
                   type: "instance",
+                  component: "Box",
+                  label: "Dialog Header",
+                  props: [],
+                  styles: [tc.flex(), tc.flex("col"), tc.gap(1)].flat(),
+                  children: [
+                    {
+                      type: "instance",
+                      component: "DialogTitle",
+                      label: "Dialog Title",
+                      props: [],
+                      /**
+                       * text-lg leading-none tracking-tight
+                       **/
+                      styles: [
+                        tc.my(0),
+                        tc.leading("none"),
+                        tc.text("lg"),
+                        tc.tracking("tight"),
+                      ].flat(),
+                      children: [
+                        {
+                          type: "text",
+                          value: "Dialog Title",
+                        },
+                      ],
+                    },
+                    {
+                      type: "instance",
+                      component: "DialogDescription",
+                      label: "Dialog Description",
+                      props: [],
+                      /**
+                       * text-sm text-muted-foreground
+                       **/
+                      styles: [
+                        tc.my(0),
+                        tc.text("sm"),
+                        tc.text("mutedForeground"),
+                      ].flat(),
+                      children: [
+                        {
+                          type: "text",
+                          value: "dialog description text you can edit",
+                        },
+                      ],
+                    },
+                  ],
+                },
+
+                {
+                  type: "instance",
+                  component: "Text",
+                  children: [{ type: "text", value: "The text you can edit" }],
+                },
+
+                {
+                  type: "instance",
                   component: "DialogClose",
                   label: "Dialog Close",
                   props: [],
@@ -186,19 +243,7 @@ export const metaDialog: WsComponentMeta = {
                     tc.hover(tc.opacity(100)),
                     tc.focus(tc.ring("ring", 2, "background", 2)),
                   ].flat(),
-                  children: [
-                    {
-                      type: "instance",
-                      component: "Text",
-                      children: [{ type: "text", value: "✕" }],
-                    },
-                  ],
-                },
-
-                {
-                  type: "instance",
-                  component: "Text",
-                  children: [{ type: "text", value: "The text you can edit" }],
+                  children: [{ type: "text", value: "✕" }],
                 },
               ],
             },

--- a/packages/sdk-components-react/src/radix-dialog.ws.tsx
+++ b/packages/sdk-components-react/src/radix-dialog.ws.tsx
@@ -119,6 +119,7 @@ export const metaDialog: WsComponentMeta = {
                 tc.z(50),
                 // tc.grid(), we don't have grid use flex instead
                 tc.flex(),
+                tc.flex("col"),
                 tc.gap(4),
                 tc.m("auto"),
                 tc.maxW("lg"),

--- a/packages/sdk-components-react/src/radix-dialog.ws.tsx
+++ b/packages/sdk-components-react/src/radix-dialog.ws.tsx
@@ -10,6 +10,9 @@ import {
   propsDialogContent,
   propsDialogTrigger,
   propsDialogOverlay,
+  propsDialogClose,
+  propsDialogTitle,
+  propsDialogDescription,
 } from "./__generated__/radix-dialog.props";
 
 // @todo add [data-state] to button and link
@@ -35,6 +38,30 @@ export const metaDialogOverlay: WsComponentMeta = {
   invalidAncestors: [],
   type: "container",
   label: "DialogOverlay",
+  icon: RadioCheckedIcon,
+};
+
+export const metaDialogTitle: WsComponentMeta = {
+  category: "hidden",
+  invalidAncestors: [],
+  type: "container",
+  label: "DialogTitle",
+  icon: RadioCheckedIcon,
+};
+
+export const metaDialogDescription: WsComponentMeta = {
+  category: "hidden",
+  invalidAncestors: [],
+  type: "container",
+  label: "DialogDescription",
+  icon: RadioCheckedIcon,
+};
+
+export const metaDialogClose: WsComponentMeta = {
+  category: "hidden",
+  invalidAncestors: [],
+  type: "container",
+  label: "DialogClose",
   icon: RadioCheckedIcon,
 };
 
@@ -127,6 +154,7 @@ export const metaDialog: WsComponentMeta = {
                 tc.bg("background"),
                 tc.p(6),
                 tc.shadow("lg"),
+                tc.relative(),
               ].flat(),
               children: [
                 {
@@ -159,5 +187,20 @@ export const propsMetaDialogContent: WsComponentPropsMeta = {
 
 export const propsMetaDialogOverlay: WsComponentPropsMeta = {
   props: propsDialogOverlay,
+  initialProps: [],
+};
+
+export const propsMetaDialogClose: WsComponentPropsMeta = {
+  props: propsDialogClose,
+  initialProps: [],
+};
+
+export const propsMetaDialogTitle: WsComponentPropsMeta = {
+  props: propsDialogTitle,
+  initialProps: [],
+};
+
+export const propsMetaDialogDescription: WsComponentPropsMeta = {
+  props: propsDialogDescription,
   initialProps: [],
 };

--- a/packages/sdk-components-react/src/radix-dialog.ws.tsx
+++ b/packages/sdk-components-react/src/radix-dialog.ws.tsx
@@ -144,7 +144,6 @@ export const metaDialog: WsComponentMeta = {
               styles: [
                 tc.w("full"),
                 tc.z(50),
-                // tc.grid(), we don't have grid use flex instead
                 tc.flex(),
                 tc.flex("col"),
                 tc.gap(4),

--- a/packages/sdk-components-react/src/radix-dialog.ws.tsx
+++ b/packages/sdk-components-react/src/radix-dialog.ws.tsx
@@ -159,6 +159,44 @@ export const metaDialog: WsComponentMeta = {
               children: [
                 {
                   type: "instance",
+                  component: "DialogClose",
+                  label: "Dialog Close",
+                  props: [],
+                  /**
+                   * absolute right-4 top-4
+                   * rounded-sm opacity-70
+                   * ring-offset-background
+                   * hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2
+                   * flex items-center justify-center h-4 w-4
+                   **/
+                  styles: [
+                    tc.absolute(),
+                    tc.right(4),
+                    tc.top(4),
+                    tc.rounded("sm"),
+                    tc.opacity(70),
+                    tc.flex(),
+                    tc.items("center"),
+                    tc.justify("center"),
+                    tc.h(4),
+                    tc.w(4),
+                    tc.border(0),
+                    tc.bg("transparent"),
+                    tc.outline("none"),
+                    tc.hover(tc.opacity(100)),
+                    tc.focus(tc.ring("ring", 2, "background", 2)),
+                  ].flat(),
+                  children: [
+                    {
+                      type: "instance",
+                      component: "Text",
+                      children: [{ type: "text", value: "✕" }],
+                    },
+                  ],
+                },
+
+                {
+                  type: "instance",
                   component: "Text",
                   children: [{ type: "text", value: "The text you can edit" }],
                 },

--- a/packages/sdk-components-react/src/radix-dialog.ws.tsx
+++ b/packages/sdk-components-react/src/radix-dialog.ws.tsx
@@ -1,0 +1,157 @@
+import { RadioCheckedIcon } from "@webstudio-is/icons/svg";
+import {
+  type WsComponentMeta,
+  type WsComponentPropsMeta,
+} from "@webstudio-is/react-sdk";
+import * as tc from "./theme/tailwind-classes";
+
+import {
+  propsDialog,
+  propsDialogContent,
+  propsDialogTrigger,
+  propsDialogOverlay,
+} from "./__generated__/radix-dialog.props";
+
+// @todo add [data-state] to button and link
+export const metaDialogTrigger: WsComponentMeta = {
+  category: "hidden",
+  invalidAncestors: [],
+  type: "container",
+  label: "DialogTrigger",
+  icon: RadioCheckedIcon,
+  stylable: false,
+};
+
+export const metaDialogContent: WsComponentMeta = {
+  category: "hidden",
+  invalidAncestors: [],
+  type: "container",
+  label: "DialogContent",
+  icon: RadioCheckedIcon,
+};
+
+export const metaDialogOverlay: WsComponentMeta = {
+  category: "hidden",
+  invalidAncestors: [],
+  type: "container",
+  label: "DialogOverlay",
+  icon: RadioCheckedIcon,
+};
+
+/**
+ * Styles source without animations:
+ * https://github.com/shadcn-ui/ui/blob/main/apps/www/registry/default/ui/dialog.tsx
+ *
+ * Attributions
+ * MIT License
+ * Copyright (c) 2023 shadcn
+ **/
+export const metaDialog: WsComponentMeta = {
+  category: "radix",
+  invalidAncestors: [],
+  type: "container",
+  label: "Dialog",
+  icon: RadioCheckedIcon,
+  order: 15,
+  stylable: false,
+  template: [
+    {
+      type: "instance",
+      component: "Dialog",
+      label: "Dialog",
+      props: [
+        {
+          name: "isOpen",
+          // We don't have support for boolean or undefined, instead of binding on open we bind on a string
+          type: "string",
+          value: "initial",
+          dataSourceRef: {
+            type: "variable",
+            name: "isOpen",
+          },
+        },
+      ],
+      children: [
+        {
+          type: "instance",
+          component: "DialogTrigger",
+          props: [],
+          children: [
+            {
+              type: "instance",
+              component: "Button",
+              children: [{ type: "text", value: "Button" }],
+            },
+          ],
+        },
+        {
+          type: "instance",
+          component: "DialogOverlay",
+          label: "Dialog Overlay",
+          props: [],
+          children: [],
+          // fixed inset-0 z-50 bg-background/80 backdrop-blur-sm
+          styles: [
+            tc.fixed(),
+            tc.inset(0),
+            tc.z(50),
+            tc.bg("background", 80),
+            tc.backdropBlur("sm"),
+          ].flat(),
+        },
+        {
+          type: "instance",
+          component: "DialogContent",
+          label: "Dialog Content",
+          props: [],
+          /**
+           * fixed w-full z-50
+           * grid gap-4 max-w-lg
+           * left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%]
+           * border bg-background p-6 shadow-lg
+           **/
+          styles: [
+            tc.fixed(),
+            tc.w("full"),
+            tc.z(50),
+            // tc.grid(), we don't have grid use flex instead
+            tc.flex(),
+            tc.gap(4),
+            tc.maxW("lg"),
+            tc.centerAbsolute(),
+            tc.border(),
+            tc.bg("background"),
+            tc.p(6),
+            tc.shadow("lg"),
+          ].flat(),
+          children: [
+            {
+              type: "instance",
+              component: "Text",
+              children: [{ type: "text", value: "The text you can edit" }],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+export const propsMetaDialog: WsComponentPropsMeta = {
+  props: propsDialog,
+  initialProps: ["isOpen", "modal"],
+};
+
+export const propsMetaDialogTrigger: WsComponentPropsMeta = {
+  props: propsDialogTrigger,
+};
+
+export const propsMetaDialogContent: WsComponentPropsMeta = {
+  props: propsDialogContent,
+  initialProps: [],
+};
+
+export const propsMetaDialogOverlay: WsComponentPropsMeta = {
+  props: propsDialogOverlay,
+  initialProps: [],
+};

--- a/packages/sdk-components-react/src/radix-popover.ws.tsx
+++ b/packages/sdk-components-react/src/radix-popover.ws.tsx
@@ -19,6 +19,7 @@ export const metaPopoverTrigger: WsComponentMeta = {
   label: "PopoverTrigger",
   icon: RadioCheckedIcon,
   stylable: false,
+  detachable: false,
 };
 
 export const metaPopoverContent: WsComponentMeta = {
@@ -27,6 +28,7 @@ export const metaPopoverContent: WsComponentMeta = {
   type: "container",
   label: "PopoverContent",
   icon: RadioCheckedIcon,
+  detachable: false,
 };
 
 /**

--- a/packages/sdk-components-react/src/radix-popover.ws.tsx
+++ b/packages/sdk-components-react/src/radix-popover.ws.tsx
@@ -82,7 +82,6 @@ export const metaPopover: WsComponentMeta = {
           props: [],
           /**
            *  z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none
-           *  z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md
            **/
           styles: [
             tc.z(50),

--- a/packages/sdk-components-react/src/theme/radix-common-types.ts
+++ b/packages/sdk-components-react/src/theme/radix-common-types.ts
@@ -467,4 +467,27 @@ type DefaultTheme = {
 export type EvaluatedDefaultTheme = DefaultTheme & {
   padding: DefaultTheme["spacing"];
   colors: typeof colors;
+  width: DefaultTheme["spacing"] & Record<"full", string>;
+  maxWidth: DefaultTheme["spacing"] &
+    Record<
+      | "none"
+      | "0"
+      | "xs"
+      | "sm"
+      | "md"
+      | "lg"
+      | "xl"
+      | "2xl"
+      | "3xl"
+      | "4xl"
+      | "5xl"
+      | "6xl"
+      | "7xl"
+      | "full"
+      | "min"
+      | "max"
+      | "fit"
+      | "prose",
+      string
+    >;
 };

--- a/packages/sdk-components-react/src/theme/radix-common-types.ts
+++ b/packages/sdk-components-react/src/theme/radix-common-types.ts
@@ -468,6 +468,7 @@ export type EvaluatedDefaultTheme = DefaultTheme & {
   padding: DefaultTheme["spacing"];
   colors: typeof colors;
   width: DefaultTheme["spacing"] & Record<"full", string>;
+  height: DefaultTheme["spacing"];
   margin: DefaultTheme["spacing"] & Record<"auto", string>;
   maxWidth: DefaultTheme["spacing"] &
     Record<

--- a/packages/sdk-components-react/src/theme/radix-common-types.ts
+++ b/packages/sdk-components-react/src/theme/radix-common-types.ts
@@ -468,6 +468,7 @@ export type EvaluatedDefaultTheme = DefaultTheme & {
   padding: DefaultTheme["spacing"];
   colors: typeof colors;
   width: DefaultTheme["spacing"] & Record<"full", string>;
+  margin: DefaultTheme["spacing"] & Record<"auto", string>;
   maxWidth: DefaultTheme["spacing"] &
     Record<
       | "none"

--- a/packages/sdk-components-react/src/theme/tailwind-classes.ts
+++ b/packages/sdk-components-react/src/theme/tailwind-classes.ts
@@ -415,6 +415,30 @@ export const gap = (
   ];
 };
 
+export const leading = (
+  lineHeight:
+    | StringEnumToNumeric<keyof EvaluatedDefaultTheme["lineHeight"]>
+    | NonNumeric<keyof EvaluatedDefaultTheme["lineHeight"]>
+): EmbedTemplateStyleDecl[] => {
+  const key = `${lineHeight}` as const;
+  const valueString = theme("lineHeight")[key];
+  const value = parseCssValue("lineHeight", valueString);
+
+  return [{ property: "lineHeight", value }];
+};
+
+export const tracking = (
+  letterSpacing:
+    | StringEnumToNumeric<keyof EvaluatedDefaultTheme["letterSpacing"]>
+    | NonNumeric<keyof EvaluatedDefaultTheme["letterSpacing"]>
+): EmbedTemplateStyleDecl[] => {
+  const key = `${letterSpacing}` as const;
+  const valueString = theme("letterSpacing")[key];
+  const value = parseCssValue("letterSpacing", valueString);
+
+  return [{ property: "letterSpacing", value }];
+};
+
 export const outline = (value: "none"): EmbedTemplateStyleDecl[] => {
   return [
     {

--- a/packages/sdk-components-react/src/theme/tailwind-classes.ts
+++ b/packages/sdk-components-react/src/theme/tailwind-classes.ts
@@ -271,6 +271,12 @@ export const fixed = (): EmbedTemplateStyleDecl[] => {
   return [{ property: "position", value: { type: "keyword", value: "fixed" } }];
 };
 
+export const relative = (): EmbedTemplateStyleDecl[] => {
+  return [
+    { property: "position", value: { type: "keyword", value: "relative" } },
+  ];
+};
+
 export const grid = (): EmbedTemplateStyleDecl[] => {
   return [{ property: "display", value: { type: "keyword", value: "grid" } }];
 };

--- a/packages/sdk-components-react/src/theme/tailwind-classes.ts
+++ b/packages/sdk-components-react/src/theme/tailwind-classes.ts
@@ -101,6 +101,10 @@ type StringEnumToNumeric<T extends string> = T extends `${infer Z extends
   ? Z
   : never;
 
+type NonNumeric<T extends string> = T extends `${infer Z extends number}`
+  ? never
+  : T;
+
 export const border = (
   borderWidth?: StringEnumToNumeric<keyof EvaluatedDefaultTheme["borderWidth"]>
 ): EmbedTemplateStyleDecl[] => {
@@ -151,24 +155,120 @@ export const p = (
 };
 
 export const w = (
-  spacing: StringEnumToNumeric<keyof EvaluatedDefaultTheme["spacing"]>
+  spacing:
+    | StringEnumToNumeric<keyof EvaluatedDefaultTheme["width"]>
+    | NonNumeric<keyof EvaluatedDefaultTheme["width"]>
 ): EmbedTemplateStyleDecl[] => {
   const key = `${spacing}` as const;
-  const valueString = theme("spacing")?.[key] ?? "0";
+  const valueString = theme("width")?.[key] ?? "0";
   const value = parseCssValue("width", valueString);
 
   return [{ property: "width", value }];
 };
 
+export const maxW = (
+  spacing:
+    | StringEnumToNumeric<keyof EvaluatedDefaultTheme["maxWidth"]>
+    | NonNumeric<keyof EvaluatedDefaultTheme["maxWidth"]>
+): EmbedTemplateStyleDecl[] => {
+  const key = `${spacing}` as const;
+  const valueString = theme("maxWidth")?.[key] ?? "0";
+  const value = parseCssValue("width", valueString);
+
+  return [{ property: "maxWidth", value }];
+};
+
+export const inset = (
+  spacing: StringEnumToNumeric<keyof EvaluatedDefaultTheme["spacing"]>
+): EmbedTemplateStyleDecl[] => {
+  const key = `${spacing}` as const;
+  const valueString = theme("spacing")?.[key] ?? "0";
+  const value = parseCssValue("left", valueString);
+
+  return [
+    { property: "top", value },
+    { property: "right", value },
+    { property: "bottom", value },
+    { property: "left", value },
+  ];
+};
+
+export const centerAbsolute = (): EmbedTemplateStyleDecl[] => [
+  {
+    property: "top",
+    value: { type: "unit", value: 50, unit: "%" },
+  },
+  {
+    property: "left",
+    value: { type: "unit", value: 50, unit: "%" },
+  },
+
+  {
+    property: "transform",
+    value: {
+      type: "tuple",
+      value: [
+        { type: "unparsed", value: "translateX(-50%)" },
+        { type: "unparsed", value: "translateY(-50%)" },
+      ],
+    },
+  },
+
+  // translate-x-[-50%] translate-y-[-50%]
+];
+
+export const backdropBlur = (
+  blur: keyof EvaluatedDefaultTheme["blur"]
+): EmbedTemplateStyleDecl[] => {
+  const valueString = theme("blur")[blur];
+  const value = {
+    type: "unparsed" as const,
+    value: `blur(${valueString})`,
+  };
+
+  return [{ property: "backdropFilter", value }];
+};
+
 export const bg = (
-  color: keyof EvaluatedDefaultTheme["colors"]
+  color: keyof EvaluatedDefaultTheme["colors"],
+  alpha?: number
 ): EmbedTemplateStyleDecl[] => {
   const value = parseCssValue("backgroundColor", theme("colors")[color]);
+
+  if (alpha !== undefined && value.type === "rgb") {
+    value.alpha = alpha / 100;
+  }
+
   return [
     {
       property: "backgroundColor",
       value,
     },
+  ];
+};
+
+export const fixed = (): EmbedTemplateStyleDecl[] => {
+  return [{ property: "position", value: { type: "keyword", value: "fixed" } }];
+};
+
+export const grid = (): EmbedTemplateStyleDecl[] => {
+  return [{ property: "display", value: { type: "keyword", value: "grid" } }];
+};
+
+export const flex = (): EmbedTemplateStyleDecl[] => {
+  return [{ property: "display", value: { type: "keyword", value: "flex" } }];
+};
+
+export const gap = (
+  gapValue: StringEnumToNumeric<keyof EvaluatedDefaultTheme["spacing"]>
+): EmbedTemplateStyleDecl[] => {
+  const key = `${gapValue}` as const;
+  const valueString = theme("spacing")?.[key] ?? "0";
+  const value = parseCssValue("rowGap", valueString);
+
+  return [
+    { property: "rowGap", value },
+    { property: "columnGap", value },
   ];
 };
 

--- a/packages/sdk-components-react/src/theme/tailwind-classes.ts
+++ b/packages/sdk-components-react/src/theme/tailwind-classes.ts
@@ -123,7 +123,9 @@ export const border = (
 };
 
 export const px = (
-  padding: StringEnumToNumeric<keyof EvaluatedDefaultTheme["padding"]>
+  padding:
+    | StringEnumToNumeric<keyof EvaluatedDefaultTheme["padding"]>
+    | NonNumeric<keyof EvaluatedDefaultTheme["padding"]>
 ): EmbedTemplateStyleDecl[] => {
   const key = `${padding}` as const;
   const valueString = theme("padding")?.[key] ?? "0";
@@ -136,7 +138,9 @@ export const px = (
 };
 
 export const py = (
-  padding: StringEnumToNumeric<keyof EvaluatedDefaultTheme["padding"]>
+  padding:
+    | StringEnumToNumeric<keyof EvaluatedDefaultTheme["padding"]>
+    | NonNumeric<keyof EvaluatedDefaultTheme["padding"]>
 ): EmbedTemplateStyleDecl[] => {
   const key = `${padding}` as const;
   const valueString = theme("padding")[key];
@@ -149,9 +153,49 @@ export const py = (
 };
 
 export const p = (
-  padding: StringEnumToNumeric<keyof EvaluatedDefaultTheme["padding"]>
+  padding:
+    | StringEnumToNumeric<keyof EvaluatedDefaultTheme["padding"]>
+    | NonNumeric<keyof EvaluatedDefaultTheme["padding"]>
 ): EmbedTemplateStyleDecl[] => {
   return [...px(padding), ...py(padding)];
+};
+
+export const mx = (
+  margin:
+    | StringEnumToNumeric<keyof EvaluatedDefaultTheme["margin"]>
+    | NonNumeric<keyof EvaluatedDefaultTheme["margin"]>
+): EmbedTemplateStyleDecl[] => {
+  const key = `${margin}` as const;
+  const valueString = theme("margin")?.[key] ?? "0";
+  const value = parseCssValue("marginLeft", valueString);
+
+  return [
+    { property: "marginLeft", value },
+    { property: "marginRight", value },
+  ];
+};
+
+export const my = (
+  margin:
+    | StringEnumToNumeric<keyof EvaluatedDefaultTheme["margin"]>
+    | NonNumeric<keyof EvaluatedDefaultTheme["margin"]>
+): EmbedTemplateStyleDecl[] => {
+  const key = `${margin}` as const;
+  const valueString = theme("margin")[key];
+  const value = parseCssValue("marginTop", valueString);
+
+  return [
+    { property: "marginTop", value },
+    { property: "marginBottom", value },
+  ];
+};
+
+export const m = (
+  margin:
+    | StringEnumToNumeric<keyof EvaluatedDefaultTheme["margin"]>
+    | NonNumeric<keyof EvaluatedDefaultTheme["margin"]>
+): EmbedTemplateStyleDecl[] => {
+  return [...mx(margin), ...my(margin)];
 };
 
 export const w = (
@@ -192,30 +236,6 @@ export const inset = (
     { property: "left", value },
   ];
 };
-
-export const centerAbsolute = (): EmbedTemplateStyleDecl[] => [
-  {
-    property: "top",
-    value: { type: "unit", value: 50, unit: "%" },
-  },
-  {
-    property: "left",
-    value: { type: "unit", value: 50, unit: "%" },
-  },
-
-  {
-    property: "transform",
-    value: {
-      type: "tuple",
-      value: [
-        { type: "unparsed", value: "translateX(-50%)" },
-        { type: "unparsed", value: "translateY(-50%)" },
-      ],
-    },
-  },
-
-  // translate-x-[-50%] translate-y-[-50%]
-];
 
 export const backdropBlur = (
   blur: keyof EvaluatedDefaultTheme["blur"]

--- a/packages/sdk-components-react/src/theme/tailwind-classes.ts
+++ b/packages/sdk-components-react/src/theme/tailwind-classes.ts
@@ -275,8 +275,23 @@ export const grid = (): EmbedTemplateStyleDecl[] => {
   return [{ property: "display", value: { type: "keyword", value: "grid" } }];
 };
 
-export const flex = (): EmbedTemplateStyleDecl[] => {
-  return [{ property: "display", value: { type: "keyword", value: "flex" } }];
+const flexDirection = { row: "row", col: "column" } as const;
+type FlexDirection = keyof typeof flexDirection;
+
+export const flex = (flexParam?: FlexDirection): EmbedTemplateStyleDecl[] => {
+  if (flexParam === undefined) {
+    return [{ property: "display", value: { type: "keyword", value: "flex" } }];
+  }
+
+  return [
+    {
+      property: "flexDirection",
+      value: {
+        type: "keyword",
+        value: flexDirection[flexParam],
+      },
+    },
+  ];
 };
 
 export const gap = (

--- a/packages/sdk-components-react/src/theme/tailwind-classes.ts
+++ b/packages/sdk-components-react/src/theme/tailwind-classes.ts
@@ -210,6 +210,33 @@ export const w = (
   return [{ property: "width", value }];
 };
 
+export const h = (
+  spacing:
+    | StringEnumToNumeric<keyof EvaluatedDefaultTheme["height"]>
+    | NonNumeric<keyof EvaluatedDefaultTheme["height"]>
+): EmbedTemplateStyleDecl[] => {
+  const key = `${spacing}` as const;
+  const valueString = theme("height")?.[key] ?? "0";
+  const value = parseCssValue("height", valueString);
+
+  return [{ property: "height", value }];
+};
+
+export const opacity = (
+  opacity: StringEnumToNumeric<keyof EvaluatedDefaultTheme["opacity"]>
+): EmbedTemplateStyleDecl[] => {
+  const key = `${opacity}` as const;
+  const valueString = theme("opacity")?.[key] ?? "0";
+  const value = parseCssValue("opacity", valueString);
+
+  return [
+    {
+      property: "opacity",
+      value,
+    },
+  ];
+};
+
 export const maxW = (
   spacing:
     | StringEnumToNumeric<keyof EvaluatedDefaultTheme["maxWidth"]>
@@ -222,20 +249,41 @@ export const maxW = (
   return [{ property: "maxWidth", value }];
 };
 
-export const inset = (
+const positionStyle = (
+  property: "left" | "right" | "top" | "bottom",
   spacing: StringEnumToNumeric<keyof EvaluatedDefaultTheme["spacing"]>
-): EmbedTemplateStyleDecl[] => {
+): EmbedTemplateStyleDecl => {
   const key = `${spacing}` as const;
   const valueString = theme("spacing")?.[key] ?? "0";
-  const value = parseCssValue("left", valueString);
+  const value = parseCssValue(property, valueString);
 
-  return [
-    { property: "top", value },
-    { property: "right", value },
-    { property: "bottom", value },
-    { property: "left", value },
-  ];
+  return { property, value };
 };
+
+export const top = (
+  spacing: StringEnumToNumeric<keyof EvaluatedDefaultTheme["spacing"]>
+): EmbedTemplateStyleDecl[] => [positionStyle("top", spacing)];
+
+export const right = (
+  spacing: StringEnumToNumeric<keyof EvaluatedDefaultTheme["spacing"]>
+): EmbedTemplateStyleDecl[] => [positionStyle("right", spacing)];
+
+export const bottom = (
+  spacing: StringEnumToNumeric<keyof EvaluatedDefaultTheme["spacing"]>
+): EmbedTemplateStyleDecl[] => [positionStyle("bottom", spacing)];
+
+export const left = (
+  spacing: StringEnumToNumeric<keyof EvaluatedDefaultTheme["spacing"]>
+): EmbedTemplateStyleDecl[] => [positionStyle("left", spacing)];
+
+export const inset = (
+  spacing: StringEnumToNumeric<keyof EvaluatedDefaultTheme["spacing"]>
+): EmbedTemplateStyleDecl[] => [
+  positionStyle("left", spacing),
+  positionStyle("right", spacing),
+  positionStyle("top", spacing),
+  positionStyle("bottom", spacing),
+];
 
 export const backdropBlur = (
   blur: keyof EvaluatedDefaultTheme["blur"]
@@ -277,8 +325,62 @@ export const relative = (): EmbedTemplateStyleDecl[] => {
   ];
 };
 
+export const absolute = (): EmbedTemplateStyleDecl[] => {
+  return [
+    { property: "position", value: { type: "keyword", value: "absolute" } },
+  ];
+};
+
 export const grid = (): EmbedTemplateStyleDecl[] => {
   return [{ property: "display", value: { type: "keyword", value: "grid" } }];
+};
+
+const alignItems = {
+  start: "flex-start",
+  end: "flex-end",
+  center: "center",
+  baseline: "baseline",
+  stretch: "stretch",
+} as const;
+type AlignItems = keyof typeof alignItems;
+
+export const items = (
+  alignItemsParam: AlignItems
+): EmbedTemplateStyleDecl[] => {
+  return [
+    {
+      property: "alignItems",
+      value: {
+        type: "keyword",
+        value: alignItems[alignItemsParam],
+      },
+    },
+  ];
+};
+
+const justifyContent = {
+  start: "flex-start",
+  end: "flex-end",
+  center: "center",
+  between: "space-between",
+  around: "space-around",
+  evenly: "space-evenly",
+  stretch: "stretch",
+} as const;
+type JustifyContent = keyof typeof justifyContent;
+
+export const justify = (
+  justifyContentParam: JustifyContent
+): EmbedTemplateStyleDecl[] => {
+  return [
+    {
+      property: "justifyContent",
+      value: {
+        type: "keyword",
+        value: justifyContent[justifyContentParam],
+      },
+    },
+  ];
 };
 
 const flexDirection = { row: "row", col: "column" } as const;
@@ -391,4 +493,54 @@ export const shadow = (
       value,
     },
   ];
+};
+
+export const ring = (
+  ringColor: keyof EvaluatedDefaultTheme["colors"],
+  ringWidth: StringEnumToNumeric<keyof EvaluatedDefaultTheme["ringWidth"]>,
+  ringOffsetColor: keyof EvaluatedDefaultTheme["colors"] = "background",
+  ringOffsetWidth: StringEnumToNumeric<
+    keyof EvaluatedDefaultTheme["ringOffsetWidth"]
+  > = 0,
+  inset: "inset" | "" = ""
+): EmbedTemplateStyleDecl[] => {
+  const ringWidthUnits = theme("ringWidth")[ringWidth];
+  const ringOffsetWidthUnits = theme("ringOffsetWidth")[ringOffsetWidth];
+  const ringColorRgb = theme("colors")[ringColor];
+  const ringOffsetColorRgb = theme("colors")[ringOffsetColor];
+  const ringOffsetShadow = `${inset} 0 0 0 ${ringOffsetWidthUnits} ${ringOffsetColorRgb}`;
+
+  const ringWidthParsed = parseFloat(ringWidthUnits);
+  const ringOffsetWidthParsed = parseFloat(ringOffsetWidthUnits);
+
+  const ringShadow = `${inset} 0 0 0 ${
+    ringWidthParsed + ringOffsetWidthParsed
+  }px ${ringColorRgb}`;
+
+  const value = parseBoxShadow(`${ringOffsetShadow}, ${ringShadow}`);
+
+  return [
+    {
+      property: "boxShadow",
+      value,
+    },
+  ];
+};
+
+export const hover = (
+  value: EmbedTemplateStyleDecl[]
+): EmbedTemplateStyleDecl[] => {
+  return value.map((decl) => ({
+    ...decl,
+    state: ":hover",
+  }));
+};
+
+export const focus = (
+  value: EmbedTemplateStyleDecl[]
+): EmbedTemplateStyleDecl[] => {
+  return value.map((decl) => ({
+    ...decl,
+    state: ":focus",
+  }));
 };

--- a/packages/sdk-components-react/src/theme/tailwind-colors.ts
+++ b/packages/sdk-components-react/src/theme/tailwind-colors.ts
@@ -16,6 +16,8 @@ export const colors = {
   border: "rgb(226, 232, 240)",
   background: "rgb(255, 255, 255)",
   ring: "rgb(148, 163, 184)",
+
+  mutedForeground: "rgb(100, 116, 139)",
 } as const;
 
 /*

--- a/packages/sdk-components-react/src/theme/tailwind-colors.ts
+++ b/packages/sdk-components-react/src/theme/tailwind-colors.ts
@@ -14,6 +14,7 @@ export const colors = {
   popover: "rgb(255, 255, 255)",
   popoverForeground: "rgb(2, 8, 23)",
   border: "rgb(226, 232, 240)",
+  background: "rgb(255, 255, 255)",
 } as const;
 
 /*

--- a/packages/sdk-components-react/src/theme/tailwind-colors.ts
+++ b/packages/sdk-components-react/src/theme/tailwind-colors.ts
@@ -15,6 +15,7 @@ export const colors = {
   popoverForeground: "rgb(2, 8, 23)",
   border: "rgb(226, 232, 240)",
   background: "rgb(255, 255, 255)",
+  ring: "rgb(148, 163, 184)",
 } as const;
 
 /*

--- a/packages/sdk-components-react/src/theme/tailwind-colors.ts
+++ b/packages/sdk-components-react/src/theme/tailwind-colors.ts
@@ -16,7 +16,6 @@ export const colors = {
   border: "rgb(226, 232, 240)",
   background: "rgb(255, 255, 255)",
   ring: "rgb(148, 163, 184)",
-
   mutedForeground: "rgb(100, 116, 139)",
 } as const;
 
@@ -27,8 +26,6 @@ export const colors = {
 --foreground: 222.2 84% 4.9%;
 
 --muted: 210 40% 96.1%;
---muted-foreground: 215.4 16.3% 46.9%;
-
 --card: 0 0% 100%;
 --card-foreground: 222.2 84% 4.9%;
 

--- a/packages/sdk-components-react/src/theme/tailwind-theme.ts
+++ b/packages/sdk-components-react/src/theme/tailwind-theme.ts
@@ -12,7 +12,7 @@ export const theme = <T extends keyof EvaluatedDefaultTheme>(
   const value = localTheme?.[name] as unknown;
 
   if (typeof value === "function") {
-    return value({ theme, colors });
+    return value({ theme, colors, breakpoints: () => ({}) });
   }
 
   return value as never;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1261,6 +1261,9 @@ importers:
 
   packages/sdk-components-react:
     dependencies:
+      '@radix-ui/react-dialog':
+        specifier: ^1.0.4
+        version: 1.0.4(@types/react-dom@18.2.7)(@types/react@18.2.16)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-popover':
         specifier: ^1.0.6
         version: 1.0.6(@types/react-dom@18.2.7)(@types/react@18.2.16)(react-dom@18.2.0)(react@18.2.0)


### PR DESCRIPTION
## Description

Initial dialog implementation
Additionally:
`backdropFilter` property added to support dialog backdrop css

<img width="250" alt="image" src="https://github.com/webstudio-is/webstudio-builder/assets/5077042/4f0e5b88-2b3b-42e6-bfd9-34dd36dc08f3">

Not detachables are Overlay, Trigger and Content
Header, Close can be removed 


Next PRS: 
- [ ] - Move to radix components repo
- [ ] - Add Right Icons


## Steps for reproduction

Create new project, add Radix/Dialog component


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
