### PR TITLE
Use sdk component on preview (DO NOT MERGE)

### DIFF
--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -11,6 +11,7 @@ import {
   encodeVariablesMap,
   decodeVariablesMap,
   getIndexesWithinAncestors,
+  WebstudioComponent,
 } from "@webstudio-is/react-sdk";
 import * as baseComponents from "@webstudio-is/sdk-components-react";
 import * as baseComponentMetas from "@webstudio-is/sdk-components-react/metas";
@@ -134,7 +135,7 @@ const useElementsTree = (
       executeEffectfulExpression:
         executeEffectfulExpressionWithDecodedVariables,
       onDataSourceUpdate,
-      Component: WebstudioComponentDev,
+      Component: isPreviewMode ? WebstudioComponent : WebstudioComponentDev,
       components,
       scripts: (
         <>


### PR DESCRIPTION
## Description

!!!! DO NOT MERGE !!!!
!!!! DO NOT MERGE !!!!

Idea is to use same component as on publish

the only issue right now as styles iniside dialogs etc are not working

I think because of this.

```
const instanceStyles = useInstanceStyles(instanceId);
  useCssRules({ instanceId: instance.id, instanceStyles });
```

cc @TrySound mb you know how to make it right. For me idea to use sdk component on preview looks good. As it allows to be sure that everything is implemented right.


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
