### PR TITLE
Fix jumps on editing text inside tooltips, and probably other components

### DIFF
--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -235,10 +235,14 @@ export const Canvas = ({ params }: CanvasProps): JSX.Element | null => {
   return (
     <>
       <GlobalStyles params={params} />
+      {elements}
+      {
+        // Call hooks after render to ensure effects are last.
+        // Helps improve outline calculations as all styles are then applied.
+      }
       {isPreviewMode === false && handshaken === true && (
         <DesignMode params={params} />
       )}
-      {elements}
     </>
   );
 };

--- a/apps/builder/app/canvas/features/text-editor/text-editor.tsx
+++ b/apps/builder/app/canvas/features/text-editor/text-editor.tsx
@@ -8,8 +8,6 @@ import {
   $createLineBreakNode,
   $getSelection,
   $isRangeSelection,
-  $createRangeSelection,
-  $setSelection,
 } from "lexical";
 import { LinkNode } from "@lexical/link";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";

--- a/apps/builder/app/canvas/features/text-editor/text-editor.tsx
+++ b/apps/builder/app/canvas/features/text-editor/text-editor.tsx
@@ -8,6 +8,8 @@ import {
   $createLineBreakNode,
   $getSelection,
   $isRangeSelection,
+  $createRangeSelection,
+  $setSelection,
 } from "lexical";
 import { LinkNode } from "@lexical/link";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
@@ -49,8 +51,15 @@ const AutofocusPlugin = () => {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
+    const rootElement = editor.getRootElement();
+
+    if (rootElement === null) {
+      return;
+    }
+
     editor.focus();
-  }, [editor]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return null;
 };

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -5,6 +5,7 @@ import {
   forwardRef,
   type ForwardedRef,
   useRef,
+  useLayoutEffect,
 } from "react";
 import { Suspense, lazy } from "react";
 import { useStore } from "@nanostores/react";
@@ -42,6 +43,7 @@ import { handleLinkClick } from "./link";
 import { mergeRefs } from "@react-aria/utils";
 import { composeEventHandlers } from "@radix-ui/primitive";
 import { setDataCollapsed } from "~/canvas/collapsed";
+import { getIsVisuallyHidden } from "~/shared/visually-hidden";
 
 const TextEditor = lazy(() => import("../text-editor"));
 
@@ -56,10 +58,17 @@ const ContentEditable = ({
 
   const ref = useRef<HTMLElement>(null);
 
-  useEffect(() => {
+  /**
+   * useLayoutEffect to be sure that editor plugins on useEffect would have access to rootElement
+   */
+  useLayoutEffect(() => {
     let rootElement = ref.current;
 
     if (rootElement == null) {
+      return;
+    }
+
+    if (getIsVisuallyHidden(rootElement)) {
       return;
     }
 

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -48,10 +48,6 @@ const TextEditor = lazy(() => import("../text-editor"));
 const ContentEditable = ({
   renderComponentWithRef,
 }: {
-  // Component: AnyComponent;
-  // elementRef: ForwardedRef<HTMLElement>;
-  // [idAttribute]: Instance["id"];
-  // [componentAttribute]: Instance["component"];
   renderComponentWithRef: (
     elementRef: ForwardedRef<HTMLElement>
   ) => JSX.Element;

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -66,7 +66,12 @@ const helperStyles = [
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.7);
   }`,
   // Has no width, will collapse
-  // Avoid uncollapsing the element being edited using `:not([data-lexical-editor])`.
+  // Ensure the TextEditor element doesn't uncollapse unintentionally:
+  // 1. Some TextEditor elements might appear empty for a few cycles after creation. (depends on existance of initial child)
+  // 2. If detected as empty, the collapsing algorithm could wrongly uncollapse them.
+  // 3. We prevent this by excluding elements with `data-lexical-editor`.
+  // 4. This rule is used here and not in collapsing detection because `data-lexical-editor` might not be set instantly.
+  //    Mistakes in collapsing will be corrected in the next cycle.
   `[${idAttribute}]:where(:not(body):not([data-lexical-editor])[${collapsedAttribute}="w"]) {
     padding-right: 50px;
   }`,

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -66,15 +66,15 @@ const helperStyles = [
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.7);
   }`,
   // Has no width, will collapse
-  `[${idAttribute}]:where(:not(body)[${collapsedAttribute}="w"]) {
+  `[${idAttribute}]:where(:not(body):not([data-lexical-editor])[${collapsedAttribute}="w"]) {
     padding-right: 50px;
   }`,
   // Has no height, will collapse
-  `[${idAttribute}]:where(:not(body)[${collapsedAttribute}="h"]) {
+  `[${idAttribute}]:where(:not(body):not([data-lexical-editor])[${collapsedAttribute}="h"]) {
     padding-top: 50px;
   }`,
   // Has no width or height, will collapse
-  `[${idAttribute}]:where(:not(body)[${collapsedAttribute}="wh"]) {
+  `[${idAttribute}]:where(:not(body):not([data-lexical-editor])[${collapsedAttribute}="wh"]) {
     padding-right: 50px;
     padding-top: 50px;
   }`,

--- a/apps/builder/app/canvas/shared/styles.ts
+++ b/apps/builder/app/canvas/shared/styles.ts
@@ -66,6 +66,7 @@ const helperStyles = [
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.7);
   }`,
   // Has no width, will collapse
+  // Avoid uncollapsing the element being edited using `:not([data-lexical-editor])`.
   `[${idAttribute}]:where(:not(body):not([data-lexical-editor])[${collapsedAttribute}="w"]) {
     padding-right: 50px;
   }`,


### PR DESCRIPTION
## Description

![image](https://github.com/webstudio-is/webstudio-builder/assets/5077042/dc764c12-8612-4ea4-9a07-46384a8ed5a7)

https://discord.com/channels/955905230107738152/1137452246876033114

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
