### PR TITLE
Decouple data sources from props in templates

### DIFF
--- a/packages/react-sdk/src/embed-template.test.ts
+++ b/packages/react-sdk/src/embed-template.test.ts
@@ -223,15 +223,14 @@ test("generate data for embedding from props bound to data source variables", ()
         {
           type: "instance",
           component: "Box1",
+          dataSources: {
+            showOtherBoxDataSource: { type: "variable", initialValue: false },
+          },
           props: [
             {
-              type: "boolean",
+              type: "dataSource",
               name: "showOtherBox",
-              value: false,
-              dataSourceRef: {
-                type: "variable",
-                name: "showOtherBoxDataSource",
-              },
+              dataSourceName: "showOtherBoxDataSource",
             },
           ],
           children: [],
@@ -241,13 +240,9 @@ test("generate data for embedding from props bound to data source variables", ()
           component: "Box2",
           props: [
             {
-              type: "boolean",
+              type: "dataSource",
               name: showAttribute,
-              value: false,
-              dataSourceRef: {
-                type: "variable",
-                name: "showOtherBoxDataSource",
-              },
+              dataSourceName: "showOtherBoxDataSource",
             },
           ],
           children: [],
@@ -305,12 +300,18 @@ test("generate data for embedding from props bound to data source expressions", 
         {
           type: "instance",
           component: "Box1",
+          dataSources: {
+            boxState: { type: "variable", initialValue: "initial" },
+            boxStateSuccess: {
+              type: "expression",
+              code: `boxState === 'success'`,
+            },
+          },
           props: [
             {
-              type: "string",
+              type: "dataSource",
               name: "state",
-              value: "initial",
-              dataSourceRef: { type: "variable", name: "boxState" },
+              dataSourceName: "boxState",
             },
           ],
           children: [],
@@ -320,14 +321,9 @@ test("generate data for embedding from props bound to data source expressions", 
           component: "Box2",
           props: [
             {
-              type: "boolean",
+              type: "dataSource",
               name: showAttribute,
-              value: false,
-              dataSourceRef: {
-                type: "expression",
-                name: "boxStateSuccess",
-                code: `boxState === 'success'`,
-              },
+              dataSourceName: "boxStateSuccess",
             },
           ],
           children: [],
@@ -392,12 +388,14 @@ test("generate data for embedding from action props", () => {
         {
           type: "instance",
           component: "Box1",
+          dataSources: {
+            boxState: { type: "variable", initialValue: "initial" },
+          },
           props: [
             {
-              type: "string",
+              type: "dataSource",
               name: "state",
-              value: "initial",
-              dataSourceRef: { type: "variable", name: "boxState" },
+              dataSourceName: "boxState",
             },
           ],
           children: [

--- a/packages/react-sdk/src/embed-template.ts
+++ b/packages/react-sdk/src/embed-template.ts
@@ -21,43 +21,48 @@ const EmbedTemplateText = z.object({
 
 type EmbedTemplateText = z.infer<typeof EmbedTemplateText>;
 
-const DataSourceVariableRef = z.object({
-  type: z.literal("variable"),
-  name: z.string(),
-});
-
-const DataSourceRef = z.union([
-  DataSourceVariableRef,
+const EmbedTemplateDataSource = z.union([
+  z.object({
+    type: z.literal("variable"),
+    initialValue: z.union([
+      z.string(),
+      z.number(),
+      z.boolean(),
+      z.array(z.string()),
+    ]),
+  }),
   z.object({
     type: z.literal("expression"),
-    name: z.string(),
     code: z.string(),
   }),
 ]);
 
+type EmbedTemplateDataSource = z.infer<typeof EmbedTemplateDataSource>;
+
 const EmbedTemplateProp = z.union([
+  z.object({
+    type: z.literal("dataSource"),
+    name: z.string(),
+    dataSourceName: z.string(),
+  }),
   z.object({
     type: z.literal("number"),
     name: z.string(),
-    dataSourceRef: z.optional(DataSourceRef),
     value: z.number(),
   }),
   z.object({
     type: z.literal("string"),
     name: z.string(),
-    dataSourceRef: z.optional(DataSourceRef),
     value: z.string(),
   }),
   z.object({
     type: z.literal("boolean"),
     name: z.string(),
-    dataSourceRef: z.optional(DataSourceRef),
     value: z.boolean(),
   }),
   z.object({
     type: z.literal("string[]"),
     name: z.string(),
-    dataSourceRef: z.optional(DataSourceRef),
     value: z.array(z.string()),
   }),
   z.object({
@@ -95,6 +100,7 @@ export type EmbedTemplateInstance = {
   type: "instance";
   component: string;
   label?: string;
+  dataSources?: Record<string, EmbedTemplateDataSource>;
   props?: EmbedTemplateProp[];
   styles?: EmbedTemplateStyleDecl[];
   children: Array<EmbedTemplateInstance | EmbedTemplateText>;
@@ -106,6 +112,7 @@ export const EmbedTemplateInstance: z.ZodType<EmbedTemplateInstance> = z.lazy(
       type: z.literal("instance"),
       component: z.string(),
       label: z.optional(z.string()),
+      dataSources: z.optional(z.record(z.string(), EmbedTemplateDataSource)),
       props: z.optional(z.array(EmbedTemplateProp)),
       styles: z.optional(z.array(EmbedTemplateStyleDecl)),
       children: WsEmbedTemplate,
@@ -117,6 +124,25 @@ export const WsEmbedTemplate = z.lazy(() =>
 );
 
 export type WsEmbedTemplate = z.infer<typeof WsEmbedTemplate>;
+
+const getDataSourceValue = (
+  value: Extract<EmbedTemplateDataSource, { type: "variable" }>["initialValue"]
+): Extract<DataSource, { type: "variable" }>["value"] => {
+  if (typeof value === "string") {
+    return { type: "string", value };
+  }
+  if (typeof value === "number") {
+    return { type: "number", value };
+  }
+  if (typeof value === "boolean") {
+    return { type: "boolean", value };
+  }
+  if (Array.isArray(value)) {
+    return { type: "string[]", value };
+  }
+  value satisfies never;
+  throw Error("Impossible case");
+};
 
 const createInstancesFromTemplate = (
   treeTemplate: WsEmbedTemplate,
@@ -132,6 +158,38 @@ const createInstancesFromTemplate = (
   for (const item of treeTemplate) {
     if (item.type === "instance") {
       const instanceId = nanoid();
+
+      if (item.dataSources) {
+        for (const [name, dataSource] of Object.entries(item.dataSources)) {
+          if (dataSourceByRef.has(name)) {
+            throw Error(`${name} data source already defined`);
+          }
+          if (dataSource.type === "variable") {
+            dataSourceByRef.set(name, {
+              type: "variable",
+              id: nanoid(),
+              scopeInstanceId: instanceId,
+              name,
+              value: getDataSourceValue(dataSource.initialValue),
+            });
+          }
+          if (dataSource.type === "expression") {
+            dataSourceByRef.set(name, {
+              type: "expression",
+              id: nanoid(),
+              scopeInstanceId: instanceId,
+              name,
+              // replace all references with variable names
+              code: validateExpression(dataSource.code, {
+                transformIdentifier: (ref) => {
+                  const id = dataSourceByRef.get(ref)?.id ?? ref;
+                  return encodeDataSourceVariable(id);
+                },
+              }),
+            });
+          }
+        }
+      }
 
       // populate props
       if (item.props) {
@@ -166,51 +224,21 @@ const createInstancesFromTemplate = (
             });
             continue;
           }
-          if (prop.dataSourceRef === undefined) {
-            props.push({ id: propId, instanceId, ...prop });
+          if (prop.type === "dataSource") {
+            const dataSource = dataSourceByRef.get(prop.dataSourceName);
+            if (dataSource === undefined) {
+              throw Error(`${prop.dataSourceName} data source is not defined`);
+            }
+            props.push({
+              id: propId,
+              instanceId,
+              type: "dataSource",
+              name: prop.name,
+              value: dataSource.id,
+            });
             continue;
           }
-          let dataSource = dataSourceByRef.get(prop.dataSourceRef.name);
-          if (dataSource === undefined) {
-            const id = nanoid();
-            const { name: propName, dataSourceRef, ...rest } = prop;
-            if (dataSourceRef.type === "variable") {
-              dataSource = {
-                type: "variable",
-                id,
-                // the first instance where data source is appeared in becomes its scope
-                scopeInstanceId: instanceId,
-                name: dataSourceRef.name,
-                value: rest,
-              };
-              dataSourceByRef.set(dataSourceRef.name, dataSource);
-            } else if (dataSourceRef.type === "expression") {
-              dataSource = {
-                type: "expression",
-                id,
-                scopeInstanceId: instanceId,
-                name: dataSourceRef.name,
-                // replace all references with variable names
-                code: validateExpression(dataSourceRef.code, {
-                  transformIdentifier: (ref) => {
-                    const id = dataSourceByRef.get(ref)?.id ?? ref;
-                    return encodeDataSourceVariable(id);
-                  },
-                }),
-              };
-              dataSourceByRef.set(dataSourceRef.name, dataSource);
-            } else {
-              dataSourceRef satisfies never;
-              continue;
-            }
-          }
-          props.push({
-            id: propId,
-            instanceId,
-            type: "dataSource",
-            name: prop.name,
-            value: dataSource.id,
-          });
+          props.push({ id: propId, instanceId, ...prop });
         }
       }
 

--- a/packages/sdk-components-react-radix/src/collapsible.ws.ts
+++ b/packages/sdk-components-react-radix/src/collapsible.ws.ts
@@ -18,15 +18,14 @@ export const metaCollapsible: WsComponentMeta = {
     {
       type: "instance",
       component: "Collapsible",
+      dataSources: {
+        collapsibleOpen: { type: "variable", initialValue: false },
+      },
       props: [
         {
+          type: "dataSource",
           name: "open",
-          type: "boolean",
-          value: false,
-          dataSourceRef: {
-            type: "variable",
-            name: "collapsibleOpen",
-          },
+          dataSourceName: "collapsibleOpen",
         },
         {
           name: "onOpenChange",

--- a/packages/sdk-components-react-radix/src/dialog.ws.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.ws.tsx
@@ -88,16 +88,15 @@ export const metaDialog: WsComponentMeta = {
       type: "instance",
       component: "Dialog",
       label: "Dialog",
+      dataSources: {
+        // We don't have support for boolean or undefined, instead of binding on open we bind on a string
+        isOpen: { type: "variable", initialValue: "initial" },
+      },
       props: [
         {
+          type: "dataSource",
           name: "isOpen",
-          // We don't have support for boolean or undefined, instead of binding on open we bind on a string
-          type: "string",
-          value: "initial",
-          dataSourceRef: {
-            type: "variable",
-            name: "isOpen",
-          },
+          dataSourceName: "isOpen",
         },
       ],
       children: [

--- a/packages/sdk-components-react-radix/src/popover.ws.tsx
+++ b/packages/sdk-components-react-radix/src/popover.ws.tsx
@@ -51,16 +51,15 @@ export const metaPopover: WsComponentMeta = {
       type: "instance",
       component: "Popover",
       label: "Popover",
+      dataSources: {
+        // We don't have support for boolean or undefined, instead of binding on open we bind on a string
+        isOpen: { type: "variable", initialValue: "initial" },
+      },
       props: [
         {
+          type: "dataSource",
           name: "isOpen",
-          // We don't have support for boolean or undefined, instead of binding on open we bind on a string
-          type: "string",
-          value: "initial",
-          dataSourceRef: {
-            type: "variable",
-            name: "isOpen",
-          },
+          dataSourceName: "isOpen",
         },
       ],
       children: [

--- a/packages/sdk-components-react-radix/src/tooltip.ws.tsx
+++ b/packages/sdk-components-react-radix/src/tooltip.ws.tsx
@@ -51,16 +51,15 @@ export const metaTooltip: WsComponentMeta = {
       type: "instance",
       component: "Tooltip",
       label: "Tooltip",
+      dataSources: {
+        // We don't have support for boolean or undefined, instead of binding on open we bind on a string
+        isOpen: { type: "variable", initialValue: "initial" },
+      },
       props: [
         {
+          type: "dataSource",
           name: "isOpen",
-          // We don't have support for boolean or undefined, instead of binding on open we bind on a string
-          type: "string",
-          value: "initial",
-          dataSourceRef: {
-            type: "variable",
-            name: "isOpen",
-          },
+          dataSourceName: "isOpen",
         },
       ],
       children: [

--- a/packages/sdk-components-react-remix/src/form.ws.tsx
+++ b/packages/sdk-components-react-remix/src/form.ws.tsx
@@ -32,15 +32,14 @@ export const meta: WsComponentMeta = {
     {
       type: "instance",
       component: "Form",
+      dataSources: {
+        formState: { type: "variable", initialValue: "initial" },
+      },
       props: [
         {
+          type: "dataSource",
           name: "state",
-          type: "string",
-          value: "initial",
-          dataSourceRef: {
-            type: "variable",
-            name: "formState",
-          },
+          dataSourceName: "formState",
         },
       ],
       children: [
@@ -48,16 +47,17 @@ export const meta: WsComponentMeta = {
           type: "instance",
           label: "Form Content",
           component: "Box",
+          dataSources: {
+            formInitial: {
+              type: "expression",
+              code: `formState === 'initial' || formState === 'error'`,
+            },
+          },
           props: [
             {
+              type: "dataSource",
               name: showAttribute,
-              type: "boolean",
-              value: false,
-              dataSourceRef: {
-                type: "expression",
-                name: "formInitial",
-                code: `formState === 'initial' || formState === 'error'`,
-              },
+              dataSourceName: "formInitial",
             },
           ],
           children: [
@@ -95,16 +95,17 @@ export const meta: WsComponentMeta = {
           type: "instance",
           label: "Success Message",
           component: "Box",
+          dataSources: {
+            formSuccess: {
+              type: "expression",
+              code: `formState === 'success'`,
+            },
+          },
           props: [
             {
+              type: "dataSource",
               name: showAttribute,
-              type: "boolean",
-              value: false,
-              dataSourceRef: {
-                type: "expression",
-                name: "formSuccess",
-                code: `formState === 'success'`,
-              },
+              dataSourceName: "formSuccess",
             },
           ],
           children: [
@@ -116,16 +117,17 @@ export const meta: WsComponentMeta = {
           type: "instance",
           label: "Error Message",
           component: "Box",
+          dataSources: {
+            formError: {
+              type: "expression",
+              code: `formState === 'error'`,
+            },
+          },
           props: [
             {
+              type: "dataSource",
               name: showAttribute,
-              type: "boolean",
-              value: false,
-              dataSourceRef: {
-                type: "expression",
-                name: "formError",
-                code: `formState === 'error'`,
-              },
+              dataSourceName: "formError",
             },
           ],
           children: [{ type: "text", value: "Sorry, something went wrong." }],


### PR DESCRIPTION
Here changed the way we define data sources in embed templates. Now they have separate section on instance. This way we will be able to use data sources on styles or instances without binding them to props.

```js
{
  type: 'instance',
  component: 'Form',
  dataSources: {
    state: { type: 'variable', initialValue: 'initial' },
    stateInitial: { type: 'expression', code: `state === 'initial'` }
  },
  props: [
    {
      type: 'dataSource',
      name: 'data-state',
      dataSourceName: 'state'
    }
  ],
  children: []
}
```

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
