### PR TITLE
Add prefetch viewport for as a link prefetch option

### DIFF
--- a/packages/sdk-components-react-remix/src/__generated__/link.props.ts
+++ b/packages/sdk-components-react-remix/src/__generated__/link.props.ts
@@ -434,9 +434,9 @@ export const props: Record<string, PropMeta> = {
   placeholder: { required: false, control: "text", type: "string" },
   prefetch: {
     required: false,
-    control: "radio",
+    control: "select",
     type: "string",
-    options: ["none", "intent", "render"],
+    options: ["none", "intent", "render", "viewport"],
   },
   prefix: { required: false, control: "text", type: "string" },
   preventScrollReset: { required: false, control: "boolean", type: "boolean" },

--- a/packages/sdk-components-react-remix/src/__generated__/rich-text-link.props.ts
+++ b/packages/sdk-components-react-remix/src/__generated__/rich-text-link.props.ts
@@ -434,9 +434,9 @@ export const props: Record<string, PropMeta> = {
   placeholder: { required: false, control: "text", type: "string" },
   prefetch: {
     required: false,
-    control: "radio",
+    control: "select",
     type: "string",
-    options: ["none", "intent", "render"],
+    options: ["none", "intent", "render", "viewport"],
   },
   prefix: { required: false, control: "text", type: "string" },
   preventScrollReset: { required: false, control: "boolean", type: "boolean" },

--- a/packages/sdk-components-react-remix/src/shared/remix-link.tsx
+++ b/packages/sdk-components-react-remix/src/shared/remix-link.tsx
@@ -11,7 +11,7 @@ type Props = Omit<ComponentPropsWithoutRef<typeof Link>, "target"> & {
   target?: "_self" | "_blank" | "_parent" | "_top";
 
   // useful remix props
-  prefetch?: "intent" | "render" | "none";
+  prefetch?: "none" | "intent" | "render" | "viewport";
   reloadDocument?: boolean;
   replace?: boolean;
   preventScrollReset?: boolean;
@@ -34,7 +34,10 @@ export const wrapLinkComponent = (BaseLink: typeof Link) => {
       return <RemixLink {...props} to={to} ref={ref} />;
     }
 
-    return <BaseLink {...props} ref={ref} />;
+    const { prefetch, reloadDocument, replace, preventScrollReset, ...rest } =
+      props;
+
+    return <BaseLink {...rest} ref={ref} />;
   });
 
   Component.displayName = BaseLink.displayName;


### PR DESCRIPTION
## Description

- Add prefetch viewport for as a link prefetch option
- Prevent leaking prefetch property and other remix props to the dom

## Steps for reproduction

1. add a link
2. set prefetch to viewport
3. see that it prefetches a linked page (internal page only) as the link scrolls into view

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
