### PR TITLE
Fix accrodion trigger not editable

### DIFF
--- a/packages/sdk-components-react-radix/src/accordion.ws.ts
+++ b/packages/sdk-components-react-radix/src/accordion.ws.ts
@@ -76,6 +76,7 @@ const createAccordionTrigger = ({
         {
           type: "instance",
           component: "Box",
+          label: "Icon Container",
           // h-4 w-4 shrink-0 transition-transform duration-200
           styles: [
             tc.property("rotate", "--accordion-trigger-icon-transform"),

--- a/packages/sdk-components-react-radix/src/accordion.ws.ts
+++ b/packages/sdk-components-react-radix/src/accordion.ws.ts
@@ -68,7 +68,11 @@ const createAccordionTrigger = ({
         ),
       ].flat(),
       children: [
-        ...children,
+        {
+          type: "instance",
+          component: "Text",
+          children,
+        },
         {
           type: "instance",
           component: "Box",


### PR DESCRIPTION
## Description

closes https://discord.com/channels/955905230107738152/1142493917862973450

All changes

<img width="236" alt="image" src="https://github.com/webstudio-is/webstudio-builder/assets/5077042/2ebb4abc-7def-4fd2-818e-ed085b2abc9f">


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
