### PR TITLE
Sort uploading assets newest first

### DIFF
--- a/apps/builder/app/builder/shared/assets/use-assets.tsx
+++ b/apps/builder/app/builder/shared/assets/use-assets.tsx
@@ -105,13 +105,19 @@ const assetContainersStore = computed(
     }
 
     return assetContainers.sort((container1, container2) => {
-      if (
-        container1.status === "uploading" ||
-        container2.status === "uploading"
-      ) {
+      if (container1.status === "uploading") {
         return -1;
       }
-      return container1.asset.createdAt > container2.asset.createdAt ? -1 : 1;
+      if (container2.status === "uploading") {
+        return 1;
+      }
+      if (container1.status === container2.status) {
+        if (container1.asset.createdAt === container2.asset.createdAt) {
+          return 0;
+        }
+        return container1.asset.createdAt > container2.asset.createdAt ? -1 : 1;
+      }
+      return 0;
     });
   }
 );

--- a/apps/builder/app/builder/shared/assets/use-assets.tsx
+++ b/apps/builder/app/builder/shared/assets/use-assets.tsx
@@ -103,7 +103,16 @@ const assetContainersStore = computed(
         });
       }
     }
-    return assetContainers;
+
+    return assetContainers.sort((container1, container2) => {
+      if (
+        container1.status === "uploading" ||
+        container2.status === "uploading"
+      ) {
+        return -1;
+      }
+      return container1.asset.createdAt > container2.asset.createdAt ? -1 : 1;
+    });
   }
 );
 


### PR DESCRIPTION
## Description

Currently during upload we put preview first but then item renders at the end 

## Steps for reproduction

1. upload a couple of images
2. see that new images both preview and after upload is done are at the top

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
