### PR TITLE
Use stream consumers while uploading

### DIFF
--- a/packages/asset-uploader/src/clients/fs/upload.ts
+++ b/packages/asset-uploader/src/clients/fs/upload.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
+import { buffer } from "node:stream/consumers";
 import { getAssetData } from "../../utils/get-asset-data";
-import { toUint8Array } from "../../utils/to-uint8-array";
 import { createSizeLimiter } from "../../utils/size-limiter";
 
 export const uploadToFs = async ({
@@ -23,7 +23,7 @@ export const uploadToFs = async ({
   await mkdir(dirname(filepath), { recursive: true }).catch(() => {});
   const limitSize = createSizeLimiter(maxSize, name);
 
-  const data = await toUint8Array(limitSize(dataStream));
+  const data = await buffer(limitSize(dataStream));
   await writeFile(filepath, data);
 
   const assetData = await getAssetData({

--- a/packages/asset-uploader/src/clients/s3/upload.ts
+++ b/packages/asset-uploader/src/clients/s3/upload.ts
@@ -1,5 +1,5 @@
+import { arrayBuffer } from "node:stream/consumers";
 import type { SignatureV4 } from "@smithy/signature-v4";
-import { toUint8Array } from "../../utils/to-uint8-array";
 import { getAssetData } from "../../utils/get-asset-data";
 import { createSizeLimiter } from "../../utils/size-limiter";
 
@@ -28,7 +28,7 @@ export const uploadToS3 = async ({
   // this has to be a stream that goes directly to s3
   // Size check has to happen as you stream and interrupted when size is too big
   // Also check if S3 client has an option to check the size limit
-  const data = await toUint8Array(limitSize(dataStream));
+  const data = await arrayBuffer(limitSize(dataStream));
 
   const url = new URL(`/${bucket}/${name}`, endpoint);
 
@@ -64,7 +64,7 @@ export const uploadToS3 = async ({
   const assetData = await getAssetData({
     type: type.startsWith("image") ? "image" : "font",
     size: data.byteLength,
-    data,
+    data: new Uint8Array(data),
   });
 
   return assetData;

--- a/packages/asset-uploader/src/utils/to-uint8-array.ts
+++ b/packages/asset-uploader/src/utils/to-uint8-array.ts
@@ -1,8 +1,0 @@
-export const toUint8Array = async (data: AsyncIterable<ArrayBuffer>) => {
-  const result = [];
-  for await (const chunk of data) {
-    result.push(Buffer.from(chunk));
-  }
-
-  return new Uint8Array(Buffer.concat(result));
-};


### PR DESCRIPTION
Looks like node now provides nice utilities to convert stream into json, buffer, text etc. Super handy

https://nodejs.org/docs/latest-v18.x/api/webstreams.html#utility-consumers

Cloudflare node compat supports this as well
https://developers.cloudflare.com/workers/runtime-apis/nodejs/streams/

## Code Review

- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
