### PR TITLE
Added cite tag to Text component as well as cite prop in initial props to Blockquote component

### DIFF
--- a/packages/sdk-components-react/src/__generated__/text.props.ts
+++ b/packages/sdk-components-react/src/__generated__/text.props.ts
@@ -452,10 +452,10 @@ export const props: Record<string, PropMeta> = {
   tabIndex: { required: false, control: "number", type: "number" },
   tag: {
     required: false,
-    control: "radio",
+    control: "select",
     type: "string",
     defaultValue: "div",
-    options: ["div", "figcaption", "span"],
+    options: ["div", "cite", "figcaption", "span"],
   },
   title: { required: false, control: "text", type: "string" },
   translate: {

--- a/packages/sdk-components-react/src/blockquote.ws.tsx
+++ b/packages/sdk-components-react/src/blockquote.ws.tsx
@@ -78,5 +78,5 @@ export const meta: WsComponentMeta = {
 
 export const propsMeta: WsComponentPropsMeta = {
   props,
-  initialProps: ["id"],
+  initialProps: ["id", "cite"],
 };

--- a/packages/sdk-components-react/src/text.tsx
+++ b/packages/sdk-components-react/src/text.tsx
@@ -9,7 +9,7 @@ export const defaultTag = "div";
 
 // We don't want to enable all tags because Box is usually a container and we have specific components for many tags.
 type Props = ComponentProps<typeof defaultTag> & {
-  tag?: "div" | "span" | "figcaption";
+  tag?: "div" | "span" | "figcaption" | "cite";
 };
 
 export const Text = forwardRef<ElementRef<typeof defaultTag>, Props>(


### PR DESCRIPTION
Closes https://github.com/webstudio-is/webstudio-builder/issues/2118

## Description

Added cite tag to Text component as well as cite prop in initial props to Blockquote component

Now you can create same html structure as https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote

```html
<blockquote cite="https://www.huxley.net/bnw/four.html">
  <p>Words can be like X-rays, if you use them properly—they’ll go through anything. You read and you’re pierced.</p>
  <footer>—Aldous Huxley, <cite>Brave New World</cite></footer>
</blockquote>
```


## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
