### PR TITLE
Add component hooks

### DIFF
--- a/apps/builder/app/builder/features/inspector/inspector.tsx
+++ b/apps/builder/app/builder/features/inspector/inspector.tsx
@@ -73,7 +73,7 @@ export const Inspector = ({ publish, navigatorLayout }: InspectorProps) => {
   const metas = useStore(registeredComponentMetasStore);
 
   if (navigatorLayout === "docked" && isDragging) {
-    return <NavigatorTree />;
+    return <NavigatorTree publish={publish} />;
   }
 
   if (selectedInstance === undefined) {

--- a/apps/builder/app/builder/features/sidebar-left/navigator/navigator.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/navigator/navigator.tsx
@@ -21,7 +21,7 @@ export const Navigator = ({ isClosable, onClose, publish }: NavigatorProps) => {
         suffix={isClosable && <CloseButton onClick={() => onClose?.()} />}
       />
       <Flex grow direction="column" justify="end">
-        <NavigatorTree />
+        <NavigatorTree publish={publish} />
         <Separator />
         <CssPreview />
       </Flex>

--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -123,7 +123,7 @@ export const NavigatorTree = ({ publish }: { publish: Publish }) => {
           publish({
             type: "emitComponentHook",
             payload: {
-              name: "onNavigatorDeselect",
+              name: "onNavigatorUnselect",
               data: {
                 instanceSelection: previousInstanceSelector.flatMap((id) => {
                   const instance = instances.get(id);

--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -117,6 +117,7 @@ export const NavigatorTree = ({ publish }: { publish: Publish }) => {
         shallowEqual(selectedInstanceSelectorStore.get(), instanceSelector) ===
         false
       ) {
+        const instances = instancesStore.get();
         const previousInstanceSelector = selectedInstanceSelectorStore.get();
         if (previousInstanceSelector) {
           publish({
@@ -124,10 +125,10 @@ export const NavigatorTree = ({ publish }: { publish: Publish }) => {
             payload: {
               name: "onNavigatorDeselect",
               data: {
-                instanceSelector: previousInstanceSelector as [
-                  string,
-                  ...string[],
-                ],
+                instanceSelection: previousInstanceSelector.flatMap((id) => {
+                  const instance = instances.get(id);
+                  return instance ? [instance] : [];
+                }),
               },
             },
           });
@@ -140,7 +141,10 @@ export const NavigatorTree = ({ publish }: { publish: Publish }) => {
           payload: {
             name: "onNavigatorSelect",
             data: {
-              instanceSelector: instanceSelector as [string, ...string[]],
+              instanceSelection: instanceSelector.flatMap((id) => {
+                const instance = instances.get(id);
+                return instance ? [instance] : [];
+              }),
             },
           },
         });

--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -108,43 +108,46 @@ export const NavigatorTree = ({ publish }: { publish: Publish }) => {
     [setState]
   );
 
-  const handleSelect = useCallback((instanceSelector: InstanceSelector) => {
-    // TreeNode is refocused during "delete" hot key here https://github.com/webstudio-is/webstudio-builder/blob/5935d7818fba3739e4f16fe710ea468bf9d0ac78/packages/design-system/src/components/tree/tree.tsx#L435
-    // and then focus cause handleSelect to be called with the same instanceSelector
-    // This avoids additional rerender on node delete
-    if (
-      shallowEqual(selectedInstanceSelectorStore.get(), instanceSelector) ===
-      false
-    ) {
-      const previousInstanceSelector = selectedInstanceSelectorStore.get();
-      if (previousInstanceSelector) {
+  const handleSelect = useCallback(
+    (instanceSelector: InstanceSelector) => {
+      // TreeNode is refocused during "delete" hot key here https://github.com/webstudio-is/webstudio-builder/blob/5935d7818fba3739e4f16fe710ea468bf9d0ac78/packages/design-system/src/components/tree/tree.tsx#L435
+      // and then focus cause handleSelect to be called with the same instanceSelector
+      // This avoids additional rerender on node delete
+      if (
+        shallowEqual(selectedInstanceSelectorStore.get(), instanceSelector) ===
+        false
+      ) {
+        const previousInstanceSelector = selectedInstanceSelectorStore.get();
+        if (previousInstanceSelector) {
+          publish({
+            type: "emitComponentHook",
+            payload: {
+              name: "onNavigatorDeselect",
+              data: {
+                instanceSelector: previousInstanceSelector as [
+                  string,
+                  ...string[],
+                ],
+              },
+            },
+          });
+        }
+        selectedInstanceSelectorStore.set(instanceSelector);
+        textEditingInstanceSelectorStore.set(undefined);
+        selectedStyleSourceSelectorStore.set(undefined);
         publish({
           type: "emitComponentHook",
           payload: {
-            name: "onNavigatorDeselect",
+            name: "onNavigatorSelect",
             data: {
-              instanceSelector: previousInstanceSelector as [
-                string,
-                ...string[],
-              ],
+              instanceSelector: instanceSelector as [string, ...string[]],
             },
           },
         });
       }
-      selectedInstanceSelectorStore.set(instanceSelector);
-      textEditingInstanceSelectorStore.set(undefined);
-      selectedStyleSourceSelectorStore.set(undefined);
-      publish({
-        type: "emitComponentHook",
-        payload: {
-          name: "onNavigatorSelect",
-          data: {
-            instanceSelector: instanceSelector as [string, ...string[]],
-          },
-        },
-      });
-    }
-  }, []);
+    },
+    [publish]
+  );
 
   if (rootInstance === undefined) {
     return null;

--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -22,9 +22,10 @@ import {
   isInstanceDetachable,
   getComponentTemplateData,
 } from "~/shared/instance-utils";
+import type { Publish } from "~/shared/pubsub";
 import { InstanceTree } from "./tree";
 
-export const NavigatorTree = () => {
+export const NavigatorTree = ({ publish }: { publish: Publish }) => {
   const selectedInstanceSelector = useStore(selectedInstanceSelectorStore);
   const rootInstance = useStore(rootInstanceStore);
   const instances = useStore(instancesStore);
@@ -115,9 +116,33 @@ export const NavigatorTree = () => {
       shallowEqual(selectedInstanceSelectorStore.get(), instanceSelector) ===
       false
     ) {
+      const previousInstanceSelector = selectedInstanceSelectorStore.get();
+      if (previousInstanceSelector) {
+        publish({
+          type: "emitComponentHook",
+          payload: {
+            name: "onNavigatorDeselect",
+            data: {
+              instanceSelector: previousInstanceSelector as [
+                string,
+                ...string[],
+              ],
+            },
+          },
+        });
+      }
       selectedInstanceSelectorStore.set(instanceSelector);
       textEditingInstanceSelectorStore.set(undefined);
       selectedStyleSourceSelectorStore.set(undefined);
+      publish({
+        type: "emitComponentHook",
+        payload: {
+          name: "onNavigatorSelect",
+          data: {
+            instanceSelector: instanceSelector as [string, ...string[]],
+          },
+        },
+      });
     }
   }, []);
 

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -21,6 +21,7 @@ import * as remixComponentPropsMetas from "@webstudio-is/sdk-components-react-re
 import * as radixComponents from "@webstudio-is/sdk-components-react-radix";
 import * as radixComponentMetas from "@webstudio-is/sdk-components-react-radix/metas";
 import * as radixComponentPropsMetas from "@webstudio-is/sdk-components-react-radix/props";
+import { hooks as radixComponentHooks } from "@webstudio-is/sdk-components-react-radix/hooks";
 import { publish } from "~/shared/pubsub";
 import {
   handshakenStore,
@@ -43,6 +44,7 @@ import {
   dataSourceVariablesStore,
   registeredComponentsStore,
   registeredComponentMetasStore,
+  subscribeComponentHooks,
 } from "~/shared/nano-states";
 import { useDragAndDrop } from "./shared/use-drag-drop";
 import { useCopyPaste } from "~/shared/copy-paste";
@@ -193,8 +195,13 @@ export const Canvas = ({ params }: CanvasProps): JSX.Element | null => {
       components: radixComponents,
       metas: radixComponentMetas,
       propsMetas: radixComponentPropsMetas,
+      hooks: radixComponentHooks,
     });
   });
+
+  useEffect(() => {
+    return subscribeComponentHooks();
+  }, []);
 
   // e.g. toggling preview is still needed in both modes
   useCanvasShortcuts();

--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -199,9 +199,7 @@ export const Canvas = ({ params }: CanvasProps): JSX.Element | null => {
     });
   });
 
-  useEffect(() => {
-    return subscribeComponentHooks();
-  }, []);
+  useEffect(subscribeComponentHooks, []);
 
   // e.g. toggling preview is still needed in both modes
   useCanvasShortcuts();

--- a/apps/builder/app/shared/nano-states/components.ts
+++ b/apps/builder/app/shared/nano-states/components.ts
@@ -27,6 +27,9 @@ declare module "~/shared/pubsub" {
   }
 }
 
+// subscribe component hooks emitted from builder
+// and invoke all hooks
+// name and data is mapped to [name](context, data)
 export const subscribeComponentHooks = () => {
   return subscribe("emitComponentHook", (data) => {
     const hooks = registeredComponentHooksStore.get();

--- a/apps/builder/app/shared/nano-states/components.ts
+++ b/apps/builder/app/shared/nano-states/components.ts
@@ -10,7 +10,6 @@ import {
 } from "@webstudio-is/react-sdk";
 import type { Instance } from "@webstudio-is/project-build";
 import { subscribe } from "~/shared/pubsub";
-import { instancesStore } from "./instances";
 import { dataSourceVariablesStore, propsStore } from "./nano-states";
 
 type HookCommand = NonNullable<
@@ -33,11 +32,19 @@ export const subscribeComponentHooks = () => {
     const hooks = registeredComponentHooksStore.get();
     for (const hook of hooks) {
       const context: HookContext = {
-        instances: instancesStore.get(),
-        props: propsStore.get(),
-        setVariable: (dataSourceId, value) => {
+        setPropVariable: (instanceId, propName, value) => {
           const dataSourceVariables = new Map(dataSourceVariablesStore.get());
-          dataSourceVariables.set(dataSourceId, value);
+          const props = propsStore.get();
+          for (const prop of props.values()) {
+            if (
+              prop.instanceId === instanceId &&
+              prop.name === propName &&
+              prop.type === "dataSource"
+            ) {
+              const dataSourceId = prop.value;
+              dataSourceVariables.set(dataSourceId, value);
+            }
+          }
           dataSourceVariablesStore.set(dataSourceVariables);
         },
       };

--- a/packages/react-sdk/src/hook.ts
+++ b/packages/react-sdk/src/hook.ts
@@ -1,0 +1,18 @@
+import type { DataSource, Instances, Props } from "@webstudio-is/project-build";
+
+export type HookContext = {
+  instances: Instances;
+  props: Props;
+  setVariable: (dataSourceId: DataSource["id"], value: unknown) => void;
+};
+
+export type InstanceSelector = [string, ...string[]];
+
+type NavigatorEvent = {
+  instanceSelector: InstanceSelector;
+};
+
+export type Hook = {
+  onNavigatorSelect?: (context: HookContext, event: NavigatorEvent) => void;
+  onNavigatorDeselect?: (context: HookContext, event: NavigatorEvent) => void;
+};

--- a/packages/react-sdk/src/hook.ts
+++ b/packages/react-sdk/src/hook.ts
@@ -16,7 +16,7 @@ type NavigatorEvent = {
 
 export type Hook = {
   onNavigatorSelect?: (context: HookContext, event: NavigatorEvent) => void;
-  onNavigatorDeselect?: (context: HookContext, event: NavigatorEvent) => void;
+  onNavigatorUnselect?: (context: HookContext, event: NavigatorEvent) => void;
 };
 
 export const getClosestInstance = (

--- a/packages/react-sdk/src/hook.ts
+++ b/packages/react-sdk/src/hook.ts
@@ -1,5 +1,11 @@
 import type { Instance, Prop } from "@webstudio-is/project-build";
 
+/**
+ * Hooks are subscriptions to builder events
+ * with limited way to interact with it.
+ * Called independently from components.
+ */
+
 export type HookContext = {
   setPropVariable: (
     instanceId: Instance["id"],

--- a/packages/react-sdk/src/hook.ts
+++ b/packages/react-sdk/src/hook.ts
@@ -1,18 +1,36 @@
-import type { DataSource, Instances, Props } from "@webstudio-is/project-build";
+import type { Instance, Prop } from "@webstudio-is/project-build";
 
 export type HookContext = {
-  instances: Instances;
-  props: Props;
-  setVariable: (dataSourceId: DataSource["id"], value: unknown) => void;
+  setPropVariable: (
+    instanceId: Instance["id"],
+    propName: Prop["name"],
+    value: unknown
+  ) => void;
 };
 
-export type InstanceSelector = [string, ...string[]];
+export type InstanceSelection = Instance[];
 
 type NavigatorEvent = {
-  instanceSelector: InstanceSelector;
+  instanceSelection: InstanceSelection;
 };
 
 export type Hook = {
   onNavigatorSelect?: (context: HookContext, event: NavigatorEvent) => void;
   onNavigatorDeselect?: (context: HookContext, event: NavigatorEvent) => void;
+};
+
+export const getClosestInstance = (
+  instanceSelection: InstanceSelection,
+  currentInstance: Instance,
+  closestComponent: Instance["component"]
+) => {
+  let matched = false;
+  for (const instance of instanceSelection) {
+    if (currentInstance === instance) {
+      matched = true;
+    }
+    if (matched && instance.component === closestComponent) {
+      return instance;
+    }
+  }
 };

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -35,3 +35,4 @@ export {
 } from "./expression";
 export { renderComponentTemplate } from "./component-renderer";
 export { getIndexesWithinAncestors } from "./instance-utils";
+export type { Hook, HookContext, InstanceSelector } from "./hook";

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -35,4 +35,4 @@ export {
 } from "./expression";
 export { renderComponentTemplate } from "./component-renderer";
 export { getIndexesWithinAncestors } from "./instance-utils";
-export type { Hook, HookContext, InstanceSelector } from "./hook";
+export * from "./hook";

--- a/packages/sdk-components-react-radix/package.json
+++ b/packages/sdk-components-react-radix/package.json
@@ -30,6 +30,12 @@
       "types": "./lib/types/props.d.ts",
       "import": "./lib/props.js",
       "require": "./lib/cjs/props.js"
+    },
+    "./hooks": {
+      "source": "./src/hooks.ts",
+      "types": "./lib/types/hooks.d.ts",
+      "import": "./lib/hooks.js",
+      "require": "./lib/cjs/hooks.js"
     }
   },
   "scripts": {

--- a/packages/sdk-components-react-radix/src/collapsible.tsx
+++ b/packages/sdk-components-react-radix/src/collapsible.tsx
@@ -42,7 +42,7 @@ export const CollapsibleContent: ForwardRefExoticComponent<
 const namespace = "@webstudio-is/sdk-components-react-radix";
 
 export const hooksCollapsible: Hook = {
-  onNavigatorDeselect: (context, event) => {
+  onNavigatorUnselect: (context, event) => {
     for (const instance of event.instanceSelection) {
       if (instance.component === `${namespace}:CollapsibleContent`) {
         const collapsible = getClosestInstance(

--- a/packages/sdk-components-react-radix/src/collapsible.tsx
+++ b/packages/sdk-components-react-radix/src/collapsible.tsx
@@ -41,6 +41,9 @@ export const CollapsibleContent: ForwardRefExoticComponent<
 
 const namespace = "@webstudio-is/sdk-components-react-radix";
 
+// For each CollapsibleContent component within the selection,
+// we identify its closest parent Collapsible component
+// and update its open prop bound to variable.
 export const hooksCollapsible: Hook = {
   onNavigatorUnselect: (context, event) => {
     for (const instance of event.instanceSelection) {

--- a/packages/sdk-components-react-radix/src/hooks.ts
+++ b/packages/sdk-components-react-radix/src/hooks.ts
@@ -1,0 +1,4 @@
+import type { Hook } from "@webstudio-is/react-sdk";
+import { hooksCollapsible } from "./collapsible";
+
+export const hooks: Hook[] = [hooksCollapsible];


### PR DESCRIPTION
We want to control some builder behavior specific to some components. For example set open state on dialog, collapsible etc when select in navigator.

Here I added hooks to be called from builder and executed in canvas. For now added 2 hooks onNavigatorSelect and onNavigatorDeselect.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
