### PR TITLE
Automatically open tab content on select in navigator

### DIFF
--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -125,7 +125,7 @@ export const NavigatorTree = ({ publish }: { publish: Publish }) => {
             payload: {
               name: "onNavigatorUnselect",
               data: {
-                instanceSelection: previousInstanceSelector.flatMap((id) => {
+                instancePath: previousInstanceSelector.flatMap((id) => {
                   const instance = instances.get(id);
                   return instance ? [instance] : [];
                 }),
@@ -141,7 +141,7 @@ export const NavigatorTree = ({ publish }: { publish: Publish }) => {
           payload: {
             name: "onNavigatorSelect",
             data: {
-              instanceSelection: instanceSelector.flatMap((id) => {
+              instancePath: instanceSelector.flatMap((id) => {
                 const instance = instances.get(id);
                 return instance ? [instance] : [];
               }),

--- a/packages/react-sdk/src/hook.test.ts
+++ b/packages/react-sdk/src/hook.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "@jest/globals";
+import { getClosestInstance, type InstancePath } from ".";
+
+test("get closest instance", () => {
+  const instancePath: InstancePath = [
+    { type: "instance", id: "4", component: "Content", children: [] },
+    { type: "instance", id: "3", component: "Tabs", children: [] },
+    { type: "instance", id: "2", component: "Content", children: [] },
+    { type: "instance", id: "1", component: "Tabs", children: [] },
+    { type: "instance", id: "0", component: "Body", children: [] },
+  ];
+  const [content2, tabs2, content1, tabs1, _body] = instancePath;
+  expect(getClosestInstance(instancePath, content2, "Tabs")).toBe(tabs2);
+  expect(getClosestInstance(instancePath, content1, "Tabs")).toBe(tabs1);
+});

--- a/packages/react-sdk/src/hook.ts
+++ b/packages/react-sdk/src/hook.ts
@@ -1,4 +1,5 @@
 import type { Instance, Prop } from "@webstudio-is/project-build";
+import type { IndexesWithinAncestors } from "./instance-utils";
 
 /**
  * Hooks are subscriptions to builder events
@@ -7,6 +8,8 @@ import type { Instance, Prop } from "@webstudio-is/project-build";
  */
 
 export type HookContext = {
+  indexesWithinAncestors: IndexesWithinAncestors;
+  getPropValue: (instanceId: Instance["id"], propName: Prop["name"]) => unknown;
   setPropVariable: (
     instanceId: Instance["id"],
     propName: Prop["name"],
@@ -14,10 +17,13 @@ export type HookContext = {
   ) => void;
 };
 
-export type InstanceSelection = Instance[];
+export type InstancePath = Instance[];
 
 type NavigatorEvent = {
-  instanceSelection: InstanceSelection;
+  /**
+   * List of instances from selected to the root
+   */
+  instancePath: InstancePath;
 };
 
 export type Hook = {
@@ -25,13 +31,17 @@ export type Hook = {
   onNavigatorUnselect?: (context: HookContext, event: NavigatorEvent) => void;
 };
 
+/**
+ * Find closest matching instance by component name
+ * by lookup in instance path
+ */
 export const getClosestInstance = (
-  instanceSelection: InstanceSelection,
+  instancePath: InstancePath,
   currentInstance: Instance,
   closestComponent: Instance["component"]
 ) => {
   let matched = false;
-  for (const instance of instanceSelection) {
+  for (const instance of instancePath) {
     if (currentInstance === instance) {
       matched = true;
     }

--- a/packages/sdk-components-react-radix/src/collapsible.tsx
+++ b/packages/sdk-components-react-radix/src/collapsible.tsx
@@ -46,10 +46,10 @@ const namespace = "@webstudio-is/sdk-components-react-radix";
 // and update its open prop bound to variable.
 export const hooksCollapsible: Hook = {
   onNavigatorUnselect: (context, event) => {
-    for (const instance of event.instanceSelection) {
+    for (const instance of event.instancePath) {
       if (instance.component === `${namespace}:CollapsibleContent`) {
         const collapsible = getClosestInstance(
-          event.instanceSelection,
+          event.instancePath,
           instance,
           `${namespace}:Collapsible`
         );
@@ -60,10 +60,10 @@ export const hooksCollapsible: Hook = {
     }
   },
   onNavigatorSelect: (context, event) => {
-    for (const instance of event.instanceSelection) {
+    for (const instance of event.instancePath) {
       if (instance.component === `${namespace}:CollapsibleContent`) {
         const collapsible = getClosestInstance(
-          event.instanceSelection,
+          event.instancePath,
           instance,
           `${namespace}:Collapsible`
         );

--- a/packages/sdk-components-react-radix/src/hooks.ts
+++ b/packages/sdk-components-react-radix/src/hooks.ts
@@ -1,4 +1,5 @@
 import type { Hook } from "@webstudio-is/react-sdk";
 import { hooksCollapsible } from "./collapsible";
+import { hooksTabs } from "./tabs";
 
-export const hooks: Hook[] = [hooksCollapsible];
+export const hooks: Hook[] = [hooksCollapsible, hooksTabs];


### PR DESCRIPTION
Here added tabs hooks to auto select tab when its content is selected.
Added new utils to hook context getPropValue and indexesWithinAncestors.

Renamed instanceSelection to instancePath.

Had to pass all props in edit mode in webstudio component


https://github.com/webstudio-is/webstudio-builder/assets/5635476/1f1211bc-0ea4-4d21-9205-1439668e08b4



## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
