### PR TITLE
Use open prop in radix components

### DIFF
--- a/packages/sdk-components-react-radix/src/__generated__/dialog.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/dialog.props.ts
@@ -1,7 +1,6 @@
 import type { PropMeta } from "@webstudio-is/generate-arg-types";
 
 export const propsDialog: Record<string, PropMeta> = {
-  defaultOpen: { required: false, control: "boolean", type: "boolean" },
   modal: { required: false, control: "boolean", type: "boolean" },
   open: { required: false, control: "boolean", type: "boolean" },
 };

--- a/packages/sdk-components-react-radix/src/__generated__/dialog.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/dialog.props.ts
@@ -2,12 +2,6 @@ import type { PropMeta } from "@webstudio-is/generate-arg-types";
 
 export const propsDialog: Record<string, PropMeta> = {
   defaultOpen: { required: false, control: "boolean", type: "boolean" },
-  isOpen: {
-    required: true,
-    control: "radio",
-    type: "string",
-    options: ["open", "initial", "closed"],
-  },
   modal: { required: false, control: "boolean", type: "boolean" },
   open: { required: false, control: "boolean", type: "boolean" },
 };

--- a/packages/sdk-components-react-radix/src/__generated__/popover.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/popover.props.ts
@@ -2,12 +2,6 @@ import type { PropMeta } from "@webstudio-is/generate-arg-types";
 
 export const propsPopover: Record<string, PropMeta> = {
   defaultOpen: { required: false, control: "boolean", type: "boolean" },
-  isOpen: {
-    required: true,
-    control: "radio",
-    type: "string",
-    options: ["open", "initial", "closed"],
-  },
   modal: { required: false, control: "boolean", type: "boolean" },
   open: { required: false, control: "boolean", type: "boolean" },
 };

--- a/packages/sdk-components-react-radix/src/__generated__/popover.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/popover.props.ts
@@ -1,7 +1,6 @@
 import type { PropMeta } from "@webstudio-is/generate-arg-types";
 
 export const propsPopover: Record<string, PropMeta> = {
-  defaultOpen: { required: false, control: "boolean", type: "boolean" },
   modal: { required: false, control: "boolean", type: "boolean" },
   open: { required: false, control: "boolean", type: "boolean" },
 };

--- a/packages/sdk-components-react-radix/src/__generated__/sheet.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/sheet.props.ts
@@ -2,12 +2,6 @@ import type { PropMeta } from "@webstudio-is/generate-arg-types";
 
 export const propsSheet: Record<string, PropMeta> = {
   defaultOpen: { required: false, control: "boolean", type: "boolean" },
-  isOpen: {
-    required: true,
-    control: "radio",
-    type: "string",
-    options: ["open", "initial", "closed"],
-  },
   modal: { required: false, control: "boolean", type: "boolean" },
   open: { required: false, control: "boolean", type: "boolean" },
 };

--- a/packages/sdk-components-react-radix/src/__generated__/sheet.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/sheet.props.ts
@@ -1,7 +1,6 @@
 import type { PropMeta } from "@webstudio-is/generate-arg-types";
 
 export const propsSheet: Record<string, PropMeta> = {
-  defaultOpen: { required: false, control: "boolean", type: "boolean" },
   modal: { required: false, control: "boolean", type: "boolean" },
   open: { required: false, control: "boolean", type: "boolean" },
 };

--- a/packages/sdk-components-react-radix/src/__generated__/tooltip.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/tooltip.props.ts
@@ -1,7 +1,6 @@
 import type { PropMeta } from "@webstudio-is/generate-arg-types";
 
 export const propsTooltip: Record<string, PropMeta> = {
-  defaultOpen: { required: false, control: "boolean", type: "boolean" },
   delayDuration: {
     description:
       "The duration from when the pointer enters the trigger until the tooltip gets opened. This will\noverride the prop with the same name passed to Provider.\n@defaultValue 700",

--- a/packages/sdk-components-react-radix/src/__generated__/tooltip.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/tooltip.props.ts
@@ -16,12 +16,6 @@ export const propsTooltip: Record<string, PropMeta> = {
     control: "boolean",
     type: "boolean",
   },
-  isOpen: {
-    required: true,
-    control: "radio",
-    type: "string",
-    options: ["open", "initial", "closed"],
-  },
   open: { required: false, control: "boolean", type: "boolean" },
 };
 export const propsTooltipTrigger: Record<string, PropMeta> = {};

--- a/packages/sdk-components-react-radix/src/collapsible.tsx
+++ b/packages/sdk-components-react-radix/src/collapsible.tsx
@@ -45,20 +45,6 @@ const namespace = "@webstudio-is/sdk-components-react-radix";
 // we identify its closest parent Collapsible component
 // and update its open prop bound to variable.
 export const hooksCollapsible: Hook = {
-  onNavigatorUnselect: (context, event) => {
-    for (const instance of event.instancePath) {
-      if (instance.component === `${namespace}:CollapsibleContent`) {
-        const collapsible = getClosestInstance(
-          event.instancePath,
-          instance,
-          `${namespace}:Collapsible`
-        );
-        if (collapsible) {
-          context.setPropVariable(collapsible.id, "open", false);
-        }
-      }
-    }
-  },
   onNavigatorSelect: (context, event) => {
     for (const instance of event.instancePath) {
       if (instance.component === `${namespace}:CollapsibleContent`) {

--- a/packages/sdk-components-react-radix/src/collapsible.ws.ts
+++ b/packages/sdk-components-react-radix/src/collapsible.ws.ts
@@ -42,11 +42,7 @@ export const metaCollapsible: WsComponentMeta = {
           name: "onOpenChange",
           type: "action",
           value: [
-            {
-              type: "execute",
-              args: ["open"],
-              code: `collapsibleOpen = open`,
-            },
+            { type: "execute", args: ["open"], code: `collapsibleOpen = open` },
           ],
         },
       ],

--- a/packages/sdk-components-react-radix/src/dialog.stories.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { renderComponentTemplate } from "@webstudio-is/react-sdk";
+import { Dialog as DialogPrimitive } from "./dialog";
+import * as baseComponents from "@webstudio-is/sdk-components-react";
+import * as baseMetas from "@webstudio-is/sdk-components-react/metas";
+import * as radixComponents from "./components";
+import * as radixMetas from "./metas";
+
+export default {
+  title: "Components/Dialog",
+  component: DialogPrimitive,
+} satisfies Meta<typeof DialogPrimitive>;
+
+export const Dialog: StoryObj<typeof DialogPrimitive> = {
+  render: () =>
+    renderComponentTemplate({
+      name: "Dialog",
+      components: { ...baseComponents, ...radixComponents },
+      metas: { ...baseMetas, ...radixMetas },
+    }),
+};

--- a/packages/sdk-components-react-radix/src/dialog.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.tsx
@@ -62,10 +62,10 @@ const namespace = "@webstudio-is/sdk-components-react-radix";
 // and update its open prop bound to variable.
 export const hooksDialog: Hook = {
   onNavigatorUnselect: (context, event) => {
-    for (const instance of event.instanceSelection) {
+    for (const instance of event.instancePath) {
       if (instance.component === `${namespace}:DialogOverlay`) {
         const dialog = getClosestInstance(
-          event.instanceSelection,
+          event.instancePath,
           instance,
           `${namespace}:Dialog`
         );
@@ -76,10 +76,10 @@ export const hooksDialog: Hook = {
     }
   },
   onNavigatorSelect: (context, event) => {
-    for (const instance of event.instanceSelection) {
+    for (const instance of event.instancePath) {
       if (instance.component === `${namespace}:DialogOverlay`) {
         const dialog = getClosestInstance(
-          event.instanceSelection,
+          event.instancePath,
           instance,
           `${namespace}:Dialog`
         );

--- a/packages/sdk-components-react-radix/src/dialog.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.tsx
@@ -1,33 +1,21 @@
 /* eslint-disable react/display-name */
 // We can't use .displayName until this is merged https://github.com/styleguidist/react-docgen-typescript/pull/449
 
-import * as DialogPrimitive from "@radix-ui/react-dialog";
-
 import {
-  forwardRef,
-  type ElementRef,
   type ComponentPropsWithoutRef,
-  Children,
   type ReactNode,
+  forwardRef,
+  Children,
 } from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { getClosestInstance, type Hook } from "@webstudio-is/react-sdk";
 
-/**
- * We don't have support for boolean or undefined nor in UI not at Data variables,
- * instead of binding on "open" prop we bind variable on a isOpen prop to be able to show Dialog in the builder
- **/
-type BuilderDialogProps = {
-  isOpen: "initial" | "open" | "closed";
-};
-
+// wrap in forwardRef because Root is functional component without ref
 export const Dialog = forwardRef<
-  ElementRef<"div">,
-  ComponentPropsWithoutRef<typeof DialogPrimitive.Root> & BuilderDialogProps
->(({ open: openProp, isOpen, ...props }, ref) => {
-  const open =
-    openProp ??
-    (isOpen === "open" ? true : isOpen === "closed" ? false : undefined);
-
-  return <DialogPrimitive.Root open={open} {...props} />;
+  HTMLDivElement,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Root>
+>((props, _ref) => {
+  return <DialogPrimitive.Root {...props} />;
 });
 
 /**
@@ -37,20 +25,20 @@ export const Dialog = forwardRef<
  * which would prevent us from displaying styles properly in the builder.
  */
 export const DialogTrigger = forwardRef<
-  ElementRef<"div">,
+  HTMLButtonElement,
   { children: ReactNode }
 >(({ children, ...props }, ref) => {
   const firstChild = Children.toArray(children)[0];
 
   return (
-    <DialogPrimitive.Trigger asChild={true} {...props}>
+    <DialogPrimitive.Trigger ref={ref} asChild={true} {...props}>
       {firstChild ?? <button>Add button or link</button>}
     </DialogPrimitive.Trigger>
   );
 });
 
 export const DialogOverlay = forwardRef<
-  ElementRef<"div">,
+  HTMLDivElement,
   ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >((props, ref) => {
   return (
@@ -64,3 +52,41 @@ export const DialogContent = DialogPrimitive.Content;
 export const DialogClose = DialogPrimitive.Close;
 export const DialogTitle = DialogPrimitive.Title;
 export const DialogDescription = DialogPrimitive.Description;
+
+/* BUILDER HOOKS */
+
+const namespace = "@webstudio-is/sdk-components-react-radix";
+
+// For each DialogOverlay component within the selection,
+// we identify its closest parent Dialog component
+// and update its open prop bound to variable.
+export const hooksDialog: Hook = {
+  onNavigatorUnselect: (context, event) => {
+    for (const instance of event.instanceSelection) {
+      if (instance.component === `${namespace}:DialogOverlay`) {
+        const dialog = getClosestInstance(
+          event.instanceSelection,
+          instance,
+          `${namespace}:Dialog`
+        );
+        if (dialog) {
+          context.setPropVariable(dialog.id, "open", false);
+        }
+      }
+    }
+  },
+  onNavigatorSelect: (context, event) => {
+    for (const instance of event.instanceSelection) {
+      if (instance.component === `${namespace}:DialogOverlay`) {
+        const dialog = getClosestInstance(
+          event.instanceSelection,
+          instance,
+          `${namespace}:Dialog`
+        );
+        if (dialog) {
+          context.setPropVariable(dialog.id, "open", true);
+        }
+      }
+    }
+  },
+};

--- a/packages/sdk-components-react-radix/src/dialog.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.tsx
@@ -13,7 +13,7 @@ import { getClosestInstance, type Hook } from "@webstudio-is/react-sdk";
 // wrap in forwardRef because Root is functional component without ref
 export const Dialog = forwardRef<
   HTMLDivElement,
-  ComponentPropsWithoutRef<typeof DialogPrimitive.Root>
+  Omit<ComponentPropsWithoutRef<typeof DialogPrimitive.Root>, "defaultOpen">
 >((props, _ref) => {
   return <DialogPrimitive.Root {...props} />;
 });

--- a/packages/sdk-components-react-radix/src/dialog.ws.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.ws.tsx
@@ -44,7 +44,6 @@ const descriptionPresetStyle = {
 // @todo add [data-state] to button and link
 export const metaDialogTrigger: WsComponentMeta = {
   category: "hidden",
-  invalidAncestors: [],
   type: "container",
   label: "Dialog Trigger",
   icon: TriggerIcon,
@@ -54,7 +53,6 @@ export const metaDialogTrigger: WsComponentMeta = {
 
 export const metaDialogContent: WsComponentMeta = {
   category: "hidden",
-  invalidAncestors: [],
   type: "container",
   label: "Dialog Content",
   presetStyle,
@@ -64,7 +62,6 @@ export const metaDialogContent: WsComponentMeta = {
 
 export const metaDialogOverlay: WsComponentMeta = {
   category: "hidden",
-  invalidAncestors: [],
   type: "container",
   label: "Dialog Overlay",
   presetStyle,
@@ -74,7 +71,6 @@ export const metaDialogOverlay: WsComponentMeta = {
 
 export const metaDialogTitle: WsComponentMeta = {
   category: "hidden",
-  invalidAncestors: [],
   type: "container",
   presetStyle: titlePresetStyle,
   label: "Dialog Title",
@@ -83,7 +79,6 @@ export const metaDialogTitle: WsComponentMeta = {
 
 export const metaDialogDescription: WsComponentMeta = {
   category: "hidden",
-  invalidAncestors: [],
   type: "container",
   presetStyle: descriptionPresetStyle,
   label: "Dialog Description",
@@ -92,7 +87,6 @@ export const metaDialogDescription: WsComponentMeta = {
 
 export const metaDialogClose: WsComponentMeta = {
   category: "hidden",
-  invalidAncestors: [],
   type: "container",
   presetStyle: buttonPresetStyle,
   label: "Dialog Close",
@@ -109,7 +103,6 @@ export const metaDialogClose: WsComponentMeta = {
  **/
 export const metaDialog: WsComponentMeta = {
   category: "radix",
-  invalidAncestors: [],
   type: "container",
   label: "Dialog",
   icon: DialogIcon,
@@ -120,14 +113,20 @@ export const metaDialog: WsComponentMeta = {
       type: "instance",
       component: "Dialog",
       dataSources: {
-        // We don't have support for boolean or undefined, instead of binding on open we bind on a string
-        isOpen: { type: "variable", initialValue: "initial" },
+        dialogOpen: { type: "variable", initialValue: false },
       },
       props: [
         {
           type: "dataSource",
-          name: "isOpen",
-          dataSourceName: "isOpen",
+          name: "open",
+          dataSourceName: "dialogOpen",
+        },
+        {
+          name: "onOpenChange",
+          type: "action",
+          value: [
+            { type: "execute", args: ["open"], code: `dialogOpen = open` },
+          ],
         },
       ],
       children: [

--- a/packages/sdk-components-react-radix/src/hooks.ts
+++ b/packages/sdk-components-react-radix/src/hooks.ts
@@ -1,5 +1,16 @@
 import type { Hook } from "@webstudio-is/react-sdk";
 import { hooksCollapsible } from "./collapsible";
 import { hooksTabs } from "./tabs";
+import { hooksDialog } from "./dialog";
+import { hooksPopover } from "./popover";
+import { hooksSheet } from "./sheet";
+import { hooksTooltip } from "./tooltip";
 
-export const hooks: Hook[] = [hooksCollapsible, hooksTabs];
+export const hooks: Hook[] = [
+  hooksCollapsible,
+  hooksTabs,
+  hooksDialog,
+  hooksPopover,
+  hooksSheet,
+  hooksTooltip,
+];

--- a/packages/sdk-components-react-radix/src/popover.stories.tsx
+++ b/packages/sdk-components-react-radix/src/popover.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { renderComponentTemplate } from "@webstudio-is/react-sdk";
+import { Popover as PopoverPrimitive } from "./popover";
+import * as baseComponents from "@webstudio-is/sdk-components-react";
+import * as baseMetas from "@webstudio-is/sdk-components-react/metas";
+import * as radixComponents from "./components";
+import * as radixMetas from "./metas";
+
+export default {
+  title: "Components/Popover",
+  component: PopoverPrimitive,
+} satisfies Meta<typeof PopoverPrimitive>;
+
+export const Popover: StoryObj<typeof PopoverPrimitive> = {
+  render: () =>
+    renderComponentTemplate({
+      name: "Popover",
+      components: { ...baseComponents, ...radixComponents },
+      metas: { ...baseMetas, ...radixMetas },
+    }),
+};

--- a/packages/sdk-components-react-radix/src/popover.tsx
+++ b/packages/sdk-components-react-radix/src/popover.tsx
@@ -66,10 +66,10 @@ const namespace = "@webstudio-is/sdk-components-react-radix";
 // and update its open prop bound to variable.
 export const hooksPopover: Hook = {
   onNavigatorUnselect: (context, event) => {
-    for (const instance of event.instanceSelection) {
+    for (const instance of event.instancePath) {
       if (instance.component === `${namespace}:PopoverContent`) {
         const popover = getClosestInstance(
-          event.instanceSelection,
+          event.instancePath,
           instance,
           `${namespace}:Popover`
         );
@@ -80,10 +80,10 @@ export const hooksPopover: Hook = {
     }
   },
   onNavigatorSelect: (context, event) => {
-    for (const instance of event.instanceSelection) {
+    for (const instance of event.instancePath) {
       if (instance.component === `${namespace}:PopoverContent`) {
         const popover = getClosestInstance(
-          event.instanceSelection,
+          event.instancePath,
           instance,
           `${namespace}:Popover`
         );

--- a/packages/sdk-components-react-radix/src/popover.tsx
+++ b/packages/sdk-components-react-radix/src/popover.tsx
@@ -13,7 +13,7 @@ import { getClosestInstance, type Hook } from "@webstudio-is/react-sdk";
 // wrap in forwardRef because Root is functional component without ref
 export const Popover = forwardRef<
   HTMLDivElement,
-  ComponentPropsWithoutRef<typeof PopoverPrimitive.Root>
+  Omit<ComponentPropsWithoutRef<typeof PopoverPrimitive.Root>, "defaultOpen">
 >((props, _ref) => {
   return <PopoverPrimitive.Root {...props} />;
 });

--- a/packages/sdk-components-react-radix/src/popover.tsx
+++ b/packages/sdk-components-react-radix/src/popover.tsx
@@ -1,33 +1,21 @@
 /* eslint-disable react/display-name */
 // We can't use .displayName until this is merged https://github.com/styleguidist/react-docgen-typescript/pull/449
 
-import * as PopoverPrimitive from "@radix-ui/react-popover";
-
 import {
-  forwardRef,
-  type ElementRef,
   type ComponentPropsWithoutRef,
-  Children,
   type ReactNode,
+  forwardRef,
+  Children,
 } from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import { getClosestInstance, type Hook } from "@webstudio-is/react-sdk";
 
-/**
- * We don't have support for boolean or undefined nor in UI not at Data variables,
- * instead of binding on "open" prop we bind variable on a isOpen prop to be able to show Popover in the builder
- **/
-type BuilderPopoverProps = {
-  isOpen: "initial" | "open" | "closed";
-};
-
+// wrap in forwardRef because Root is functional component without ref
 export const Popover = forwardRef<
-  ElementRef<"div">,
-  ComponentPropsWithoutRef<typeof PopoverPrimitive.Root> & BuilderPopoverProps
->(({ open: openProp, isOpen, ...props }, ref) => {
-  const open =
-    openProp ??
-    (isOpen === "open" ? true : isOpen === "closed" ? false : undefined);
-
-  return <PopoverPrimitive.Root open={open} {...props} />;
+  HTMLDivElement,
+  ComponentPropsWithoutRef<typeof PopoverPrimitive.Root>
+>((props, _ref) => {
+  return <PopoverPrimitive.Root {...props} />;
 });
 
 /**
@@ -37,7 +25,7 @@ export const Popover = forwardRef<
  * which would prevent us from displaying styles properly in the builder.
  */
 export const PopoverTrigger = forwardRef<
-  ElementRef<"button">,
+  HTMLButtonElement,
   { children: ReactNode }
 >(({ children, ...props }, ref) => {
   const firstChild = Children.toArray(children)[0];
@@ -50,7 +38,7 @@ export const PopoverTrigger = forwardRef<
 });
 
 export const PopoverContent = forwardRef<
-  ElementRef<typeof PopoverPrimitive.Content>,
+  HTMLDivElement,
   ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
 >(
   (
@@ -68,3 +56,41 @@ export const PopoverContent = forwardRef<
     </PopoverPrimitive.Portal>
   )
 );
+
+/* BUILDER HOOKS */
+
+const namespace = "@webstudio-is/sdk-components-react-radix";
+
+// For each PopoverContent component within the selection,
+// we identify its closest parent Popover component
+// and update its open prop bound to variable.
+export const hooksPopover: Hook = {
+  onNavigatorUnselect: (context, event) => {
+    for (const instance of event.instanceSelection) {
+      if (instance.component === `${namespace}:PopoverContent`) {
+        const popover = getClosestInstance(
+          event.instanceSelection,
+          instance,
+          `${namespace}:Popover`
+        );
+        if (popover) {
+          context.setPropVariable(popover.id, "open", false);
+        }
+      }
+    }
+  },
+  onNavigatorSelect: (context, event) => {
+    for (const instance of event.instanceSelection) {
+      if (instance.component === `${namespace}:PopoverContent`) {
+        const popover = getClosestInstance(
+          event.instanceSelection,
+          instance,
+          `${namespace}:Popover`
+        );
+        if (popover) {
+          context.setPropVariable(popover.id, "open", true);
+        }
+      }
+    }
+  },
+};

--- a/packages/sdk-components-react-radix/src/popover.ws.tsx
+++ b/packages/sdk-components-react-radix/src/popover.ws.tsx
@@ -19,7 +19,6 @@ const presetStyle = {
 // @todo add [data-state] to button and link
 export const metaPopoverTrigger: WsComponentMeta = {
   category: "hidden",
-  invalidAncestors: [],
   type: "container",
   label: "Popover Trigger",
   icon: TriggerIcon,
@@ -29,7 +28,6 @@ export const metaPopoverTrigger: WsComponentMeta = {
 
 export const metaPopoverContent: WsComponentMeta = {
   category: "hidden",
-  invalidAncestors: [],
   type: "container",
   presetStyle,
   label: "Popover Content",
@@ -47,7 +45,6 @@ export const metaPopoverContent: WsComponentMeta = {
  **/
 export const metaPopover: WsComponentMeta = {
   category: "radix",
-  invalidAncestors: [],
   type: "container",
   label: "Popover",
   icon: PopoverIcon,
@@ -58,14 +55,20 @@ export const metaPopover: WsComponentMeta = {
       type: "instance",
       component: "Popover",
       dataSources: {
-        // We don't have support for boolean or undefined, instead of binding on open we bind on a string
-        isOpen: { type: "variable", initialValue: "initial" },
+        popoverOpen: { type: "variable", initialValue: false },
       },
       props: [
         {
           type: "dataSource",
-          name: "isOpen",
-          dataSourceName: "isOpen",
+          name: "open",
+          dataSourceName: "popoverOpen",
+        },
+        {
+          name: "onOpenChange",
+          type: "action",
+          value: [
+            { type: "execute", args: ["open"], code: `popoverOpen = open` },
+          ],
         },
       ],
       children: [

--- a/packages/sdk-components-react-radix/src/sheet.tsx
+++ b/packages/sdk-components-react-radix/src/sheet.tsx
@@ -3,6 +3,7 @@ import {
   type ElementRef,
   type ComponentPropsWithoutRef,
 } from "react";
+import { getClosestInstance, type Hook } from "@webstudio-is/react-sdk";
 import * as Dialog from "./dialog";
 
 export const Sheet = Dialog.Dialog;
@@ -38,3 +39,41 @@ export const SheetContent = forwardRef<
     );
   }
 );
+
+/* BUILDER HOOKS */
+
+const namespace = "@webstudio-is/sdk-components-react-radix";
+
+// For each SheetOverlay component within the selection,
+// we identify its closest parent Sheet component
+// and update its open prop bound to variable.
+export const hooksSheet: Hook = {
+  onNavigatorUnselect: (context, event) => {
+    for (const instance of event.instanceSelection) {
+      if (instance.component === `${namespace}:SheetOverlay`) {
+        const sheet = getClosestInstance(
+          event.instanceSelection,
+          instance,
+          `${namespace}:Sheet`
+        );
+        if (sheet) {
+          context.setPropVariable(sheet.id, "open", false);
+        }
+      }
+    }
+  },
+  onNavigatorSelect: (context, event) => {
+    for (const instance of event.instanceSelection) {
+      if (instance.component === `${namespace}:SheetOverlay`) {
+        const sheet = getClosestInstance(
+          event.instanceSelection,
+          instance,
+          `${namespace}:Sheet`
+        );
+        if (sheet) {
+          context.setPropVariable(sheet.id, "open", true);
+        }
+      }
+    }
+  },
+};

--- a/packages/sdk-components-react-radix/src/sheet.tsx
+++ b/packages/sdk-components-react-radix/src/sheet.tsx
@@ -49,10 +49,10 @@ const namespace = "@webstudio-is/sdk-components-react-radix";
 // and update its open prop bound to variable.
 export const hooksSheet: Hook = {
   onNavigatorUnselect: (context, event) => {
-    for (const instance of event.instanceSelection) {
+    for (const instance of event.instancePath) {
       if (instance.component === `${namespace}:SheetOverlay`) {
         const sheet = getClosestInstance(
-          event.instanceSelection,
+          event.instancePath,
           instance,
           `${namespace}:Sheet`
         );
@@ -63,10 +63,10 @@ export const hooksSheet: Hook = {
     }
   },
   onNavigatorSelect: (context, event) => {
-    for (const instance of event.instanceSelection) {
+    for (const instance of event.instancePath) {
       if (instance.component === `${namespace}:SheetOverlay`) {
         const sheet = getClosestInstance(
-          event.instanceSelection,
+          event.instancePath,
           instance,
           `${namespace}:Sheet`
         );

--- a/packages/sdk-components-react-radix/src/sheet.ws.tsx
+++ b/packages/sdk-components-react-radix/src/sheet.ws.tsx
@@ -128,14 +128,20 @@ export const metaSheet: WsComponentMeta = {
       type: "instance",
       component: "Sheet",
       dataSources: {
-        // We don't have support for boolean or undefined, instead of binding on open we bind on a string
-        isOpen: { type: "variable", initialValue: "initial" },
+        sheetOpen: { type: "variable", initialValue: false },
       },
       props: [
         {
           type: "dataSource",
-          name: "isOpen",
-          dataSourceName: "isOpen",
+          name: "open",
+          dataSourceName: "sheetOpen",
+        },
+        {
+          name: "onOpenChange",
+          type: "action",
+          value: [
+            { type: "execute", args: ["open"], code: `sheetOpen = open` },
+          ],
         },
       ],
       children: [

--- a/packages/sdk-components-react-radix/src/tabs.ws.ts
+++ b/packages/sdk-components-react-radix/src/tabs.ws.ts
@@ -81,11 +81,7 @@ export const metaTabs: WsComponentMeta = {
           name: "onValueChange",
           type: "action",
           value: [
-            {
-              type: "execute",
-              args: ["value"],
-              code: `tabsValue = value`,
-            },
+            { type: "execute", args: ["value"], code: `tabsValue = value` },
           ],
         },
       ],

--- a/packages/sdk-components-react-radix/src/tooltip.stories.tsx
+++ b/packages/sdk-components-react-radix/src/tooltip.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { renderComponentTemplate } from "@webstudio-is/react-sdk";
+import { Tooltip as TooltipPrimitive } from "./tooltip";
+import * as baseComponents from "@webstudio-is/sdk-components-react";
+import * as baseMetas from "@webstudio-is/sdk-components-react/metas";
+import * as radixComponents from "./components";
+import * as radixMetas from "./metas";
+
+export default {
+  title: "Components/Tooltip",
+  component: TooltipPrimitive,
+} satisfies Meta<typeof TooltipPrimitive>;
+
+export const Tooltip: StoryObj<typeof TooltipPrimitive> = {
+  render: () =>
+    renderComponentTemplate({
+      name: "Tooltip",
+      components: { ...baseComponents, ...radixComponents },
+      metas: { ...baseMetas, ...radixMetas },
+    }),
+};

--- a/packages/sdk-components-react-radix/src/tooltip.tsx
+++ b/packages/sdk-components-react-radix/src/tooltip.tsx
@@ -2,34 +2,22 @@
 // We can't use .displayName until this is merged https://github.com/styleguidist/react-docgen-typescript/pull/449
 
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { getClosestInstance, type Hook } from "@webstudio-is/react-sdk";
 
 import {
   forwardRef,
-  type ElementRef,
   type ComponentPropsWithoutRef,
-  Children,
   type ReactNode,
+  Children,
 } from "react";
 
-/**
- * We don't have support for boolean or undefined nor in UI not at Data variables,
- * instead of binding on "open" prop we bind variable on a isOpen prop to be able to show Tooltip in the builder
- **/
-type BuilderTooltipProps = {
-  isOpen: "initial" | "open" | "closed";
-};
-
 export const Tooltip = forwardRef<
-  ElementRef<"div">,
-  ComponentPropsWithoutRef<typeof TooltipPrimitive.Root> & BuilderTooltipProps
->(({ open: openProp, isOpen, ...props }, ref) => {
-  const open =
-    openProp ??
-    (isOpen === "open" ? true : isOpen === "closed" ? false : undefined);
-
+  HTMLDivElement,
+  ComponentPropsWithoutRef<typeof TooltipPrimitive.Root>
+>((props, _ref) => {
   return (
     <TooltipPrimitive.Provider>
-      <TooltipPrimitive.Root open={open} {...props} />
+      <TooltipPrimitive.Root {...props} />
     </TooltipPrimitive.Provider>
   );
 });
@@ -41,7 +29,7 @@ export const Tooltip = forwardRef<
  * which would prevent us from displaying styles properly in the builder.
  */
 export const TooltipTrigger = forwardRef<
-  ElementRef<"button">,
+  HTMLButtonElement,
   { children: ReactNode }
 >(({ children, ...props }, ref) => {
   const firstChild = Children.toArray(children)[0];
@@ -54,7 +42,7 @@ export const TooltipTrigger = forwardRef<
 });
 
 export const TooltipContent = forwardRef<
-  ElementRef<typeof TooltipPrimitive.Content>,
+  HTMLDivElement,
   ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ sideOffset = 4, hideWhenDetached = true, ...props }, ref) => (
   <TooltipPrimitive.Portal>
@@ -67,3 +55,41 @@ export const TooltipContent = forwardRef<
     />
   </TooltipPrimitive.Portal>
 ));
+
+/* BUILDER HOOKS */
+
+const namespace = "@webstudio-is/sdk-components-react-radix";
+
+// For each TooltipContent component within the selection,
+// we identify its closest parent Tooltip component
+// and update its open prop bound to variable.
+export const hooksTooltip: Hook = {
+  onNavigatorUnselect: (context, event) => {
+    for (const instance of event.instanceSelection) {
+      if (instance.component === `${namespace}:TooltipContent`) {
+        const tooltip = getClosestInstance(
+          event.instanceSelection,
+          instance,
+          `${namespace}:Tooltip`
+        );
+        if (tooltip) {
+          context.setPropVariable(tooltip.id, "open", false);
+        }
+      }
+    }
+  },
+  onNavigatorSelect: (context, event) => {
+    for (const instance of event.instanceSelection) {
+      if (instance.component === `${namespace}:TooltipContent`) {
+        const tooltip = getClosestInstance(
+          event.instanceSelection,
+          instance,
+          `${namespace}:Tooltip`
+        );
+        if (tooltip) {
+          context.setPropVariable(tooltip.id, "open", true);
+        }
+      }
+    }
+  },
+};

--- a/packages/sdk-components-react-radix/src/tooltip.tsx
+++ b/packages/sdk-components-react-radix/src/tooltip.tsx
@@ -13,7 +13,7 @@ import {
 
 export const Tooltip = forwardRef<
   HTMLDivElement,
-  ComponentPropsWithoutRef<typeof TooltipPrimitive.Root>
+  Omit<ComponentPropsWithoutRef<typeof TooltipPrimitive.Root>, "defaultOpen">
 >((props, _ref) => {
   return (
     <TooltipPrimitive.Provider>

--- a/packages/sdk-components-react-radix/src/tooltip.tsx
+++ b/packages/sdk-components-react-radix/src/tooltip.tsx
@@ -65,10 +65,10 @@ const namespace = "@webstudio-is/sdk-components-react-radix";
 // and update its open prop bound to variable.
 export const hooksTooltip: Hook = {
   onNavigatorUnselect: (context, event) => {
-    for (const instance of event.instanceSelection) {
+    for (const instance of event.instancePath) {
       if (instance.component === `${namespace}:TooltipContent`) {
         const tooltip = getClosestInstance(
-          event.instanceSelection,
+          event.instancePath,
           instance,
           `${namespace}:Tooltip`
         );
@@ -79,10 +79,10 @@ export const hooksTooltip: Hook = {
     }
   },
   onNavigatorSelect: (context, event) => {
-    for (const instance of event.instanceSelection) {
+    for (const instance of event.instancePath) {
       if (instance.component === `${namespace}:TooltipContent`) {
         const tooltip = getClosestInstance(
-          event.instanceSelection,
+          event.instancePath,
           instance,
           `${namespace}:Tooltip`
         );

--- a/packages/sdk-components-react-radix/src/tooltip.ws.tsx
+++ b/packages/sdk-components-react-radix/src/tooltip.ws.tsx
@@ -20,7 +20,6 @@ const presetStyle = {
 export const metaTooltipTrigger: WsComponentMeta = {
   category: "hidden",
   detachable: false,
-  invalidAncestors: [],
   type: "container",
   label: "Tooltip Trigger",
   icon: TriggerIcon,
@@ -30,7 +29,6 @@ export const metaTooltipTrigger: WsComponentMeta = {
 export const metaTooltipContent: WsComponentMeta = {
   category: "hidden",
   detachable: false,
-  invalidAncestors: [],
   type: "container",
   presetStyle,
   label: "Tooltip Content",
@@ -47,7 +45,6 @@ export const metaTooltipContent: WsComponentMeta = {
  **/
 export const metaTooltip: WsComponentMeta = {
   category: "radix",
-  invalidAncestors: [],
   type: "container",
   label: "Tooltip",
   icon: TooltipIcon,
@@ -58,14 +55,20 @@ export const metaTooltip: WsComponentMeta = {
       type: "instance",
       component: "Tooltip",
       dataSources: {
-        // We don't have support for boolean or undefined, instead of binding on open we bind on a string
-        isOpen: { type: "variable", initialValue: "initial" },
+        tooltipOpen: { type: "variable", initialValue: false },
       },
       props: [
         {
           type: "dataSource",
-          name: "isOpen",
-          dataSourceName: "isOpen",
+          name: "open",
+          dataSourceName: "tooltipOpen",
+        },
+        {
+          name: "onOpenChange",
+          type: "action",
+          value: [
+            { type: "execute", args: ["open"], code: `tooltipOpen = open` },
+          ],
         },
       ],
       children: [


### PR DESCRIPTION
Fix https://github.com/webstudio-is/webstudio-builder/issues/2046

- replaced isOpen with open
- added builder hooks to open content when select in navigator
- remove unselect hook from collapsible
- added stories to preview templates

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
