### PR TITLE
Use styled radix button at dialog, sheet, popover and tooltip

### DIFF
--- a/packages/sdk-components-react-radix/src/button.ws.ts
+++ b/packages/sdk-components-react-radix/src/button.ws.ts
@@ -1,6 +1,7 @@
 import { ButtonElementIcon } from "@webstudio-is/icons/svg";
 import {
   defaultStates,
+  EmbedTemplateInstance,
   type PresetStyle,
   type WsComponentMeta,
   type WsComponentPropsMeta,
@@ -12,6 +13,105 @@ import * as tc from "./theme/tailwind-classes";
 const presetStyle = {
   button,
 } satisfies PresetStyle<"button">;
+
+export const template = (props?: {
+  props?: EmbedTemplateInstance["props"];
+  children?: WsComponentMeta["template"];
+}): NonNullable<WsComponentMeta["template"]> => [
+  {
+    type: "instance",
+    component: "Button",
+    styles: [
+      // 'inline-flex items-center justify-center rounded-md text-sm font-medium
+      // ring-offset-background transition-colors
+      // focus-visible:outline-none focus-visible:ring-2
+      // focus-visible:ring-ring focus-visible:ring-offset-2
+      // disabled:pointer-events-none disabled:opacity-50'
+      tc.border(0),
+      tc.bg("transparent"),
+      tc.inlineFlex(),
+      tc.items("center"),
+      tc.justify("center"),
+      tc.rounded("md"),
+      tc.text("sm"),
+      tc.font("medium"),
+      tc.focusVisible(
+        [tc.outline("none"), tc.ring("ring", 2, "background", 2)].flat()
+      ),
+      tc.state([tc.pointerEvents("none"), tc.opacity(50)].flat(), ":disabled"),
+
+      // VARIANT
+      // default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+      tc.state(
+        [tc.bg("primary"), tc.text("primaryForeground")].flat(),
+        "[data-variant=default]"
+      ),
+      tc.state(
+        [[tc.bg("primary", 90)].flat()].flat(),
+        "[data-variant=default]:hover"
+      ),
+
+      // destructive:'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+      tc.state(
+        [tc.bg("destructive"), tc.text("destructiveForeground")].flat(),
+        "[data-variant=destructive]"
+      ),
+      tc.state(
+        [[tc.bg("destructive", 90)].flat()].flat(),
+        "[data-variant=destructive]:hover"
+      ),
+
+      // outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+      tc.state(
+        [tc.border(), tc.border("input"), tc.bg("background")].flat(),
+        "[data-variant=outline]"
+      ),
+      tc.state(
+        [[tc.bg("accent", 90), tc.text("accentForeground")].flat()].flat(),
+        "[data-variant=outline]:hover"
+      ),
+
+      // secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+      tc.state(
+        [tc.bg("secondary"), tc.text("secondaryForeground")].flat(),
+        "[data-variant=secondary]"
+      ),
+      tc.state(
+        [[tc.bg("secondary", 80)].flat()].flat(),
+        "[data-variant=secondary]:hover"
+      ),
+
+      // ghost: 'hover:bg-accent hover:text-accent-foreground',
+      tc.state(
+        [[tc.bg("accent"), tc.text("accentForeground")].flat()].flat(),
+        "[data-variant=ghost]:hover"
+      ),
+
+      // link: 'text-primary underline-offset-4 hover:underline',
+      tc.state(
+        [tc.text("primary"), tc.underlineOffset(4)].flat(),
+        "[data-variant=link]"
+      ),
+      tc.state([[tc.underline()].flat()].flat(), "[data-variant=link]:hover"),
+
+      // SIZE
+      // default: 'h-10 px-4 py-2',
+      tc.state([tc.h(10), tc.px(4), tc.py(2)].flat(), "[data-size=default]"),
+
+      // sm: 'h-9 rounded-md px-3',
+      tc.state([tc.h(10), tc.px(3)].flat(), "[data-size=sm]"),
+
+      // lg: 'h-11 rounded-md px-8',
+      tc.state([tc.h(11), tc.px(8)].flat(), "[data-size=lg]"),
+
+      // icon: 'h-10 w-10',
+      tc.state([tc.h(10), tc.w(10)].flat(), "[data-size=icon]"),
+    ].flat(),
+
+    children: props?.children ?? [{ type: "text", value: "Button" }],
+    props: props?.props,
+  },
+];
 
 export const meta: WsComponentMeta = {
   category: "radix",
@@ -46,103 +146,7 @@ export const meta: WsComponentMeta = {
     { selector: "[data-variant=link]:hover", label: "Link Hover" },
   ],
   order: 1,
-  template: [
-    {
-      type: "instance",
-      component: "Button",
-      styles: [
-        // 'inline-flex items-center justify-center rounded-md text-sm font-medium
-        // ring-offset-background transition-colors
-        // focus-visible:outline-none focus-visible:ring-2
-        // focus-visible:ring-ring focus-visible:ring-offset-2
-        // disabled:pointer-events-none disabled:opacity-50'
-        tc.border(0),
-        tc.bg("transparent"),
-        tc.inlineFlex(),
-        tc.items("center"),
-        tc.justify("center"),
-        tc.rounded("md"),
-        tc.text("sm"),
-        tc.font("medium"),
-        tc.focusVisible(
-          [tc.outline("none"), tc.ring("ring", 2, "background", 2)].flat()
-        ),
-        tc.state(
-          [tc.pointerEvents("none"), tc.opacity(50)].flat(),
-          ":disabled"
-        ),
-
-        // VARIANT
-        // default: 'bg-primary text-primary-foreground hover:bg-primary/90',
-        tc.state(
-          [tc.bg("primary"), tc.text("primaryForeground")].flat(),
-          "[data-variant=default]"
-        ),
-        tc.state(
-          [[tc.bg("primary", 90)].flat()].flat(),
-          "[data-variant=default]:hover"
-        ),
-
-        // destructive:'bg-destructive text-destructive-foreground hover:bg-destructive/90',
-        tc.state(
-          [tc.bg("destructive"), tc.text("destructiveForeground")].flat(),
-          "[data-variant=destructive]"
-        ),
-        tc.state(
-          [[tc.bg("destructive", 90)].flat()].flat(),
-          "[data-variant=destructive]:hover"
-        ),
-
-        // outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
-        tc.state(
-          [tc.border(), tc.border("input"), tc.bg("background")].flat(),
-          "[data-variant=outline]"
-        ),
-        tc.state(
-          [[tc.bg("accent", 90), tc.text("accentForeground")].flat()].flat(),
-          "[data-variant=outline]:hover"
-        ),
-
-        // secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        tc.state(
-          [tc.bg("secondary"), tc.text("secondaryForeground")].flat(),
-          "[data-variant=secondary]"
-        ),
-        tc.state(
-          [[tc.bg("secondary", 80)].flat()].flat(),
-          "[data-variant=secondary]:hover"
-        ),
-
-        // ghost: 'hover:bg-accent hover:text-accent-foreground',
-        tc.state(
-          [[tc.bg("accent"), tc.text("accentForeground")].flat()].flat(),
-          "[data-variant=ghost]:hover"
-        ),
-
-        // link: 'text-primary underline-offset-4 hover:underline',
-        tc.state(
-          [tc.text("primary"), tc.underlineOffset(4)].flat(),
-          "[data-variant=link]"
-        ),
-        tc.state([[tc.underline()].flat()].flat(), "[data-variant=link]:hover"),
-
-        // SIZE
-        // default: 'h-10 px-4 py-2',
-        tc.state([tc.h(10), tc.px(4), tc.py(2)].flat(), "[data-size=default]"),
-
-        // sm: 'h-9 rounded-md px-3',
-        tc.state([tc.h(10), tc.px(3)].flat(), "[data-size=sm]"),
-
-        // lg: 'h-11 rounded-md px-8',
-        tc.state([tc.h(11), tc.px(8)].flat(), "[data-size=lg]"),
-
-        // icon: 'h-10 w-10',
-        tc.state([tc.h(10), tc.w(10)].flat(), "[data-size=icon]"),
-      ].flat(),
-
-      children: [{ type: "text", value: "Button you can edit" }],
-    },
-  ],
+  template: template(),
 };
 
 export const propsMeta: WsComponentPropsMeta = {

--- a/packages/sdk-components-react-radix/src/dialog.ws.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.ws.tsx
@@ -22,6 +22,7 @@ import {
   propsDialogTitle,
   propsDialogDescription,
 } from "./__generated__/dialog.props";
+import { template as buttonTemplate } from "./button.ws";
 
 import { div, button, h2, p } from "@webstudio-is/react-sdk/css-normalize";
 
@@ -127,13 +128,9 @@ export const metaDialog: WsComponentMeta = {
           type: "instance",
           component: "DialogTrigger",
           props: [],
-          children: [
-            {
-              type: "instance",
-              component: "Button",
-              children: [{ type: "text", value: "Button" }],
-            },
-          ],
+          children: buttonTemplate({
+            children: [{ type: "text", value: "Button" }],
+          }),
         },
         {
           type: "instance",

--- a/packages/sdk-components-react-radix/src/popover.ws.tsx
+++ b/packages/sdk-components-react-radix/src/popover.ws.tsx
@@ -11,6 +11,7 @@ import {
   propsPopoverTrigger,
 } from "./__generated__/popover.props";
 import { div } from "@webstudio-is/react-sdk/css-normalize";
+import { template as buttonTemplate } from "./button.ws";
 
 const presetStyle = {
   div,
@@ -73,13 +74,9 @@ export const metaPopover: WsComponentMeta = {
           type: "instance",
           component: "PopoverTrigger",
           props: [],
-          children: [
-            {
-              type: "instance",
-              component: "Button",
-              children: [{ type: "text", value: "Button" }],
-            },
-          ],
+          children: buttonTemplate({
+            children: [{ type: "text", value: "Button" }],
+          }),
         },
         {
           type: "instance",

--- a/packages/sdk-components-react-radix/src/sheet.ws.tsx
+++ b/packages/sdk-components-react-radix/src/sheet.ws.tsx
@@ -25,6 +25,7 @@ import {
 import { div, nav, button, h2, p } from "@webstudio-is/react-sdk/css-normalize";
 import type { SheetContent } from "./sheet";
 import type { ComponentProps } from "react";
+import { template as buttonTemplate } from "./button.ws";
 
 type ContentTags = NonNullable<ComponentProps<typeof SheetContent>["tag"]>;
 
@@ -141,13 +142,27 @@ export const metaSheet: WsComponentMeta = {
         {
           type: "instance",
           component: "SheetTrigger",
-          children: [
-            {
-              type: "instance",
-              component: "Button",
-              children: [{ type: "text", value: "Button" }],
-            },
-          ],
+          children: buttonTemplate({
+            props: [
+              { name: "variant", type: "string", value: "ghost" },
+              { name: "size", type: "string", value: "icon" },
+            ],
+            children: [
+              {
+                type: "instance",
+                component: "HtmlEmbed",
+                label: "Spinner SVG",
+                props: [
+                  {
+                    type: "string",
+                    name: "code",
+                    value: HamburgerMenuIcon,
+                  },
+                ],
+                children: [],
+              },
+            ],
+          }),
         },
         {
           type: "instance",

--- a/packages/sdk-components-react-radix/src/sheet.ws.tsx
+++ b/packages/sdk-components-react-radix/src/sheet.ws.tsx
@@ -151,7 +151,7 @@ export const metaSheet: WsComponentMeta = {
               {
                 type: "instance",
                 component: "HtmlEmbed",
-                label: "Spinner SVG",
+                label: "Hamburger Menu Svg",
                 props: [
                   {
                     type: "string",

--- a/packages/sdk-components-react-radix/src/tooltip.ws.tsx
+++ b/packages/sdk-components-react-radix/src/tooltip.ws.tsx
@@ -11,6 +11,7 @@ import {
   propsTooltipTrigger,
 } from "./__generated__/tooltip.props";
 import { div } from "@webstudio-is/react-sdk/css-normalize";
+import { template as buttonTemplate } from "./button.ws";
 
 const presetStyle = {
   div,
@@ -73,13 +74,9 @@ export const metaTooltip: WsComponentMeta = {
           type: "instance",
           component: "TooltipTrigger",
           props: [],
-          children: [
-            {
-              type: "instance",
-              component: "Button",
-              children: [{ type: "text", value: "Button" }],
-            },
-          ],
+          children: buttonTemplate({
+            children: [{ type: "text", value: "Button" }],
+          }),
         },
         {
           type: "instance",


### PR DESCRIPTION
## Description

For Sheet used variant="ghost" size="icon" with svg embed 

<img width="498" alt="image" src="https://github.com/webstudio-is/webstudio-builder/assets/5077042/e0a85586-318e-42bf-b546-404fc42151f1">


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
