### PR TITLE
Add list item section to style panel

### DIFF
--- a/apps/builder/app/builder/features/style-panel/controls/select/select-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/controls/select/select-control.tsx
@@ -12,19 +12,26 @@ export const SelectControl = ({
   items,
 }: ControlProps) => {
   const { items: defaultItems } = styleConfigByName(property);
-  const value = currentStyle[property]?.value;
+  const styleValue = currentStyle[property]?.value;
   const setValue = setProperty(property);
+  const options = (items ?? defaultItems).map(({ name }) => name);
+  const value = toValue(styleValue);
+  // append selected value when not present in the list of options
+  // because radix requires values to always be in the list
+  if (options.includes(value) === false) {
+    options.push(value);
+  }
 
   return (
     <Select
       // show empty field instead of radix placeholder
       // like css value input does
       placeholder=""
-      options={(items ?? defaultItems).map(({ name }) => name)}
+      options={options}
       getLabel={(name) => {
         return toPascalCase(name);
       }}
-      value={toValue(value)}
+      value={value}
       onChange={(name) => {
         const value = parseCssValue(property, name);
         setValue(value);

--- a/apps/builder/app/builder/features/style-panel/sections/index.ts
+++ b/apps/builder/app/builder/features/style-panel/sections/index.ts
@@ -1,4 +1,5 @@
 export * from "./layout/layout";
+export * from "./list-item";
 export * from "./flex-child/flex-child";
 export * from "./grid-child/grid-child";
 export * from "./space/space";

--- a/apps/builder/app/builder/features/style-panel/sections/list-item.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/list-item.tsx
@@ -1,0 +1,39 @@
+import type { StyleProperty } from "@webstudio-is/css-data";
+import { Grid, theme } from "@webstudio-is/design-system";
+import { styleConfigByName } from "../shared/configs";
+import type { RenderCategoryProps } from "../style-sections";
+import { PropertyName } from "../shared/property-name";
+import { SelectControl } from "../controls";
+
+import { CollapsibleSection } from "../shared/collapsible-section";
+
+const properties: StyleProperty[] = ["listStyleType"];
+
+export const ListItemSection = ({
+  currentStyle: style,
+  setProperty,
+  deleteProperty,
+}: RenderCategoryProps) => {
+  return (
+    <CollapsibleSection
+      label="List Item"
+      currentStyle={style}
+      properties={properties}
+    >
+      <Grid gap={2} css={{ gridTemplateColumns: `1fr ${theme.spacing[22]}` }}>
+        <PropertyName
+          label={styleConfigByName("listStyleType").label}
+          properties={["listStyleType"]}
+          style={style}
+          onReset={() => deleteProperty("listStyleType")}
+        />
+        <SelectControl
+          property={"listStyleType"}
+          currentStyle={style}
+          setProperty={setProperty}
+          deleteProperty={deleteProperty}
+        />
+      </Grid>
+    </CollapsibleSection>
+  );
+};

--- a/apps/builder/app/builder/features/style-panel/sections/list-item.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/list-item.tsx
@@ -20,7 +20,7 @@ export const ListItemSection = ({
       currentStyle={style}
       properties={properties}
     >
-      <Grid gap={2} css={{ gridTemplateColumns: `1fr ${theme.spacing[22]}` }}>
+      <Grid gap={2} css={{ gridTemplateColumns: `1fr ${theme.spacing[21]}` }}>
         <PropertyName
           label={styleConfigByName("listStyleType").label}
           properties={["listStyleType"]}

--- a/apps/builder/app/builder/features/style-panel/style-sections.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-sections.tsx
@@ -1,3 +1,4 @@
+import type { htmlTags as HtmlTag } from "html-tags";
 import { Grid } from "@webstudio-is/design-system";
 import { toValue } from "@webstudio-is/css-engine";
 import { styleConfigByName } from "./shared/configs";
@@ -23,12 +24,14 @@ import {
   OutlineSection,
   EffectsSection,
   BoxShadowsSection,
+  ListItemSection,
 } from "./sections";
 
 export const categories = [
   "layout",
   "flexChild",
   "gridChild",
+  "listItem",
   "space",
   "size",
   "typography",
@@ -38,7 +41,7 @@ export const categories = [
   "boxShadows",
   "outline",
   "effects",
-];
+] as const;
 
 export type Category = (typeof categories)[number];
 
@@ -119,24 +122,29 @@ export const renderCategory = ({
 
 export const shouldRenderCategory = (
   { currentStyle, category }: RenderCategoryProps,
-  parentStyle: StyleInfo
+  parentStyle: StyleInfo,
+  tag: undefined | HtmlTag
 ) => {
   switch (category) {
     case "flexChild":
       return toValue(parentStyle.display?.value).includes("flex");
     case "gridChild":
       return toValue(currentStyle.display?.value).includes("grid");
+    case "listItem":
+      return tag === "ul" || tag === "ol" || tag === "li";
   }
 
   return true;
 };
 
-export const sections: {
-  [Property in Category]: (props: RenderCategoryProps) => JSX.Element | null;
-} = {
+export const sections: Record<
+  Category,
+  (props: RenderCategoryProps) => JSX.Element | null
+> = {
   layout: LayoutSection,
   flexChild: FlexChildSection,
   gridChild: GridChildSection,
+  listItem: ListItemSection,
   space: SpaceSection,
   size: SizeSection,
   position: PositionSection,

--- a/apps/builder/app/builder/features/style-panel/style-settings.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-settings.tsx
@@ -9,8 +9,12 @@ import {
 import type { SetProperty, CreateBatchUpdate } from "./shared/use-style-data";
 import type { StyleInfo } from "./shared/style-info";
 import { useStore } from "@nanostores/react";
-import { selectedInstanceSelectorStore } from "~/shared/nano-states";
+import {
+  selectedInstanceIntanceToTagStore,
+  selectedInstanceSelectorStore,
+} from "~/shared/nano-states";
 import { useStyleInfoByInstanceId } from "./shared/style-info";
+import { computed } from "nanostores";
 
 export type StyleSettingsProps = {
   currentStyle: StyleInfo;
@@ -31,12 +35,23 @@ const useParentStyle = () => {
   return parentStyleInfo;
 };
 
+const selectedInstanceTagStore = computed(
+  [selectedInstanceSelectorStore, selectedInstanceIntanceToTagStore],
+  (instanceSelector, instanceToTag) => {
+    if (instanceSelector === undefined || instanceToTag === undefined) {
+      return;
+    }
+    return instanceToTag.get(instanceSelector[0]);
+  }
+);
+
 export const StyleSettings = ({
   setProperty,
   deleteProperty,
   createBatchUpdate,
   currentStyle,
 }: StyleSettingsProps) => {
+  const selectedInstanceTag = useStore(selectedInstanceTagStore);
   const all = [];
   const parentStyle = useParentStyle();
 
@@ -49,7 +64,7 @@ export const StyleSettings = ({
       category,
     };
 
-    if (shouldRenderCategory(categoryProps, parentStyle)) {
+    if (shouldRenderCategory(categoryProps, parentStyle, selectedInstanceTag)) {
       all.push(
         <Fragment key={category}>{renderCategory(categoryProps)}</Fragment>
       );

--- a/packages/css-data/bin/mdn-data.ts
+++ b/packages/css-data/bin/mdn-data.ts
@@ -61,7 +61,7 @@ const normalizedValues = {
   "text-size-adjust": autoValue,
 } as const;
 
-const beautifyKeyword = (property: string, keyword: string) => {
+const beautifyKeyword = (_property: string, keyword: string) => {
   /*
    * The default value is `invert` or `currentcolor` for some css properties.
    * But that isn't supported in all browsers, example outline-color.
@@ -363,7 +363,8 @@ const keywordValues = (() => {
     }
 
     if (keywords.size !== 0) {
-      result[camelCase(property)] = Array.from(keywords);
+      const key = camelCase(property);
+      result[key] = [...(result[key] ?? []), ...keywords];
     }
   }
 

--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -23,7 +23,7 @@
     "camelcase": "^7.0.1",
     "html-tags": "^3.3.1",
     "jest": "^29.6.2",
-    "mdn-data": "2.0.30",
+    "mdn-data": "2.0.32",
     "tsx": "^3.12.6",
     "type-fest": "^3.7.1",
     "typescript": "5.1.6",

--- a/packages/css-data/src/__generated__/keyword-values.ts
+++ b/packages/css-data/src/__generated__/keyword-values.ts
@@ -2,6 +2,19 @@
 export const keywordValues = {
   WebkitFontSmoothing: ["auto", "none", "antialiased", "subpixel-antialiased"],
   MozOsxFontSmoothing: ["auto", "grayscale"],
+  listStyleType: [
+    "disc",
+    "circle",
+    "square",
+    "decimal",
+    "georgian",
+    "trad-chinese-informal",
+    "kannada",
+    "none",
+    "initial",
+    "inherit",
+    "unset",
+  ],
   accentColor: [
     "auto",
     "transparent",
@@ -2877,7 +2890,6 @@ export const keywordValues = {
     "inherit",
     "unset",
   ],
-  printColorAdjust: ["economy", "exact", "initial", "inherit", "unset"],
   colorScheme: [
     "normal",
     "light",
@@ -3080,6 +3092,15 @@ export const keywordValues = {
   containIntrinsicHeight: ["none", "auto", "initial", "inherit", "unset"],
   containIntrinsicInlineSize: ["none", "auto", "initial", "inherit", "unset"],
   containIntrinsicWidth: ["none", "auto", "initial", "inherit", "unset"],
+  containerName: ["none", "initial", "inherit", "unset"],
+  containerType: [
+    "normal",
+    "size",
+    "inline-size",
+    "initial",
+    "inherit",
+    "unset",
+  ],
   content: [
     "normal",
     "none",
@@ -3227,6 +3248,7 @@ export const keywordValues = {
   fontKerning: ["auto", "normal", "none", "initial", "inherit", "unset"],
   fontLanguageOverride: ["normal", "initial", "inherit", "unset"],
   fontOpticalSizing: ["auto", "none", "initial", "inherit", "unset"],
+  fontPalette: ["normal", "light", "dark", "initial", "inherit", "unset"],
   fontVariationSettings: ["normal", "initial", "inherit", "unset"],
   fontSize: [
     "xx-small",
@@ -3352,6 +3374,15 @@ export const keywordValues = {
     "inherit",
     "unset",
   ],
+  fontVariantEmoji: [
+    "normal",
+    "text",
+    "emoji",
+    "unicode",
+    "initial",
+    "inherit",
+    "unset",
+  ],
   fontVariantLigatures: [
     "normal",
     "none",
@@ -3461,6 +3492,7 @@ export const keywordValues = {
     "unset",
   ],
   hyphenateCharacter: ["auto", "initial", "inherit", "unset"],
+  hyphenateLimitChars: ["auto", "initial", "inherit", "unset"],
   hyphens: ["none", "manual", "auto", "initial", "inherit", "unset"],
   imageOrientation: ["from-image", "flip", "initial", "inherit", "unset"],
   imageRendering: [
@@ -3596,7 +3628,6 @@ export const keywordValues = {
   lineHeightStep: ["initial", "inherit", "unset"],
   listStyleImage: ["none", "initial", "inherit", "unset"],
   listStylePosition: ["inside", "outside", "initial", "inherit", "unset"],
-  listStyleType: ["none", "initial", "inherit", "unset"],
   marginBlockEnd: ["auto", "initial", "inherit", "unset"],
   marginBlockStart: ["auto", "initial", "inherit", "unset"],
   marginBottom: ["auto", "initial", "inherit", "unset"],
@@ -4142,6 +4173,7 @@ export const keywordValues = {
   paddingLeft: ["initial", "inherit", "unset"],
   paddingRight: ["initial", "inherit", "unset"],
   paddingTop: ["initial", "inherit", "unset"],
+  page: ["auto", "initial", "inherit", "unset"],
   pageBreakAfter: [
     "auto",
     "always",
@@ -4212,6 +4244,7 @@ export const keywordValues = {
     "inherit",
     "unset",
   ],
+  printColorAdjust: ["economy", "exact", "initial", "inherit", "unset"],
   quotes: ["none", "auto", "initial", "inherit", "unset"],
   resize: [
     "none",
@@ -5164,6 +5197,7 @@ export const keywordValues = {
     "inherit",
     "unset",
   ],
+  viewTransitionName: ["none", "initial", "inherit", "unset"],
   visibility: ["visible", "hidden", "collapse", "initial", "inherit", "unset"],
   whiteSpace: [
     "normal",

--- a/packages/css-data/src/__generated__/properties.ts
+++ b/packages/css-data/src/__generated__/properties.ts
@@ -958,16 +958,6 @@ export const properties = {
     popularity: 0.90791486,
     appliesTo: "allElementsAndText",
   },
-  printColorAdjust: {
-    unitGroups: [],
-    inherited: true,
-    initial: {
-      type: "keyword",
-      value: "economy",
-    },
-    popularity: 0,
-    appliesTo: "allElements",
-  },
   colorScheme: {
     unitGroups: [],
     inherited: true,
@@ -1109,6 +1099,26 @@ export const properties = {
     popularity: 0,
     appliesTo: "elementsForWhichSizeContainmentCanApply",
   },
+  containerName: {
+    unitGroups: [],
+    inherited: false,
+    initial: {
+      type: "keyword",
+      value: "none",
+    },
+    popularity: 0,
+    appliesTo: "allElements",
+  },
+  containerType: {
+    unitGroups: [],
+    inherited: false,
+    initial: {
+      type: "keyword",
+      value: "normal",
+    },
+    popularity: 0,
+    appliesTo: "allElements",
+  },
   content: {
     unitGroups: [],
     inherited: false,
@@ -1127,7 +1137,7 @@ export const properties = {
       value: "visible",
     },
     popularity: 0.04199404,
-    appliesTo: "elementsForWhichLayoutContainmentCanApply",
+    appliesTo: "elementsForWhichSizeContainmentCanApply",
   },
   counterIncrement: {
     unitGroups: ["number"],
@@ -1321,6 +1331,16 @@ export const properties = {
     popularity: 0.0006232,
     appliesTo: "allElements",
   },
+  fontPalette: {
+    unitGroups: [],
+    inherited: true,
+    initial: {
+      type: "keyword",
+      value: "normal",
+    },
+    popularity: 0,
+    appliesTo: "allElementsAndText",
+  },
   fontVariationSettings: {
     unitGroups: ["number"],
     inherited: true,
@@ -1429,6 +1449,16 @@ export const properties = {
     },
     popularity: 0.00328361,
     appliesTo: "allElements",
+  },
+  fontVariantEmoji: {
+    unitGroups: [],
+    inherited: true,
+    initial: {
+      type: "keyword",
+      value: "normal",
+    },
+    popularity: 0,
+    appliesTo: "allElementsAndText",
   },
   fontVariantLigatures: {
     unitGroups: [],
@@ -1602,6 +1632,16 @@ export const properties = {
   },
   hyphenateCharacter: {
     unitGroups: [],
+    inherited: true,
+    initial: {
+      type: "keyword",
+      value: "auto",
+    },
+    popularity: 0,
+    appliesTo: "allElements",
+  },
+  hyphenateLimitChars: {
+    unitGroups: ["number"],
     inherited: true,
     initial: {
       type: "keyword",
@@ -2640,6 +2680,16 @@ export const properties = {
     popularity: 0.82360295,
     appliesTo: "allElementsExceptInternalTableDisplayTypes",
   },
+  page: {
+    unitGroups: [],
+    inherited: false,
+    initial: {
+      type: "keyword",
+      value: "auto",
+    },
+    popularity: 0.00131264,
+    appliesTo: "blockElementsInNormalFlow",
+  },
   pageBreakAfter: {
     unitGroups: [],
     inherited: false,
@@ -2729,6 +2779,16 @@ export const properties = {
       value: "static",
     },
     popularity: 0.92435004,
+    appliesTo: "allElements",
+  },
+  printColorAdjust: {
+    unitGroups: [],
+    inherited: true,
+    initial: {
+      type: "keyword",
+      value: "economy",
+    },
+    popularity: 0,
     appliesTo: "allElements",
   },
   quotes: {
@@ -3521,6 +3581,16 @@ export const properties = {
     },
     popularity: 0.84531302,
     appliesTo: "inlineLevelAndTableCellElements",
+  },
+  viewTransitionName: {
+    unitGroups: [],
+    inherited: false,
+    initial: {
+      type: "keyword",
+      value: "none",
+    },
+    popularity: 0,
+    appliesTo: "allElements",
   },
   visibility: {
     unitGroups: [],

--- a/packages/css-data/src/custom-data.ts
+++ b/packages/css-data/src/custom-data.ts
@@ -45,3 +45,13 @@ propertiesData.MozOsxFontSmoothing = {
   appliesTo: "allElements",
 };
 keywordValues.MozOsxFontSmoothing = ["auto", "grayscale"];
+
+keywordValues.listStyleType = [
+  "disc",
+  "circle",
+  "square",
+  "decimal",
+  "georgian",
+  "trad-chinese-informal",
+  "kannada",
+];

--- a/packages/sdk-components-react/src/list.ws.tsx
+++ b/packages/sdk-components-react/src/list.ws.tsx
@@ -54,5 +54,5 @@ export const meta: WsComponentMeta = {
 
 export const propsMeta: WsComponentPropsMeta = {
   props,
-  initialProps: ["id", "ordered", "type", "start", "reversed"],
+  initialProps: ["id", "ordered", "start", "reversed"],
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -504,8 +504,8 @@ importers:
         specifier: ^29.6.2
         version: 29.6.2(@types/node@18.13.0)
       mdn-data:
-        specifier: 2.0.30
-        version: 2.0.30
+        specifier: 2.0.32
+        version: 2.0.32
       tsx:
         specifier: ^3.12.6
         version: 3.12.6
@@ -3831,21 +3831,21 @@ packages:
     dependencies:
       '@inquirer/core': 0.0.26-alpha.0
       '@inquirer/input': 0.0.26-alpha.0
-      chalk: 5.0.1
+      chalk: 5.3.0
     dev: false
 
   /@inquirer/core@0.0.26-alpha.0:
     resolution: {integrity: sha512-g3mserTS5ekmwluiZnhaJbYOkKiKNTGatRXDH1jVe+bBc57mtmP3HvlvhZiU7yYgEAXM/TIR5Qd8sNu+kAi8rg==}
     dependencies:
       ansi-escapes: 5.0.0
-      chalk: 5.0.1
-      cli-spinners: 2.7.0
+      chalk: 5.3.0
+      cli-spinners: 2.9.0
       cli-width: 4.0.0
       lodash: 4.17.21
       mute-stream: 0.0.8
       run-async: 2.4.1
       string-width: 5.1.2
-      strip-ansi: 7.0.1
+      strip-ansi: 7.1.0
       wrap-ansi: 8.1.0
     dev: false
 
@@ -3853,7 +3853,7 @@ packages:
     resolution: {integrity: sha512-4bSSl4LB62UiHSE0hZQIKK2buOTmGR8E7c34fVMbN4qya6++cqoJyEBZG6GRqBfUxiS4fFXFAyWl10ttlHW+dQ==}
     dependencies:
       '@inquirer/core': 0.0.26-alpha.0
-      chalk: 5.0.1
+      chalk: 5.3.0
     dev: false
 
   /@isaacs/cliui@8.0.2:
@@ -3862,7 +3862,7 @@ packages:
     dependencies:
       string-width: 5.1.2
       string-width-cjs: /string-width@4.2.3
-      strip-ansi: 7.0.1
+      strip-ansi: 7.1.0
       strip-ansi-cjs: /strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: /wrap-ansi@7.0.0
@@ -8457,11 +8457,6 @@ packages:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  /chalk@5.0.1:
-    resolution: {integrity: sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-    dev: false
-
   /chalk@5.3.0:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
@@ -8542,14 +8537,9 @@ packages:
       restore-cursor: 4.0.0
     dev: false
 
-  /cli-spinners@2.7.0:
-    resolution: {integrity: sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==}
-    engines: {node: '>=6'}
-
   /cli-spinners@2.9.0:
     resolution: {integrity: sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==}
     engines: {node: '>=6'}
-    dev: false
 
   /cli-table3@0.6.2:
     resolution: {integrity: sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==}
@@ -12238,6 +12228,10 @@ packages:
   /mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
 
+  /mdn-data@2.0.32:
+    resolution: {integrity: sha512-dGzrfhOPm47P8qlChU77TGlCEcFNOCDAhCbHP53LST3FR5jSB5JSHaPjyYW2uFd2CV6D6z4tzCGW09pTxSn0aA==}
+    dev: true
+
   /mdurl@1.0.1:
     resolution: {integrity: sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==}
     dev: true
@@ -13357,7 +13351,7 @@ packages:
       bl: 4.1.0
       chalk: 4.1.2
       cli-cursor: 3.1.0
-      cli-spinners: 2.7.0
+      cli-spinners: 2.9.0
       is-interactive: 1.0.0
       is-unicode-supported: 0.1.0
       log-symbols: 4.1.0
@@ -15132,7 +15126,7 @@ packages:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
-      strip-ansi: 7.0.1
+      strip-ansi: 7.1.0
 
   /string-width@6.1.0:
     resolution: {integrity: sha512-k01swCJAgQmuADB0YIc+7TuatfNvTBVOoaUWJjTB9R4VJzR5vNWzf5t42ESVZFPS8xTySF7CAdV4t/aaIm3UnQ==}
@@ -15204,18 +15198,11 @@ packages:
     dependencies:
       ansi-regex: 5.0.1
 
-  /strip-ansi@7.0.1:
-    resolution: {integrity: sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==}
-    engines: {node: '>=12'}
-    dependencies:
-      ansi-regex: 6.0.1
-
   /strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.0.1
-    dev: false
 
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -16307,7 +16294,7 @@ packages:
     dependencies:
       ansi-styles: 6.1.0
       string-width: 5.1.2
-      strip-ansi: 7.0.1
+      strip-ansi: 7.1.0
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/pull/2063 https://github.com/webstudio-is/webstudio-builder/issues/2079 https://github.com/webstudio-is/webstudio-builder/issues/2060

Here added new "List Item" section specifically for List and ListItem components. Now user can cutomize list item markers for whole list or per each item.

Changed behavior of Select Control to put current value into the list of options if not present. This way display shows "List Item" instead of nothing.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
