### PR TITLE
Fix if mouse leaves Tooltip.Content and moves over an iframe, the Radix Tooltip stays open

### DIFF
--- a/apps/builder/app/builder/builder.tsx
+++ b/apps/builder/app/builder/builder.tsx
@@ -11,7 +11,6 @@ import { useSyncServer } from "./shared/sync/sync-server";
 import { useSharedShortcuts } from "~/shared/shortcuts";
 import { SidebarLeft, Navigator } from "./features/sidebar-left";
 import { Inspector } from "./features/inspector";
-import { isCanvasPointerEventsEnabledStore } from "./shared/nano-states";
 import { Topbar } from "./features/topbar";
 import builderStyles from "./builder.css";
 // eslint-disable-next-line import/no-internal-modules
@@ -286,9 +285,6 @@ export const Builder = ({
     },
     [publishRef, onRefReadCanvas]
   );
-  const isCanvasPointerEventsEnabled = useStore(
-    isCanvasPointerEventsEnabledStore
-  );
 
   const navigatorLayout = useNavigatorLayout();
 
@@ -306,7 +302,6 @@ export const Builder = ({
             <CanvasIframe
               ref={iframeRefCallback}
               src={canvasUrl}
-              pointerEvents={isCanvasPointerEventsEnabled ? "auto" : "none"}
               title={project.title}
               css={{
                 height: "100%",

--- a/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
@@ -2,6 +2,7 @@ import type { Publish } from "~/shared/pubsub";
 import type { Instance } from "@webstudio-is/project-build";
 import { SettingsSection } from "./settings-section/settings-section";
 import { PropsSectionContainer } from "./props-section/props-section";
+import { Tooltip } from "@webstudio-is/design-system";
 
 export const SettingsPanelContainer = ({
   selectedInstance,
@@ -13,6 +14,10 @@ export const SettingsPanelContainer = ({
   return (
     <>
       <SettingsSection />
+      <Tooltip defaultOpen={true} content="This is a tooltip">
+        <button>TEST</button>
+      </Tooltip>
+
       <PropsSectionContainer
         publish={publish}
         selectedInstance={selectedInstance}

--- a/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
+++ b/apps/builder/app/builder/features/settings-panel/settings-panel.tsx
@@ -2,7 +2,6 @@ import type { Publish } from "~/shared/pubsub";
 import type { Instance } from "@webstudio-is/project-build";
 import { SettingsSection } from "./settings-section/settings-section";
 import { PropsSectionContainer } from "./props-section/props-section";
-import { Tooltip } from "@webstudio-is/design-system";
 
 export const SettingsPanelContainer = ({
   selectedInstance,
@@ -14,10 +13,6 @@ export const SettingsPanelContainer = ({
   return (
     <>
       <SettingsSection />
-      <Tooltip defaultOpen={true} content="This is a tooltip">
-        <button>TEST</button>
-      </Tooltip>
-
       <PropsSectionContainer
         publish={publish}
         selectedInstance={selectedInstance}

--- a/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
@@ -9,6 +9,8 @@ import {
   useDrag,
   ComponentCard,
   toast,
+  enableCanvasPointerEvents,
+  disableCanvasPointerEvents,
 } from "@webstudio-is/design-system";
 import {
   instancesStore,
@@ -17,11 +19,7 @@ import {
   selectedPageStore,
 } from "~/shared/nano-states";
 import { useSubscribe, type Publish } from "~/shared/pubsub";
-import {
-  canvasRectStore,
-  isCanvasPointerEventsEnabledStore,
-  scaleStore,
-} from "~/builder/shared/nano-states";
+import { canvasRectStore, scaleStore } from "~/builder/shared/nano-states";
 import {
   computeInstancesConstraints,
   findClosestDroppableTarget,
@@ -144,7 +142,7 @@ export const useDraggable = ({
           dragComponent: componentName,
         },
       });
-      isCanvasPointerEventsEnabledStore.set(false);
+      disableCanvasPointerEvents();
     },
     onMove: (point) => {
       setPoint(point);
@@ -161,7 +159,8 @@ export const useDraggable = ({
         type: "dragEnd",
         payload: { isCanceled },
       });
-      isCanvasPointerEventsEnabledStore.set(true);
+
+      enableCanvasPointerEvents();
     },
   });
 

--- a/apps/builder/app/builder/features/workspace/canvas-iframe.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-iframe.tsx
@@ -1,32 +1,22 @@
 import { forwardRef } from "react";
-import { type CSS, css } from "@webstudio-is/design-system";
+import {
+  type CSS,
+  css,
+  canvasPointerEventsPropertyName,
+} from "@webstudio-is/design-system";
 
 const iframeStyle = css({
   border: "none",
-  variants: {
-    pointerEvents: {
-      none: {
-        pointerEvents: "none",
-      },
-      auto: {},
-    },
-  },
+  pointerEvents: `var(${canvasPointerEventsPropertyName})`,
 });
 
 type CanvasIframeProps = {
-  pointerEvents: "auto" | "none";
   css: CSS;
 } & JSX.IntrinsicElements["iframe"];
 
 export const CanvasIframe = forwardRef<HTMLIFrameElement, CanvasIframeProps>(
-  ({ pointerEvents = "auto", css, ...rest }, ref) => {
-    return (
-      <iframe
-        {...rest}
-        ref={ref}
-        className={iframeStyle({ pointerEvents, css })}
-      />
-    );
+  ({ css, ...rest }, ref) => {
+    return <iframe {...rest} ref={ref} className={iframeStyle({ css })} />;
   }
 );
 

--- a/apps/builder/app/builder/features/workspace/canvas-tools/resize-handles.tsx
+++ b/apps/builder/app/builder/features/workspace/canvas-tools/resize-handles.tsx
@@ -1,11 +1,14 @@
 import { useStore } from "@nanostores/react";
 import { findApplicableMedia } from "@webstudio-is/css-engine";
-import { css, numericScrubControl, theme } from "@webstudio-is/design-system";
-import { useEffect, useRef } from "react";
 import {
-  canvasWidthStore,
-  isCanvasPointerEventsEnabledStore,
-} from "~/builder/shared/nano-states";
+  css,
+  disableCanvasPointerEvents,
+  enableCanvasPointerEvents,
+  numericScrubControl,
+  theme,
+} from "@webstudio-is/design-system";
+import { useEffect, useRef } from "react";
+import { canvasWidthStore } from "~/builder/shared/nano-states";
 import { minCanvasWidth } from "~/shared/breakpoints";
 import {
   breakpointsStore,
@@ -113,11 +116,11 @@ const useScrub = ({ side }: { side: "right" | "left" }) => {
       },
       onStatusChange(status) {
         if (status === "scrubbing") {
-          isCanvasPointerEventsEnabledStore.set(false);
+          disableCanvasPointerEvents();
           isResizingCanvasStore.set(true);
           return;
         }
-        isCanvasPointerEventsEnabledStore.set(true);
+        enableCanvasPointerEvents();
         isResizingCanvasStore.set(false);
       },
       onValueInput(event) {

--- a/apps/builder/app/builder/shared/nano-states/index.ts
+++ b/apps/builder/app/builder/shared/nano-states/index.ts
@@ -17,8 +17,6 @@ export const useCanvasWidth = () => useValue(canvasWidthStore);
 
 export const canvasRectStore = atom<DOMRect | undefined>();
 
-export const isCanvasPointerEventsEnabledStore = atom<boolean>(true);
-
 export const workspaceRectStore = atom<DOMRect | undefined>();
 
 export const scaleStore = computed(

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -61,6 +61,7 @@
     "@radix-ui/react-toggle-group": "^1.0.4",
     "@radix-ui/react-toolbar": "^1.0.4",
     "@radix-ui/react-tooltip": "^1.0.6",
+    "@radix-ui/react-use-controllable-state": "^1.0.1",
     "@react-aria/focus": "^3.13.0",
     "@react-aria/interactions": "^3.16.0",
     "@react-aria/utils": "^3.18.0",
@@ -73,7 +74,8 @@
     "match-sorter": "^6.3.1",
     "react-hot-toast": "^2.4.1",
     "token-transformer": "^0.0.28",
-    "use-debounce": "^9.0.4"
+    "use-debounce": "^9.0.4",
+    "warn-once": "^0.1.1"
   },
   "exports": {
     "source": "./src/index.ts",

--- a/packages/design-system/src/components/tooltip.tsx
+++ b/packages/design-system/src/components/tooltip.tsx
@@ -56,19 +56,22 @@ let openTooltipsCount = 0;
  * The current workaround is to set pointer-events: none on the canvas when the tooltip is open.
  **/
 const handleTooltipOpenChange = (open: boolean) => {
+  if (openTooltipsCount < 0) {
+    // Should be impossible but in case if we've missed a tooltip open/close event,
+    // just enable events and stop this algorithm, to preserve system in working state
+    warnOnce(true, "Tooltip counter can't be less than 0");
+    enableCanvasPointerEvents();
+    return;
+  }
+
   // Multiple tooltips can open simultaneously. Use a counter instead of a boolean to manage them.
   openTooltipsCount = openTooltipsCount + (open ? 1 : -1);
+
   if (openTooltipsCount > 0) {
     disableCanvasPointerEvents();
   }
 
-  if (openTooltipsCount === 0) {
-    enableCanvasPointerEvents();
-  }
-
-  warnOnce(true, "Tooltip counter can't be less than 0");
-  // try to restore if it happens
-  openTooltipsCount = 0;
+  enableCanvasPointerEvents();
 };
 
 export const Tooltip = forwardRef(

--- a/packages/design-system/src/components/tooltip.tsx
+++ b/packages/design-system/src/components/tooltip.tsx
@@ -1,11 +1,17 @@
 import type { Ref, ComponentProps, ReactNode, ReactElement } from "react";
-import { Fragment, forwardRef } from "react";
+import { Fragment, forwardRef, useEffect, useRef } from "react";
 import { styled } from "../stitches.config";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import { Box } from "./box";
 import { Text } from "./text";
 import type { CSS } from "../stitches.config";
 import { theme } from "../stitches.config";
+import warnOnce from "warn-once";
+import {
+  disableCanvasPointerEvents,
+  enableCanvasPointerEvents,
+} from "../utilities";
 
 export type TooltipProps = ComponentProps<typeof TooltipPrimitive.Root> &
   Omit<ComponentProps<typeof Content>, "content"> & {
@@ -42,6 +48,29 @@ const Arrow = styled(TooltipPrimitive.Arrow, {
   marginTop: -0.5,
 });
 
+let openTooltipsCount = 0;
+
+/**
+ * When the mouse leaves Tooltip.Content and moves over an iframe, the Radix Tooltip stays open.
+ * This happens because Radix's internal grace area relies on the pointermove event, which isn't triggered over iframes.
+ * The current workaround is to set pointer-events: none on the canvas when the tooltip is open.
+ **/
+const handleTooltipOpenChange = (open: boolean) => {
+  // Multiple tooltips can open simultaneously. Use a counter instead of a boolean to manage them.
+  openTooltipsCount = openTooltipsCount + (open ? 1 : -1);
+  if (openTooltipsCount > 0) {
+    disableCanvasPointerEvents();
+  }
+
+  if (openTooltipsCount === 0) {
+    enableCanvasPointerEvents();
+  }
+
+  warnOnce(true, "Tooltip counter can't be less than 0");
+  // try to restore if it happens
+  openTooltipsCount = 0;
+};
+
 export const Tooltip = forwardRef(
   (
     {
@@ -50,7 +79,7 @@ export const Tooltip = forwardRef(
       defaultOpen,
       delayDuration,
       disableHoverableContent,
-      open,
+      open: openProp,
       onOpenChange,
       triggerProps,
       ...props
@@ -59,6 +88,32 @@ export const Tooltip = forwardRef(
     },
     ref: Ref<HTMLDivElement>
   ) => {
+    const isOpenRef = useRef(false);
+
+    // We need to intercept tooltip open
+    const [open = false, setOpen] = useControllableState({
+      prop: openProp,
+      defaultProp: defaultOpen,
+      onChange: (open) => {
+        onOpenChange?.(open);
+      },
+    });
+
+    // Manage scenarios where defaultOpen or open is initially set, or when the tooltip is unmounted.
+    useEffect(() => {
+      if (isOpenRef.current !== open) {
+        handleTooltipOpenChange(open);
+        isOpenRef.current = open;
+      }
+
+      return () => {
+        if (isOpenRef.current) {
+          handleTooltipOpenChange(false);
+          isOpenRef.current = false;
+        }
+      };
+    }, [open]);
+
     if (!content) {
       return children;
     }
@@ -67,7 +122,7 @@ export const Tooltip = forwardRef(
       <TooltipPrimitive.Root
         open={open}
         defaultOpen={defaultOpen}
-        onOpenChange={onOpenChange}
+        onOpenChange={setOpen}
         delayDuration={delayDuration}
         disableHoverableContent={disableHoverableContent}
       >

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./stitches.config";
 export * from "./components/storybook";
+export * from "./utilities";
 
 // Aligned with Figma
 

--- a/packages/design-system/src/utilities.ts
+++ b/packages/design-system/src/utilities.ts
@@ -1,0 +1,14 @@
+export const canvasPointerEventsPropertyName = "--canvas-pointer-events";
+
+export const enableCanvasPointerEvents = () => {
+  document.documentElement.style.removeProperty(
+    canvasPointerEventsPropertyName
+  );
+};
+
+export const disableCanvasPointerEvents = () => {
+  document.documentElement.style.setProperty(
+    canvasPointerEventsPropertyName,
+    "none"
+  );
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -724,6 +724,9 @@ importers:
       use-debounce:
         specifier: ^9.0.4
         version: 9.0.4(react@18.2.0)
+      warn-once:
+        specifier: ^0.1.1
+        version: 0.1.1
     devDependencies:
       '@jest/globals':
         specifier: ^29.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -682,6 +682,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.0.6
         version: 1.0.6(@types/react-dom@18.2.7)(@types/react@18.2.16)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state':
+        specifier: ^1.0.1
+        version: 1.0.1(@types/react@18.2.16)(react@18.2.0)
       '@react-aria/focus':
         specifier: ^3.13.0
         version: 3.13.0(react@18.2.0)


### PR DESCRIPTION
## Description

When the mouse leaves Tooltip.Content and moves over an iframe, the Radix Tooltip stays open.
This happens because Radix's internal grace area relies on the pointermove event, which isn't triggered over iframes.
The current workaround is to set pointer-events: none on the canvas when the tooltip is open.

Here are:
- [x] Tooltip component sets `--canvas-pointer-events` on the documentElement if any tooltip is open
- [x] Iframe uses `--canvas-pointer-events`
- [x] `isCanvasPointerEventsEnabledStore` in order to use above css variable
- [x] Color picker hack fully removed. Now just intercepts `open` state change, as it's dialog and  canvas is not interactive when it's open already so it's safe to disable pointer-events too.


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
