### PR TITLE
Add inline-flex display option

### DIFF
--- a/apps/builder/app/builder/features/style-panel/sections/layout/layout.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/layout/layout.tsx
@@ -415,6 +415,7 @@ const orderedDisplayValues = [
   "block",
   "flex",
   "inline-block",
+  "inline-flex",
   "inline",
   "none",
 ];


### PR DESCRIPTION
## Description

This adds inline-flex display option as requested here https://github.com/webstudio-is/webstudio/discussions/50

The use case is having a button with icon and text, without turning it into block element with full width.

## Steps for reproduction

1. select any element and set display: flex


## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
