### PR TITLE
Partially fix tooltip trigger editing

### DIFF
--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -258,9 +258,14 @@ export const WebstudioComponentDev = forwardRef<
     }
   }
 
+  // Do not pass Radix handlers in edit mode
+  const componentProps = isPreviewMode
+    ? { ...restProps, ...props, ...composedHandlers }
+    : props;
+
   const instanceElement = (
     <>
-      <Component {...restProps} {...props} {...composedHandlers} ref={ref}>
+      <Component {...componentProps} ref={ref}>
         {renderWebstudioComponentChildren(children)}
       </Component>
     </>
@@ -279,7 +284,11 @@ export const WebstudioComponentDev = forwardRef<
         rootInstanceSelector={instanceSelector}
         instances={instances}
         contentEditable={
-          <ContentEditable {...props} elementRef={ref} Component={Component} />
+          <ContentEditable
+            {...componentProps}
+            elementRef={ref}
+            Component={Component}
+          />
         }
         onChange={(instancesList) => {
           store.createTransaction([instancesStore], (instances) => {

--- a/apps/builder/app/canvas/instance-selected.ts
+++ b/apps/builder/app/canvas/instance-selected.ts
@@ -201,14 +201,21 @@ export const subscribeSelectedInstance = (
 
   // detect movement of the element within same parent
   // React prevent remount when key stays the same
+  // `attributes: true` fixes issues with popups after trigger text editing
+  // that cause radix to incorrectly set content in a wrong position at first render
   const mutationObserver = new MutationObserver(update);
 
   const updateObservers = () => {
     for (const element of elements) {
       resizeObserver.observe(element);
+
       const parent = element?.parentElement;
       if (parent) {
-        mutationObserver.observe(parent, { childList: true });
+        mutationObserver.observe(parent, {
+          childList: true,
+          attributes: true,
+          attributeFilter: ["style", "class"],
+        });
       }
     }
   };

--- a/packages/sdk-components-react-radix/src/__generated__/popover.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/popover.props.ts
@@ -418,7 +418,12 @@ export const propsPopoverContent: Record<string, PropMeta> = {
   dir: { required: false, control: "text", type: "string" },
   draggable: { required: false, control: "boolean", type: "boolean" },
   hidden: { required: false, control: "boolean", type: "boolean" },
-  hideWhenDetached: { required: false, control: "boolean", type: "boolean" },
+  hideWhenDetached: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+    defaultValue: true,
+  },
   id: { required: false, control: "text", type: "string" },
   inputMode: {
     description:

--- a/packages/sdk-components-react-radix/src/__generated__/tooltip.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/tooltip.props.ts
@@ -429,7 +429,12 @@ export const propsTooltipContent: Record<string, PropMeta> = {
   dir: { required: false, control: "text", type: "string" },
   draggable: { required: false, control: "boolean", type: "boolean" },
   hidden: { required: false, control: "boolean", type: "boolean" },
-  hideWhenDetached: { required: false, control: "boolean", type: "boolean" },
+  hideWhenDetached: {
+    required: false,
+    control: "boolean",
+    type: "boolean",
+    defaultValue: true,
+  },
   id: { required: false, control: "text", type: "string" },
   inputMode: {
     description:

--- a/packages/sdk-components-react-radix/src/popover.tsx
+++ b/packages/sdk-components-react-radix/src/popover.tsx
@@ -52,13 +52,19 @@ export const PopoverTrigger = forwardRef<
 export const PopoverContent = forwardRef<
   ElementRef<typeof PopoverPrimitive.Content>,
   ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ sideOffset = 4, align = "center", ...props }, ref) => (
-  <PopoverPrimitive.Portal>
-    <PopoverPrimitive.Content
-      ref={ref}
-      align="center"
-      sideOffset={sideOffset}
-      {...props}
-    />
-  </PopoverPrimitive.Portal>
-));
+>(
+  (
+    { sideOffset = 4, align = "center", hideWhenDetached = true, ...props },
+    ref
+  ) => (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        ref={ref}
+        align="center"
+        sideOffset={sideOffset}
+        hideWhenDetached={hideWhenDetached}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+);

--- a/packages/sdk-components-react-radix/src/tooltip.tsx
+++ b/packages/sdk-components-react-radix/src/tooltip.tsx
@@ -56,8 +56,14 @@ export const TooltipTrigger = forwardRef<
 export const TooltipContent = forwardRef<
   ElementRef<typeof TooltipPrimitive.Content>,
   ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ sideOffset = 4, ...props }, ref) => (
+>(({ sideOffset = 4, hideWhenDetached = true, ...props }, ref) => (
   <TooltipPrimitive.Portal>
-    <TooltipPrimitive.Content ref={ref} sideOffset={sideOffset} {...props} />
+    <TooltipPrimitive.Content
+      ref={ref}
+      // Do not show content if trigger is detached
+      hideWhenDetached={hideWhenDetached}
+      sideOffset={sideOffset}
+      {...props}
+    />
   </TooltipPrimitive.Portal>
 ));


### PR DESCRIPTION
## Description

https://discord.com/channels/955905230107738152/1137094092417941695

<img width="180" alt="image" src="https://cdn.discordapp.com/attachments/1137094092417941695/1137094092640231454/Screen_Recording_2023-08-04_at_21.43.44.gif">

Fixes positioning. But still have tooltip content blink, seems like tooltip doesn't like changing trigger on the fly.

Blinking will not be fixed until we change how editor works

I created a simple reproducible example changing the trigger using setInterval and get same behaviour as we have

![Screen Recording 2023-08-05 at 10 00 02](https://github.com/webstudio-is/webstudio-builder/assets/5077042/67655855-4b61-41a3-9ea4-c4664c0ebf38)





## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
