### PR TITLE
Fix presets in radix (namespaces issue)

### DIFF
--- a/packages/react-sdk/src/css/style-rules.ts
+++ b/packages/react-sdk/src/css/style-rules.ts
@@ -86,7 +86,7 @@ export const getPresetStyleRules = (
   const presetStyleRules = new Map<string, Style>();
   for (const [tag, styles] of Object.entries(presetStyle)) {
     for (const styleDecl of styles) {
-      const selector = `${tag}:where([${componentAttribute}=${component}])${
+      const selector = `${tag}:where([${componentAttribute}="${component}"])${
         styleDecl.state ?? ""
       }`;
       let rule = presetStyleRules.get(selector);

--- a/packages/sdk-components-react-radix/src/collapsible.ws.ts
+++ b/packages/sdk-components-react-radix/src/collapsible.ws.ts
@@ -4,6 +4,7 @@ import {
   ContentIcon,
 } from "@webstudio-is/icons/svg";
 import type {
+  PresetStyle,
   WsComponentMeta,
   WsComponentPropsMeta,
 } from "@webstudio-is/react-sdk";
@@ -12,10 +13,16 @@ import {
   propsCollapsibleContent,
   propsCollapsibleTrigger,
 } from "./__generated__/collapsible.props";
+import { div } from "@webstudio-is/react-sdk/css-normalize";
+
+const presetStyle = {
+  div,
+} satisfies PresetStyle<"div">;
 
 export const metaCollapsible: WsComponentMeta = {
   category: "radix",
   type: "container",
+  presetStyle,
   label: "Collapsible",
   icon: CollapsibleIcon,
   template: [
@@ -83,6 +90,7 @@ export const metaCollapsibleTrigger: WsComponentMeta = {
 export const metaCollapsibleContent: WsComponentMeta = {
   category: "hidden",
   type: "container",
+  presetStyle,
   label: "Collapsible Content",
   icon: ContentIcon,
   detachable: false,

--- a/packages/sdk-components-react-radix/src/dialog.ws.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.ws.tsx
@@ -8,6 +8,7 @@ import {
   ButtonElementIcon,
 } from "@webstudio-is/icons/svg";
 import {
+  type PresetStyle,
   type WsComponentMeta,
   type WsComponentPropsMeta,
 } from "@webstudio-is/react-sdk";
@@ -21,6 +22,16 @@ import {
   propsDialogTitle,
   propsDialogDescription,
 } from "./__generated__/dialog.props";
+
+import { div, button } from "@webstudio-is/react-sdk/css-normalize";
+
+const presetStyle = {
+  div,
+} satisfies PresetStyle<"div">;
+
+const buttonPresetStyle = {
+  button,
+} satisfies PresetStyle<"button">;
 
 // @todo add [data-state] to button and link
 export const metaDialogTrigger: WsComponentMeta = {
@@ -38,6 +49,7 @@ export const metaDialogContent: WsComponentMeta = {
   invalidAncestors: [],
   type: "container",
   label: "DialogContent",
+  presetStyle,
   icon: ContentIcon,
   detachable: false,
 };
@@ -47,6 +59,7 @@ export const metaDialogOverlay: WsComponentMeta = {
   invalidAncestors: [],
   type: "container",
   label: "DialogOverlay",
+  presetStyle,
   icon: OverlayIcon,
   detachable: false,
 };
@@ -55,6 +68,7 @@ export const metaDialogTitle: WsComponentMeta = {
   category: "hidden",
   invalidAncestors: [],
   type: "container",
+  presetStyle,
   label: "DialogTitle",
   icon: HeadingIcon,
 };
@@ -63,6 +77,7 @@ export const metaDialogDescription: WsComponentMeta = {
   category: "hidden",
   invalidAncestors: [],
   type: "container",
+  presetStyle,
   label: "DialogDescription",
   icon: TextIcon,
 };
@@ -71,6 +86,7 @@ export const metaDialogClose: WsComponentMeta = {
   category: "hidden",
   invalidAncestors: [],
   type: "container",
+  presetStyle: buttonPresetStyle,
   label: "DialogClose",
   icon: ButtonElementIcon,
 };

--- a/packages/sdk-components-react-radix/src/popover.ws.tsx
+++ b/packages/sdk-components-react-radix/src/popover.ws.tsx
@@ -1,5 +1,6 @@
 import { PopoverIcon, TriggerIcon, ContentIcon } from "@webstudio-is/icons/svg";
 import {
+  type PresetStyle,
   type WsComponentMeta,
   type WsComponentPropsMeta,
 } from "@webstudio-is/react-sdk";
@@ -9,6 +10,11 @@ import {
   propsPopoverContent,
   propsPopoverTrigger,
 } from "./__generated__/popover.props";
+import { div } from "@webstudio-is/react-sdk/css-normalize";
+
+const presetStyle = {
+  div,
+} satisfies PresetStyle<"div">;
 
 // @todo add [data-state] to button and link
 export const metaPopoverTrigger: WsComponentMeta = {
@@ -25,6 +31,7 @@ export const metaPopoverContent: WsComponentMeta = {
   category: "hidden",
   invalidAncestors: [],
   type: "container",
+  presetStyle,
   label: "PopoverContent",
   icon: ContentIcon,
   detachable: false,

--- a/packages/sdk-components-react-radix/src/tooltip.ws.tsx
+++ b/packages/sdk-components-react-radix/src/tooltip.ws.tsx
@@ -1,5 +1,6 @@
 import { TooltipIcon, TriggerIcon, ContentIcon } from "@webstudio-is/icons/svg";
 import {
+  type PresetStyle,
   type WsComponentMeta,
   type WsComponentPropsMeta,
 } from "@webstudio-is/react-sdk";
@@ -9,6 +10,11 @@ import {
   propsTooltipContent,
   propsTooltipTrigger,
 } from "./__generated__/tooltip.props";
+import { div } from "@webstudio-is/react-sdk/css-normalize";
+
+const presetStyle = {
+  div,
+} satisfies PresetStyle<"div">;
 
 // @todo add [data-state] to button and link
 export const metaTooltipTrigger: WsComponentMeta = {
@@ -26,6 +32,7 @@ export const metaTooltipContent: WsComponentMeta = {
   detachable: false,
   invalidAncestors: [],
   type: "container",
+  presetStyle,
   label: "TooltipContent",
   icon: ContentIcon,
 };


### PR DESCRIPTION
## Description

Fix presets in case of namespaeces added `"` to selector
<img width="605" alt="image" src="https://github.com/webstudio-is/webstudio-builder/assets/5077042/9b367c73-466e-4592-b45f-0b84660e423f">


Added presets to radix components


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
