### PR TITLE
Fix pointer events

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { useStore } from "@nanostores/react";
 import { createPortal } from "react-dom";
 import type { Instance } from "@webstudio-is/project-build";
@@ -9,7 +9,7 @@ import {
   useDrag,
   ComponentCard,
   toast,
-  disableCanvasPointerEvents,
+  useDisableCanvasPointerEvents,
 } from "@webstudio-is/design-system";
 import {
   instancesStore,
@@ -126,7 +126,8 @@ export const useDraggable = ({
   const [point, setPoint] = useState<Point>({ x: 0, y: 0 });
   const canvasRect = useStore(canvasRectStore);
   const scale = useStore(scaleStore);
-  const enableCanvasPointerEventsRef = useRef<() => void>();
+  const { enableCanvasPointerEvents, disableCanvasPointerEvents } =
+    useDisableCanvasPointerEvents();
 
   const dragHandlers = useDrag<Instance["component"]>({
     elementToData(element) {
@@ -142,8 +143,7 @@ export const useDraggable = ({
           dragComponent: componentName,
         },
       });
-      enableCanvasPointerEventsRef.current?.();
-      enableCanvasPointerEventsRef.current = disableCanvasPointerEvents();
+      disableCanvasPointerEvents();
     },
     onMove: (point) => {
       setPoint(point);
@@ -161,16 +161,9 @@ export const useDraggable = ({
         payload: { isCanceled },
       });
 
-      enableCanvasPointerEventsRef.current?.();
+      enableCanvasPointerEvents();
     },
   });
-
-  useEffect(
-    () => () => {
-      enableCanvasPointerEventsRef.current?.();
-    },
-    []
-  );
 
   useSubscribe("cancelCurrentDrag", () => {
     dragHandlers.cancelCurrentDrag();

--- a/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useStore } from "@nanostores/react";
 import { createPortal } from "react-dom";
 import type { Instance } from "@webstudio-is/project-build";
@@ -9,7 +9,6 @@ import {
   useDrag,
   ComponentCard,
   toast,
-  enableCanvasPointerEvents,
   disableCanvasPointerEvents,
 } from "@webstudio-is/design-system";
 import {
@@ -127,6 +126,7 @@ export const useDraggable = ({
   const [point, setPoint] = useState<Point>({ x: 0, y: 0 });
   const canvasRect = useStore(canvasRectStore);
   const scale = useStore(scaleStore);
+  const enableCanvasPointerEventsRef = useRef<() => void>();
 
   const dragHandlers = useDrag<Instance["component"]>({
     elementToData(element) {
@@ -142,7 +142,8 @@ export const useDraggable = ({
           dragComponent: componentName,
         },
       });
-      disableCanvasPointerEvents();
+      enableCanvasPointerEventsRef.current?.();
+      enableCanvasPointerEventsRef.current = disableCanvasPointerEvents();
     },
     onMove: (point) => {
       setPoint(point);
@@ -160,9 +161,16 @@ export const useDraggable = ({
         payload: { isCanceled },
       });
 
-      enableCanvasPointerEvents();
+      enableCanvasPointerEventsRef.current?.();
     },
   });
+
+  useEffect(
+    () => () => {
+      enableCanvasPointerEventsRef.current?.();
+    },
+    []
+  );
 
   useSubscribe("cancelCurrentDrag", () => {
     dragHandlers.cancelCurrentDrag();

--- a/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { colord, extend, type RgbaColor } from "colord";
 import namesPlugin from "colord/plugins/names";
 import { type ColorResult, type RGBColor, SketchPicker } from "react-color";
@@ -14,7 +14,7 @@ import {
   PopoverTrigger,
   PopoverContent,
   css,
-  disableCanvasPointerEvents,
+  useDisableCanvasPointerEvents,
 } from "@webstudio-is/design-system";
 import { toValue } from "@webstudio-is/css-engine";
 import { theme } from "@webstudio-is/design-system";
@@ -121,7 +121,8 @@ export const ColorPicker = ({
   property,
 }: ColorPickerProps) => {
   const [displayColorPicker, setDisplayColorPicker] = useState(false);
-  const enableCanvasPointerEventsRef = useRef<() => void>();
+  const { enableCanvasPointerEvents, disableCanvasPointerEvents } =
+    useDisableCanvasPointerEvents();
 
   const currentValue =
     intermediateValue ?? styleValueResolve(value, currentColor);
@@ -170,20 +171,12 @@ export const ColorPicker = ({
     setDisplayColorPicker(open);
     if (open) {
       // Dragging over canvas iframe with CORS policies will lead to loosing events and getting stuck in mousedown state.
-      enableCanvasPointerEventsRef.current?.();
-      enableCanvasPointerEventsRef.current = disableCanvasPointerEvents();
+      disableCanvasPointerEvents();
       return;
     }
 
-    enableCanvasPointerEventsRef.current?.();
+    enableCanvasPointerEvents();
   };
-
-  useEffect(
-    () => () => {
-      enableCanvasPointerEventsRef.current?.();
-    },
-    []
-  );
 
   const prefix = (
     <Popover modal open={displayColorPicker} onOpenChange={handleOpenChange}>

--- a/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
+++ b/apps/builder/app/builder/features/style-panel/shared/color-picker.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { colord, extend, type RgbaColor } from "colord";
 import namesPlugin from "colord/plugins/names";
 import { type ColorResult, type RGBColor, SketchPicker } from "react-color";
@@ -14,7 +14,6 @@ import {
   PopoverTrigger,
   PopoverContent,
   css,
-  enableCanvasPointerEvents,
   disableCanvasPointerEvents,
 } from "@webstudio-is/design-system";
 import { toValue } from "@webstudio-is/css-engine";
@@ -122,6 +121,7 @@ export const ColorPicker = ({
   property,
 }: ColorPickerProps) => {
   const [displayColorPicker, setDisplayColorPicker] = useState(false);
+  const enableCanvasPointerEventsRef = useRef<() => void>();
 
   const currentValue =
     intermediateValue ?? styleValueResolve(value, currentColor);
@@ -170,11 +170,20 @@ export const ColorPicker = ({
     setDisplayColorPicker(open);
     if (open) {
       // Dragging over canvas iframe with CORS policies will lead to loosing events and getting stuck in mousedown state.
-      disableCanvasPointerEvents();
+      enableCanvasPointerEventsRef.current?.();
+      enableCanvasPointerEventsRef.current = disableCanvasPointerEvents();
       return;
     }
-    enableCanvasPointerEvents();
+
+    enableCanvasPointerEventsRef.current?.();
   };
+
+  useEffect(
+    () => () => {
+      enableCanvasPointerEventsRef.current?.();
+    },
+    []
+  );
 
   const prefix = (
     <Popover modal open={displayColorPicker} onOpenChange={handleOpenChange}>

--- a/packages/design-system/src/components/tooltip.tsx
+++ b/packages/design-system/src/components/tooltip.tsx
@@ -7,11 +7,7 @@ import { Box } from "./box";
 import { Text } from "./text";
 import type { CSS } from "../stitches.config";
 import { theme } from "../stitches.config";
-import warnOnce from "warn-once";
-import {
-  disableCanvasPointerEvents,
-  enableCanvasPointerEvents,
-} from "../utilities";
+import { disableCanvasPointerEvents } from "../utilities";
 
 export type TooltipProps = ComponentProps<typeof TooltipPrimitive.Root> &
   Omit<ComponentProps<typeof Content>, "content"> & {
@@ -48,33 +44,6 @@ const Arrow = styled(TooltipPrimitive.Arrow, {
   marginTop: -0.5,
 });
 
-let openTooltipsCount = 0;
-
-/**
- * When the mouse leaves Tooltip.Content and moves over an iframe, the Radix Tooltip stays open.
- * This happens because Radix's internal grace area relies on the pointermove event, which isn't triggered over iframes.
- * The current workaround is to set pointer-events: none on the canvas when the tooltip is open.
- **/
-const handleTooltipOpenChange = (open: boolean) => {
-  if (openTooltipsCount < 0) {
-    // Should be impossible but in case if we've missed a tooltip open/close event,
-    // just enable events and stop this algorithm, to preserve system in working state
-    warnOnce(true, "Tooltip counter can't be less than 0");
-    enableCanvasPointerEvents();
-    return;
-  }
-
-  // Multiple tooltips can open simultaneously. Use a counter instead of a boolean to manage them.
-  openTooltipsCount = openTooltipsCount + (open ? 1 : -1);
-
-  if (openTooltipsCount > 0) {
-    disableCanvasPointerEvents();
-    return;
-  }
-
-  enableCanvasPointerEvents();
-};
-
 export const Tooltip = forwardRef(
   (
     {
@@ -103,16 +72,22 @@ export const Tooltip = forwardRef(
       },
     });
 
-    // Manage scenarios where defaultOpen or open is initially set, or when the tooltip is unmounted.
+    /**
+     * When the mouse leaves Tooltip.Content and moves over an iframe, the Radix Tooltip stays open.
+     * This happens because Radix's internal grace area relies on the pointermove event, which isn't triggered over iframes.
+     * The current workaround is to set pointer-events: none on the canvas when the tooltip is open.
+     **/
     useEffect(() => {
+      let enableCanvasPointerEvents: (() => void) | undefined;
       if (isOpenRef.current !== open) {
-        handleTooltipOpenChange(open);
+        enableCanvasPointerEvents?.();
+        enableCanvasPointerEvents = disableCanvasPointerEvents();
         isOpenRef.current = open;
       }
 
       return () => {
         if (isOpenRef.current) {
-          handleTooltipOpenChange(false);
+          enableCanvasPointerEvents?.();
           isOpenRef.current = false;
         }
       };

--- a/packages/design-system/src/components/tooltip.tsx
+++ b/packages/design-system/src/components/tooltip.tsx
@@ -1,5 +1,5 @@
 import type { Ref, ComponentProps, ReactNode, ReactElement } from "react";
-import { Fragment, forwardRef, useEffect, useRef } from "react";
+import { Fragment, forwardRef, useEffect } from "react";
 import { styled } from "../stitches.config";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
@@ -61,8 +61,6 @@ export const Tooltip = forwardRef(
     },
     ref: Ref<HTMLDivElement>
   ) => {
-    const isOpenRef = useRef(false);
-
     // We need to intercept tooltip open
     const [open = false, setOpen] = useControllableState({
       prop: openProp,
@@ -78,19 +76,12 @@ export const Tooltip = forwardRef(
      * The current workaround is to set pointer-events: none on the canvas when the tooltip is open.
      **/
     useEffect(() => {
-      let enableCanvasPointerEvents: (() => void) | undefined;
-      if (isOpenRef.current !== open) {
-        enableCanvasPointerEvents?.();
-        enableCanvasPointerEvents = disableCanvasPointerEvents();
-        isOpenRef.current = open;
-      }
-
-      return () => {
-        if (isOpenRef.current) {
+      if (open) {
+        const enableCanvasPointerEvents = disableCanvasPointerEvents();
+        return () => {
           enableCanvasPointerEvents?.();
-          isOpenRef.current = false;
-        }
-      };
+        };
+      }
     }, [open]);
 
     if (!content) {

--- a/packages/design-system/src/utilities.ts
+++ b/packages/design-system/src/utilities.ts
@@ -1,14 +1,50 @@
 export const canvasPointerEventsPropertyName = "--canvas-pointer-events";
 
-export const enableCanvasPointerEvents = () => {
-  document.documentElement.style.removeProperty(
-    canvasPointerEventsPropertyName
-  );
+let disableCount = 0;
+
+const updateCanvasPointerEvents = () => {
+  if (disableCount < 0) {
+    // Should be impossible as counter control implemented as disposable resource
+    throw new Error("canvas pointer event counter can't be less than 0");
+  }
+
+  // use ===1 instead of >0 for optimisation
+  if (disableCount === 1) {
+    document.documentElement.style.setProperty(
+      canvasPointerEventsPropertyName,
+      "none"
+    );
+    return;
+  }
+
+  if (disableCount === 0) {
+    document.documentElement.style.removeProperty(
+      canvasPointerEventsPropertyName
+    );
+  }
 };
 
+/**
+ * Temporarily disables pointer events on the canvas using canvasPointerEventsPropertyName.
+ * Use the returned disposable to re-enable them.
+ *
+ * Implemented as disposable to
+ * - Ensure events are first disabled, then enabled in sequence.
+ * - To support concurrent calls (internal counter tracks the number of disables/enables).
+ **/
 export const disableCanvasPointerEvents = () => {
-  document.documentElement.style.setProperty(
-    canvasPointerEventsPropertyName,
-    "none"
-  );
+  let disposeCalled = false;
+
+  disableCount += 1;
+  updateCanvasPointerEvents();
+
+  return () => {
+    if (disposeCalled) {
+      // It's perfectly ok to dispose multiple times.
+      return;
+    }
+    disposeCalled = true;
+    disableCount -= 1;
+    updateCanvasPointerEvents();
+  };
 };

--- a/packages/design-system/src/utilities.ts
+++ b/packages/design-system/src/utilities.ts
@@ -1,3 +1,6 @@
+import { useEffect, useMemo, useRef } from "react";
+import warnOnce from "warn-once";
+
 export const canvasPointerEventsPropertyName = "--canvas-pointer-events";
 
 let disableCount = 0;
@@ -47,4 +50,34 @@ export const disableCanvasPointerEvents = () => {
     disableCount -= 1;
     updateCanvasPointerEvents();
   };
+};
+
+export const useDisableCanvasPointerEvents = () => {
+  const enableCanvasPointerEventsRef = useRef<() => void>();
+
+  const enableDisable = useMemo(
+    () => ({
+      enableCanvasPointerEvents: () => {
+        warnOnce(
+          enableCanvasPointerEventsRef.current === undefined,
+          "enableCanvasPointerEvents was called before disableCanvasPointerEvents, this is not an issue but may indicate the problem with the code."
+        );
+        enableCanvasPointerEventsRef.current?.();
+      },
+      disableCanvasPointerEvents: () => {
+        enableCanvasPointerEventsRef.current?.();
+        enableCanvasPointerEventsRef.current = disableCanvasPointerEvents();
+      },
+    }),
+    []
+  );
+
+  useEffect(
+    () => () => {
+      enableCanvasPointerEventsRef.current?.();
+    },
+    [enableDisable]
+  );
+
+  return enableDisable;
 };


### PR DESCRIPTION
## Description

Fix bug with drag component etc

implemented disableCanvasPointerEvents as disposable resource. 
That makes it much easier to control order of execution (disable first then enable), be sure that counter is always >=0, 
and easier control about enable/disable events allowing to dispose only if resource was created.



## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
