### PR TITLE
Rewrite migrations with zx like api

### DIFF
--- a/packages/prisma-client/migrations-cli/commands.ts
+++ b/packages/prisma-client/migrations-cli/commands.ts
@@ -141,8 +141,8 @@ const isNoopSql = (sqlScript: string) => {
   );
 };
 
-const ensureNoChangesInPrismaSchema = () => {
-  const sqlScript = prismaMigrations.cliDiff();
+const ensureNoChangesInPrismaSchema = async () => {
+  const sqlScript = await prismaMigrations.cliDiff();
   if (isNoopSql(sqlScript ?? "") === false) {
     throw new UserError(
       "There are changes in schema.prisma. Please create a schema migration first."
@@ -159,7 +159,7 @@ export const createSchema = async ({ name }: { name: string }) => {
   // We need the database to be up to date before we can do a diff.
   ensureNoPending(status);
 
-  const sqlScript = prismaMigrations.cliDiff();
+  const sqlScript = await prismaMigrations.cliDiff();
 
   if (isNoopSql(sqlScript ?? "")) {
     logger.info("No changes to apply");
@@ -186,7 +186,7 @@ export const createData = async ({ name }: { name: string }) => {
 
   ensureNoFailed(status);
   ensureNoPending(status);
-  ensureNoChangesInPrismaSchema();
+  await ensureNoChangesInPrismaSchema();
 
   const migrationName = prismaMigrations.generateMigrationName(name);
 
@@ -216,7 +216,7 @@ ${schemaContent}`;
   writeFile(schemaFilePath, schemaContent);
   logger.info(`Created: ${schemaFilePath}`);
 
-  prismaMigrations.generateMigrationClient(migrationName);
+  await prismaMigrations.generateMigrationClient(migrationName);
   logger.info(
     `Created: ${path.join(
       prismaMigrations.migrationsDir,

--- a/packages/prisma-client/migrations-cli/umzug.ts
+++ b/packages/prisma-client/migrations-cli/umzug.ts
@@ -25,7 +25,7 @@ export const umzug = new Umzug({
           ...params,
           up: async () => {
             await prismaMigrations.setStarted(params.name, sqlFilePath);
-            prismaMigrations.cliExecute(sqlFilePath);
+            await prismaMigrations.cliExecute(sqlFilePath);
           },
         };
       }
@@ -34,7 +34,7 @@ export const umzug = new Umzug({
         return {
           ...params,
           up: async () => {
-            prismaMigrations.generateMigrationClient(params.name);
+            await prismaMigrations.generateMigrationClient(params.name);
 
             // eslint-disable-next-line @typescript-eslint/no-var-requires
             const migration = await import(tsFilePath);

--- a/packages/prisma-client/package.json
+++ b/packages/prisma-client/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@inquirer/confirm": "^0.0.25-alpha.0",
     "dotenv": "^16.3.1",
-    "execa": "^6.1.0",
+    "execa": "^7.2.0",
     "nanoid": "^4.0.2",
     "umzug": "^3.2.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1066,8 +1066,8 @@ importers:
         specifier: ^16.3.1
         version: 16.3.1
       execa:
-        specifier: ^6.1.0
-        version: 6.1.0
+        specifier: ^7.2.0
+        version: 7.2.0
       nanoid:
         specifier: ^4.0.2
         version: 4.0.2
@@ -9836,6 +9836,22 @@ packages:
       onetime: 6.0.0
       signal-exit: 3.0.7
       strip-final-newline: 3.0.0
+    dev: true
+
+  /execa@7.2.0:
+    resolution: {integrity: sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==}
+    engines: {node: ^14.18.0 || ^16.14.0 || >=18.0.0}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 6.0.1
+      human-signals: 4.3.1
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.1.0
+      onetime: 6.0.0
+      signal-exit: 3.0.7
+      strip-final-newline: 3.0.0
+    dev: false
 
   /exit-hook@2.2.1:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
@@ -10684,6 +10700,12 @@ packages:
   /human-signals@3.0.1:
     resolution: {integrity: sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==}
     engines: {node: '>=12.20.0'}
+    dev: true
+
+  /human-signals@4.3.1:
+    resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
+    engines: {node: '>=14.18.0'}
+    dev: false
 
   /hyphenate-style-name@1.0.4:
     resolution: {integrity: sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==}


### PR DESCRIPTION
The new execa version added support for zx like api. It's much smaller and does not pollute globals.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
