### PR TITLE
Add action to form's initial props

### DIFF
--- a/packages/sdk-components-react-remix/src/form.ws.tsx
+++ b/packages/sdk-components-react-remix/src/form.ws.tsx
@@ -139,5 +139,5 @@ export const meta: WsComponentMeta = {
 
 export const propsMeta: WsComponentPropsMeta = {
   props,
-  initialProps: ["id", "state"],
+  initialProps: ["id", "state", "action"],
 };

--- a/packages/sdk-components-react/src/form.ws.tsx
+++ b/packages/sdk-components-react/src/form.ws.tsx
@@ -64,5 +64,5 @@ export const meta: WsComponentMeta = {
 
 export const propsMeta: WsComponentPropsMeta = {
   props,
-  initialProps: ["id"],
+  initialProps: ["id", "action"],
 };


### PR DESCRIPTION
## Description

Action is used for hooks, so should be there by default

## Steps for reproduction

1. open form settings
2. see there is Action property

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)


## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
