### PR TITLE
Fix Toolbar dissapears in the tooltip

### DIFF
--- a/apps/builder/app/canvas/features/text-editor/toolbar-connector.tsx
+++ b/apps/builder/app/canvas/features/text-editor/toolbar-connector.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   type RangeSelection,
   type TextNode,
@@ -91,14 +91,14 @@ const getSelectionClienRect = () => {
   return domRange.getBoundingClientRect();
 };
 
-export const ToolbarConnectorPlugin = ({
+const ToolbarConnectorPluginInternal = ({
   onSelectNode,
 }: {
   onSelectNode: (nodeKey: string) => void;
 }) => {
   const [editor] = useLexicalComposerContext();
-  const isMouseDownRef = useRef(false);
 
+  const isMouseDownRef = useRef(false);
   // control toolbar state on data or selection updates
   const updateToolbar = useCallback(() => {
     const selection = $getSelection();
@@ -274,4 +274,33 @@ export const ToolbarConnectorPlugin = ({
   });
 
   return null;
+};
+
+export const ToolbarConnectorPlugin = ({
+  onSelectNode,
+}: {
+  onSelectNode: (nodeKey: string) => void;
+}) => {
+  const [editor] = useLexicalComposerContext();
+  const [hasRootElement, setHasRootElement] = useState(false);
+
+  useEffect(() => {
+    const rootElement = editor.getRootElement();
+
+    /**
+     * We don't set root element for VisuallyHidden nodes
+     * and need to prevent Toolbar events in this case
+     */
+    if (rootElement === null) {
+      return;
+    }
+
+    setHasRootElement(true);
+  }, [editor]);
+
+  if (hasRootElement === false) {
+    return null;
+  }
+
+  return <ToolbarConnectorPluginInternal onSelectNode={onSelectNode} />;
 };


### PR DESCRIPTION
## Description

Fixes 3

https://discord.com/channels/955905230107738152/1137452246876033114

Toolbar selection is not working inside tooltip content text.

## Steps for reproduction

Open tooltip, start editing tooltip content text. Select some text with mouse. Mouse is now visible

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
