### PR TITLE
Add more label spacing for boolean props

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/controls/boolean.tsx
+++ b/apps/builder/app/builder/features/settings-panel/controls/boolean.tsx
@@ -15,6 +15,7 @@ export const BooleanControl = ({
       id={id}
       label={getLabel(meta, propName)}
       onDelete={onDelete}
+      labelSize="large"
     >
       <Switch
         id={id}

--- a/apps/builder/app/builder/features/settings-panel/shared.tsx
+++ b/apps/builder/app/builder/features/settings-panel/shared.tsx
@@ -150,7 +150,7 @@ export const VerticalLayout = ({
 export const HorizontalLayout = ({
   label,
   id,
-  labelSize,
+  labelSize = "default",
   onDelete,
   children,
 }: LayoutProps) => (

--- a/apps/builder/app/builder/features/settings-panel/shared.tsx
+++ b/apps/builder/app/builder/features/settings-panel/shared.tsx
@@ -127,6 +127,7 @@ export const useLocalValue = <Type,>(
 type LayoutProps = {
   label: string;
   id?: string;
+  labelSize?: "default" | "large";
   onDelete?: () => void;
   children: ReactNode;
 };
@@ -149,12 +150,15 @@ export const VerticalLayout = ({
 export const HorizontalLayout = ({
   label,
   id,
+  labelSize,
   onDelete,
   children,
 }: LayoutProps) => (
   <Grid
     css={{
-      gridTemplateColumns: `${theme.spacing[19]} 1fr`,
+      gridTemplateColumns: `${
+        labelSize === "default" ? theme.spacing[19] : theme.spacing[24]
+      } 1fr`,
       minHeight: theme.spacing[13],
     }}
     align="center"


### PR DESCRIPTION
## Description

Fixes https://discord.com/channels/955905230107738152/1136931915044237402

<img width="260" alt="image" src="https://github.com/webstudio-is/webstudio-builder/assets/5077042/7b427f37-1e88-4516-baef-66803886f771">

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
