### PR TITLE
Remove global tooltip provider

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect } from "react";
 import { useUnmount } from "react-use";
+import { TooltipProvider } from "@radix-ui/react-tooltip";
 import { type Publish, usePublish } from "~/shared/pubsub";
 import type { Build } from "@webstudio-is/project-build";
 import type { Project } from "@webstudio-is/project";
@@ -297,40 +298,42 @@ export const Builder = ({
   });
 
   return (
-    <ChromeWrapper isPreviewMode={isPreviewMode}>
-      <Topbar gridArea="header" project={project} publish={publish} />
-      <Main>
-        <Workspace onTransitionEnd={onTransitionEnd} publish={publish}>
-          <CanvasIframe
-            ref={iframeRefCallback}
-            src={canvasUrl}
-            pointerEvents={isCanvasPointerEventsEnabled ? "auto" : "none"}
-            title={project.title}
-            css={{
-              height: "100%",
-              width: "100%",
-              backgroundColor: "#fff",
-            }}
-          />
-        </Workspace>
-      </Main>
-      <SidePanel gridArea="sidebar" isPreviewMode={isPreviewMode}>
-        <SidebarLeft publish={publish} />
-      </SidePanel>
-      <NavigatorPanel
-        isPreviewMode={isPreviewMode}
-        navigatorLayout={navigatorLayout}
-        publish={publish}
-      />
-      <SidePanel
-        gridArea="inspector"
-        isPreviewMode={isPreviewMode}
-        css={{ overflow: "hidden" }}
-      >
-        <Inspector publish={publish} navigatorLayout={navigatorLayout} />
-      </SidePanel>
-      {isPreviewMode === false && <Footer />}
-      <BlockingAlerts />
-    </ChromeWrapper>
+    <TooltipProvider>
+      <ChromeWrapper isPreviewMode={isPreviewMode}>
+        <Topbar gridArea="header" project={project} publish={publish} />
+        <Main>
+          <Workspace onTransitionEnd={onTransitionEnd} publish={publish}>
+            <CanvasIframe
+              ref={iframeRefCallback}
+              src={canvasUrl}
+              pointerEvents={isCanvasPointerEventsEnabled ? "auto" : "none"}
+              title={project.title}
+              css={{
+                height: "100%",
+                width: "100%",
+                backgroundColor: "#fff",
+              }}
+            />
+          </Workspace>
+        </Main>
+        <SidePanel gridArea="sidebar" isPreviewMode={isPreviewMode}>
+          <SidebarLeft publish={publish} />
+        </SidePanel>
+        <NavigatorPanel
+          isPreviewMode={isPreviewMode}
+          navigatorLayout={navigatorLayout}
+          publish={publish}
+        />
+        <SidePanel
+          gridArea="inspector"
+          isPreviewMode={isPreviewMode}
+          css={{ overflow: "hidden" }}
+        >
+          <Inspector publish={publish} navigatorLayout={navigatorLayout} />
+        </SidePanel>
+        {isPreviewMode === false && <Footer />}
+        <BlockingAlerts />
+      </ChromeWrapper>
+    </TooltipProvider>
   );
 };

--- a/apps/builder/app/root.tsx
+++ b/apps/builder/app/root.tsx
@@ -1,9 +1,7 @@
 // Our root outlet doesn't contain a layout because we have 2 types of documents: canvas and builder and we need to decide down the line which one to render, thre is no single root document.
-import { TooltipProvider } from "@radix-ui/react-tooltip";
 import { Outlet } from "@remix-run/react";
 import { setEnv } from "@webstudio-is/feature-flags";
-import { withSentry } from "@sentry/remix";
-import { ErrorBoundary } from "@sentry/remix";
+import { withSentry, ErrorBoundary } from "@sentry/remix";
 import env from "./shared/env";
 import type { ComponentProps } from "react";
 
@@ -13,9 +11,7 @@ type OutletProps = ComponentProps<typeof Outlet>;
 
 const RootWithErrorBoundary = (props: OutletProps) => (
   <ErrorBoundary>
-    <TooltipProvider>
-      <Outlet {...props} />
-    </TooltipProvider>
+    <Outlet {...props} />
   </ErrorBoundary>
 );
 

--- a/packages/sdk-components-react-radix/src/tooltip.tsx
+++ b/packages/sdk-components-react-radix/src/tooltip.tsx
@@ -46,7 +46,9 @@ export const Tooltip = forwardRef<
 
   return (
     <div ref={ref} style={DisplayContentsStyle} {...webstudioAttributes}>
-      <TooltipPrimitive.Root open={open} {...restProps} />
+      <TooltipPrimitive.Provider>
+        <TooltipPrimitive.Root open={open} {...restProps} />
+      </TooltipPrimitive.Provider>
     </div>
   );
 });


### PR DESCRIPTION
Radix provider in canvas couples too tight with radix we should go the other way. Here wrapped each
tooltip sdk component with provider and wrapped
with provider in builder instead of root.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
