### PR TITLE
Infer label from component name

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/components.tsx
@@ -27,6 +27,7 @@ import { MetaIcon } from "~/builder/shared/meta-icon";
 import { registeredComponentMetasStore } from "~/shared/nano-states";
 import { getMetaMaps } from "./get-meta-maps";
 import { isFeatureEnabled } from "@webstudio-is/feature-flags";
+import { getInstanceLabel } from "~/shared/instance-utils";
 
 type TabContentProps = {
   onSetActiveTab: (tabName: TabName) => void;
@@ -96,7 +97,7 @@ export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
                             <ComponentCard
                               {...pressProps}
                               {...{ [dragItemAttribute]: component }}
-                              label={meta.label}
+                              label={getInstanceLabel({ component }, meta)}
                               icon={<MetaIcon size="auto" icon={meta.icon} />}
                               tabIndex={index === 0 ? 0 : -1}
                             />

--- a/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
@@ -23,6 +23,7 @@ import {
   computeInstancesConstraints,
   findClosestDroppableTarget,
   getComponentTemplateData,
+  getInstanceLabel,
   insertTemplateData,
 } from "~/shared/instance-utils";
 import { MetaIcon } from "~/builder/shared/meta-icon";
@@ -51,7 +52,7 @@ const DragLayer = ({
       }}
     >
       <ComponentCard
-        label={meta.label}
+        label={getInstanceLabel({ component }, meta)}
         icon={<MetaIcon size="auto" icon={meta.icon} />}
         style={{
           transform: `translate3d(${point.x}px, ${point.y}px, 0)`,

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -38,12 +38,27 @@ import {
 import { removeByMutable } from "./array-utils";
 import { isBaseBreakpoint } from "./breakpoints";
 import { getElementByInstanceSelector } from "./dom-utils";
+import { humanizeString } from "./string-utils";
+
+const getLabelFromComponentName = (component: Instance["component"]) => {
+  let baseName = component;
+  if (component.includes(":")) {
+    // strip namespace
+    const [_namespace, baseName] = component.split(":");
+    component = baseName;
+  }
+  return humanizeString(baseName);
+};
 
 export const getInstanceLabel = (
-  instance: { label?: string },
+  instance: { component: string; label?: string },
   meta: WsComponentMeta
 ) => {
-  return instance.label || meta.label;
+  return (
+    instance.label ||
+    meta.label ||
+    getLabelFromComponentName(instance.component)
+  );
 };
 
 export const findClosestEditableInstanceSelector = (

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -41,13 +41,12 @@ import { getElementByInstanceSelector } from "./dom-utils";
 import { humanizeString } from "./string-utils";
 
 const getLabelFromComponentName = (component: Instance["component"]) => {
-  let baseName = component;
   if (component.includes(":")) {
     // strip namespace
     const [_namespace, baseName] = component.split(":");
     component = baseName;
   }
-  return humanizeString(baseName);
+  return humanizeString(component);
 };
 
 export const getInstanceLabel = (

--- a/packages/react-sdk/src/components/component-meta.ts
+++ b/packages/react-sdk/src/components/component-meta.ts
@@ -63,7 +63,7 @@ const WsComponentMeta = z.object({
   // copied or dragged out of its parent instance
   // true by default
   detachable: z.optional(z.boolean()),
-  label: z.string(),
+  label: z.optional(z.string()),
   description: z.string().optional(),
   icon: z.string(),
   presetStyle: z.optional(z.record(z.string(), EmbedTemplateStyleDecl)),

--- a/packages/sdk-components-react-radix/src/accordion.ws.ts
+++ b/packages/sdk-components-react-radix/src/accordion.ws.ts
@@ -65,7 +65,6 @@ const accordionContentStyles: EmbedTemplateStyleDecl[] = [
 export const metaAccordion: WsComponentMeta = {
   category: "radix",
   type: "container",
-  label: "Accordion",
   icon: AccordionIcon,
   presetStyle,
   template: [
@@ -196,7 +195,6 @@ export const metaAccordion: WsComponentMeta = {
 export const metaAccordionItem: WsComponentMeta = {
   category: "hidden",
   type: "container",
-  label: "Accordion Item",
   icon: ItemIcon,
   requiredAncestors: ["Accordion"],
   indexWithinAncestor: "Accordion",
@@ -206,7 +204,6 @@ export const metaAccordionItem: WsComponentMeta = {
 export const metaAccordionHeader: WsComponentMeta = {
   category: "hidden",
   type: "container",
-  label: "Accordion Header",
   icon: HeaderIcon,
   requiredAncestors: ["AccordionItem"],
   detachable: false,
@@ -218,7 +215,6 @@ export const metaAccordionHeader: WsComponentMeta = {
 export const metaAccordionTrigger: WsComponentMeta = {
   category: "hidden",
   type: "container",
-  label: "Accordion Trigger",
   icon: TriggerIcon,
   requiredAncestors: ["AccordionHeader"],
   detachable: false,
@@ -246,7 +242,6 @@ export const metaAccordionTrigger: WsComponentMeta = {
 export const metaAccordionContent: WsComponentMeta = {
   category: "hidden",
   type: "container",
-  label: "Accordion Content",
   icon: ContentIcon,
   requiredAncestors: ["AccordionItem"],
   detachable: false,

--- a/packages/sdk-components-react-radix/src/button.ws.ts
+++ b/packages/sdk-components-react-radix/src/button.ws.ts
@@ -17,7 +17,6 @@ export const meta: WsComponentMeta = {
   category: "radix",
   type: "container",
   invalidAncestors: ["Button"],
-  label: "Button",
   icon: ButtonElementIcon,
   presetStyle,
   states: [

--- a/packages/sdk-components-react-radix/src/collapsible.ws.ts
+++ b/packages/sdk-components-react-radix/src/collapsible.ws.ts
@@ -23,7 +23,6 @@ export const metaCollapsible: WsComponentMeta = {
   category: "radix",
   type: "container",
   presetStyle,
-  label: "Collapsible",
   icon: CollapsibleIcon,
   template: [
     {
@@ -77,7 +76,6 @@ export const metaCollapsible: WsComponentMeta = {
 export const metaCollapsibleTrigger: WsComponentMeta = {
   category: "hidden",
   type: "container",
-  label: "Collapsible Trigger",
   icon: TriggerIcon,
   stylable: false,
   detachable: false,
@@ -87,7 +85,6 @@ export const metaCollapsibleContent: WsComponentMeta = {
   category: "hidden",
   type: "container",
   presetStyle,
-  label: "Collapsible Content",
   icon: ContentIcon,
   detachable: false,
 };

--- a/packages/sdk-components-react-radix/src/dialog.ws.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.ws.tsx
@@ -45,7 +45,6 @@ const descriptionPresetStyle = {
 export const metaDialogTrigger: WsComponentMeta = {
   category: "hidden",
   type: "container",
-  label: "Dialog Trigger",
   icon: TriggerIcon,
   stylable: false,
   detachable: false,
@@ -54,7 +53,6 @@ export const metaDialogTrigger: WsComponentMeta = {
 export const metaDialogContent: WsComponentMeta = {
   category: "hidden",
   type: "container",
-  label: "Dialog Content",
   presetStyle,
   icon: ContentIcon,
   detachable: false,
@@ -63,7 +61,6 @@ export const metaDialogContent: WsComponentMeta = {
 export const metaDialogOverlay: WsComponentMeta = {
   category: "hidden",
   type: "container",
-  label: "Dialog Overlay",
   presetStyle,
   icon: OverlayIcon,
   detachable: false,
@@ -73,7 +70,6 @@ export const metaDialogTitle: WsComponentMeta = {
   category: "hidden",
   type: "container",
   presetStyle: titlePresetStyle,
-  label: "Dialog Title",
   icon: HeadingIcon,
 };
 
@@ -81,7 +77,6 @@ export const metaDialogDescription: WsComponentMeta = {
   category: "hidden",
   type: "container",
   presetStyle: descriptionPresetStyle,
-  label: "Dialog Description",
   icon: TextIcon,
 };
 
@@ -89,7 +84,6 @@ export const metaDialogClose: WsComponentMeta = {
   category: "hidden",
   type: "container",
   presetStyle: buttonPresetStyle,
-  label: "Dialog Close",
   icon: ButtonElementIcon,
 };
 
@@ -104,7 +98,6 @@ export const metaDialogClose: WsComponentMeta = {
 export const metaDialog: WsComponentMeta = {
   category: "radix",
   type: "container",
-  label: "Dialog",
   icon: DialogIcon,
   order: 15,
   stylable: false,
@@ -281,7 +274,7 @@ export const metaDialog: WsComponentMeta = {
 
 export const propsMetaDialog: WsComponentPropsMeta = {
   props: propsDialog,
-  initialProps: ["isOpen", "modal"],
+  initialProps: ["open", "modal"],
 };
 
 export const propsMetaDialogTrigger: WsComponentPropsMeta = {

--- a/packages/sdk-components-react-radix/src/input.ws.ts
+++ b/packages/sdk-components-react-radix/src/input.ws.ts
@@ -17,7 +17,6 @@ export const meta: WsComponentMeta = {
   category: "radix",
   type: "control",
   invalidAncestors: ["Button"],
-  label: "Input",
   icon: FormTextFieldIcon,
   presetStyle,
   states: [

--- a/packages/sdk-components-react-radix/src/label.ws.ts
+++ b/packages/sdk-components-react-radix/src/label.ws.ts
@@ -16,7 +16,6 @@ const presetStyle = {
 export const meta: WsComponentMeta = {
   category: "radix",
   type: "container",
-  label: "Label",
   icon: LabelIcon,
   presetStyle,
   states: defaultStates,

--- a/packages/sdk-components-react-radix/src/popover.ws.tsx
+++ b/packages/sdk-components-react-radix/src/popover.ws.tsx
@@ -20,7 +20,6 @@ const presetStyle = {
 export const metaPopoverTrigger: WsComponentMeta = {
   category: "hidden",
   type: "container",
-  label: "Popover Trigger",
   icon: TriggerIcon,
   stylable: false,
   detachable: false,
@@ -30,7 +29,6 @@ export const metaPopoverContent: WsComponentMeta = {
   category: "hidden",
   type: "container",
   presetStyle,
-  label: "Popover Content",
   icon: ContentIcon,
   detachable: false,
 };
@@ -46,7 +44,6 @@ export const metaPopoverContent: WsComponentMeta = {
 export const metaPopover: WsComponentMeta = {
   category: "radix",
   type: "container",
-  label: "Popover",
   icon: PopoverIcon,
   order: 15,
   stylable: false,
@@ -117,7 +114,7 @@ export const metaPopover: WsComponentMeta = {
 
 export const propsMetaPopover: WsComponentPropsMeta = {
   props: propsPopover,
-  initialProps: ["isOpen", "modal"],
+  initialProps: ["open", "modal"],
 };
 
 export const propsMetaPopoverTrigger: WsComponentPropsMeta = {

--- a/packages/sdk-components-react-radix/src/sheet.ws.tsx
+++ b/packages/sdk-components-react-radix/src/sheet.ws.tsx
@@ -53,7 +53,6 @@ const descriptionPresetStyle = {
 export const metaSheetTrigger: WsComponentMeta = {
   category: "hidden",
   type: "container",
-  label: "Sheet Trigger",
   icon: TriggerIcon,
   stylable: false,
   detachable: false,
@@ -62,7 +61,6 @@ export const metaSheetTrigger: WsComponentMeta = {
 export const metaSheetContent: WsComponentMeta = {
   category: "hidden",
   type: "container",
-  label: "Sheet Content",
   icon: ContentIcon,
   detachable: false,
   presetStyle: contentPresetStyle,
@@ -78,7 +76,6 @@ export const metaSheetOverlay: WsComponentMeta = {
   category: "hidden",
   type: "container",
   presetStyle,
-  label: "Sheet Overlay",
   icon: OverlayIcon,
   detachable: false,
 };
@@ -87,7 +84,6 @@ export const metaSheetTitle: WsComponentMeta = {
   category: "hidden",
   type: "container",
   presetStyle: titlePresetStyle,
-  label: "Sheet Title",
   icon: HeadingIcon,
 };
 
@@ -95,7 +91,6 @@ export const metaSheetDescription: WsComponentMeta = {
   category: "hidden",
   type: "container",
   presetStyle: descriptionPresetStyle,
-  label: "Sheet Description",
   icon: TextIcon,
 };
 
@@ -103,7 +98,6 @@ export const metaSheetClose: WsComponentMeta = {
   category: "hidden",
   type: "container",
   presetStyle: buttonPresetStyle,
-  label: "Sheet Close",
   icon: ButtonElementIcon,
 };
 
@@ -119,7 +113,6 @@ export const metaSheet: WsComponentMeta = {
   category: "radix",
 
   type: "container",
-  label: "Sheet",
   icon: HamburgerMenuIcon,
   order: 15,
   stylable: false,
@@ -299,7 +292,7 @@ export const metaSheet: WsComponentMeta = {
 
 export const propsMetaSheet: WsComponentPropsMeta = {
   props: propsSheet,
-  initialProps: ["isOpen", "modal"],
+  initialProps: ["open", "modal"],
 };
 
 export const propsMetaSheetTrigger: WsComponentPropsMeta = {

--- a/packages/sdk-components-react-radix/src/tabs.ws.ts
+++ b/packages/sdk-components-react-radix/src/tabs.ws.ts
@@ -65,7 +65,6 @@ const tabsContentStyles: EmbedTemplateStyleDecl[] = [
 export const metaTabs: WsComponentMeta = {
   category: "radix",
   type: "container",
-  label: "Tabs",
   icon: TabsIcon,
   presetStyle,
   template: [
@@ -150,7 +149,6 @@ export const metaTabsList: WsComponentMeta = {
   category: "hidden",
   detachable: false,
   type: "container",
-  label: "Tabs List",
   icon: HeaderIcon,
   requiredAncestors: ["Tabs"],
   presetStyle,
@@ -159,7 +157,6 @@ export const metaTabsList: WsComponentMeta = {
 export const metaTabsTrigger: WsComponentMeta = {
   category: "hidden",
   type: "container",
-  label: "Tabs Trigger",
   icon: TriggerIcon,
   requiredAncestors: ["TabsList"],
   invalidAncestors: ["TabsTrigger"],
@@ -169,7 +166,6 @@ export const metaTabsTrigger: WsComponentMeta = {
 export const metaTabsContent: WsComponentMeta = {
   category: "hidden",
   type: "container",
-  label: "Tabs Content",
   icon: ContentIcon,
   requiredAncestors: ["Tabs"],
   indexWithinAncestor: "Tabs",

--- a/packages/sdk-components-react-radix/src/textarea.ws.ts
+++ b/packages/sdk-components-react-radix/src/textarea.ws.ts
@@ -16,7 +16,6 @@ const presetStyle = {
 export const meta: WsComponentMeta = {
   category: "radix",
   type: "control",
-  label: "Textarea",
   invalidAncestors: ["Button"],
   icon: FormTextAreaIcon,
   presetStyle,

--- a/packages/sdk-components-react-radix/src/tooltip.ws.tsx
+++ b/packages/sdk-components-react-radix/src/tooltip.ws.tsx
@@ -21,7 +21,6 @@ export const metaTooltipTrigger: WsComponentMeta = {
   category: "hidden",
   detachable: false,
   type: "container",
-  label: "Tooltip Trigger",
   icon: TriggerIcon,
   stylable: false,
 };
@@ -31,7 +30,6 @@ export const metaTooltipContent: WsComponentMeta = {
   detachable: false,
   type: "container",
   presetStyle,
-  label: "Tooltip Content",
   icon: ContentIcon,
 };
 
@@ -46,7 +44,6 @@ export const metaTooltipContent: WsComponentMeta = {
 export const metaTooltip: WsComponentMeta = {
   category: "radix",
   type: "container",
-  label: "Tooltip",
   icon: TooltipIcon,
   order: 15,
   stylable: false,
@@ -118,7 +115,7 @@ export const metaTooltip: WsComponentMeta = {
 
 export const propsMetaTooltip: WsComponentPropsMeta = {
   props: propsTooltip,
-  initialProps: ["isOpen", "delayDuration", "disableHoverableContent"],
+  initialProps: ["open", "delayDuration", "disableHoverableContent"],
 };
 
 export const propsMetaTooltipTrigger: WsComponentPropsMeta = {


### PR DESCRIPTION
Here made meta.label optional to simplify adding new stuff. Most of the time label is just a "humanized" version of component name. With radix there is an additional action to strip namespace. But still would be less repetition if the name is just inferred.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
