### PR TITLE
Add component tokens support

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source-section.test.ts
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.test.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "@jest/globals";
+import type { Breakpoint } from "@webstudio-is/project-build";
+import type { WsComponentMeta } from "@webstudio-is/react-sdk";
+import {
+  breakpointsStore,
+  registeredComponentMetasStore,
+} from "~/shared/nano-states";
+import { $presetTokens } from "./style-source-section";
+
+test("generate Styles from preset tokens", () => {
+  breakpointsStore.set(
+    new Map<Breakpoint["id"], Breakpoint>([
+      ["base", { id: "base", label: "Base" }],
+    ])
+  );
+  registeredComponentMetasStore.set(
+    new Map<string, WsComponentMeta>([
+      [
+        "Box",
+        {
+          icon: "",
+          type: "container",
+          presetTokens: {
+            boxBright: {
+              styles: [
+                {
+                  property: "color",
+                  value: { type: "keyword", value: "black" },
+                },
+              ],
+            },
+          },
+        },
+      ],
+      [
+        "Button",
+        {
+          icon: "",
+          type: "container",
+          presetTokens: {
+            buttonPrimary: {
+              styles: [
+                {
+                  property: "backgroundColor",
+                  value: { type: "keyword", value: "black" },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    ])
+  );
+  expect($presetTokens.get()).toEqual(
+    new Map([
+      [
+        "Box:boxBright",
+        {
+          component: "Box",
+          styleSource: {
+            type: "token",
+            id: "Box:boxBright",
+            name: "Box Bright",
+          },
+          styles: [
+            {
+              breakpointId: "base",
+              styleSourceId: "Box:boxBright",
+              property: "color",
+              value: { type: "keyword", value: "black" },
+            },
+          ],
+        },
+      ],
+      [
+        "Button:buttonPrimary",
+        {
+          component: "Button",
+          styleSource: {
+            type: "token",
+            id: "Button:buttonPrimary",
+            name: "Button Primary",
+          },
+          styles: [
+            {
+              breakpointId: "base",
+              styleSourceId: "Button:buttonPrimary",
+              property: "backgroundColor",
+              value: { type: "keyword", value: "black" },
+            },
+          ],
+        },
+      ],
+    ])
+  );
+});

--- a/apps/builder/app/builder/features/style-panel/style-source-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.tsx
@@ -94,7 +94,7 @@ const $baseBreakpointId = computed(breakpointsStore, (breakpoints) => {
 
 // metas are rarely change so keep preset token styles computing
 // in separate store
-const $presetTokens = computed(
+export const $presetTokens = computed(
   [registeredComponentMetasStore, $baseBreakpointId],
   (metas, baseBreakpointId) => {
     const presetTokens = new Map<

--- a/apps/builder/app/builder/features/style-panel/style-source-section.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source-section.tsx
@@ -9,6 +9,7 @@ import {
   type StyleSourceToken,
   type StyleSourceSelections,
   getStyleDeclKey,
+  StyleDecl,
 } from "@webstudio-is/project-build";
 import {
   Flex,
@@ -22,7 +23,8 @@ import {
 } from "@webstudio-is/design-system";
 import { type ItemSource, StyleSourceInput } from "./style-source";
 import {
-  availableStyleSourcesStore,
+  breakpointsStore,
+  instancesStore,
   registeredComponentMetasStore,
   selectedInstanceSelectorStore,
   selectedInstanceStatesByStyleSourceIdStore,
@@ -36,6 +38,9 @@ import {
 } from "~/shared/nano-states";
 import { removeByMutable } from "~/shared/array-utils";
 import { cloneStyles } from "~/shared/tree-utils";
+import { humanizeString } from "~/shared/string-utils";
+import { isBaseBreakpoint } from "~/shared/breakpoints";
+import { shallowComputed } from "~/shared/store-utils";
 
 const getOrCreateStyleSourceSelectionMutable = (
   styleSourceSelections: StyleSourceSelections,
@@ -81,7 +86,60 @@ const createLocalStyleSourceIfNotExists = (
   );
 };
 
-const createStyleSource = (name: string) => {
+const $baseBreakpointId = computed(breakpointsStore, (breakpoints) => {
+  const breakpointValues = Array.from(breakpoints.values());
+  const baseBreakpoint = breakpointValues.find(isBaseBreakpoint);
+  return baseBreakpoint?.id;
+});
+
+// metas are rarely change so keep preset token styles computing
+// in separate store
+const $presetTokens = computed(
+  [registeredComponentMetasStore, $baseBreakpointId],
+  (metas, baseBreakpointId) => {
+    const presetTokens = new Map<
+      StyleSource["id"],
+      {
+        component: Instance["component"];
+        styleSource: StyleSourceToken;
+        styles: StyleDecl[];
+      }
+    >();
+    if (baseBreakpointId === undefined) {
+      return presetTokens;
+    }
+    for (const [component, meta] of metas) {
+      if (meta.presetTokens === undefined) {
+        continue;
+      }
+      for (const [name, tokenValue] of Object.entries(meta.presetTokens)) {
+        const styleSourceId = `${component}:${name}`;
+        const styles: StyleDecl[] = [];
+        for (const styleDecl of tokenValue.styles) {
+          styles.push({
+            breakpointId: baseBreakpointId,
+            styleSourceId,
+            state: styleDecl.state,
+            property: styleDecl.property,
+            value: styleDecl.value,
+          });
+        }
+        presetTokens.set(styleSourceId, {
+          component,
+          styleSource: {
+            type: "token",
+            id: styleSourceId,
+            name: humanizeString(name),
+          },
+          styles,
+        });
+      }
+    }
+    return presetTokens;
+  }
+);
+
+const createStyleSource = (id: StyleSource["id"], name: string) => {
   const selectedInstanceSelector = selectedInstanceSelectorStore.get();
   if (selectedInstanceSelector === undefined) {
     return;
@@ -89,18 +147,27 @@ const createStyleSource = (name: string) => {
   const [selectedInstanceId] = selectedInstanceSelector;
   const newStyleSource: StyleSource = {
     type: "token",
-    id: nanoid(),
+    id,
     name,
   };
+  const presetTokens = $presetTokens.get();
   store.createTransaction(
-    [styleSourcesStore, styleSourceSelectionsStore],
-    (styleSources, styleSourceSelections) => {
+    [styleSourcesStore, stylesStore, styleSourceSelectionsStore],
+    (styleSources, styles, styleSourceSelections) => {
       const styleSourceSelection = getOrCreateStyleSourceSelectionMutable(
         styleSourceSelections,
         selectedInstanceId
       );
       styleSourceSelection.values.push(newStyleSource.id);
       styleSources.set(newStyleSource.id, newStyleSource);
+
+      // populate preset token styles
+      const presetToken = presetTokens.get(id);
+      if (presetToken) {
+        for (const styleDecl of presetToken.styles) {
+          styles.set(getStyleDeclKey(styleDecl), styleDecl);
+        }
+      }
     }
   );
   selectedStyleSourceSelectorStore.set({ styleSourceId: newStyleSource.id });
@@ -336,14 +403,62 @@ const convertToInputItem = (
   };
 };
 
+const $selectedInstancePresetTokens = shallowComputed(
+  [selectedInstanceSelectorStore, instancesStore, $presetTokens],
+  (selectedInstanceSelector, instances, presetTokens) => {
+    const selectedInstancePresetTokens: StyleSourceToken[] = [];
+    if (selectedInstanceSelector === undefined) {
+      return selectedInstancePresetTokens;
+    }
+    const [instanceId] = selectedInstanceSelector;
+    const instance = instances.get(instanceId);
+    if (instance === undefined) {
+      return selectedInstancePresetTokens;
+    }
+    for (const presetToken of presetTokens.values()) {
+      if (presetToken.component === instance.component) {
+        selectedInstancePresetTokens.push(presetToken.styleSource);
+      }
+    }
+    return selectedInstancePresetTokens;
+  }
+);
+
+/**
+ * find all non-local and component style sources
+ */
+const $availableStyleSources = computed(
+  [styleSourcesStore, $selectedInstancePresetTokens],
+  (styleSources, presetTokens) => {
+    const availableStylesSources: StyleSourceInputItem[] = [];
+    for (const styleSource of styleSources.values()) {
+      if (styleSource.type === "local") {
+        continue;
+      }
+      availableStylesSources.push(convertToInputItem(styleSource, []));
+    }
+    for (const styleSource of presetTokens) {
+      // skip if already present in global tokens
+      if (styleSources.has(styleSource.id)) {
+        continue;
+      }
+      availableStylesSources.push({
+        id: styleSource.id,
+        label: styleSource.name,
+        disabled: false,
+        source: "componentToken",
+        states: [],
+      });
+    }
+    return availableStylesSources;
+  }
+);
+
 export const StyleSourcesSection = () => {
   const componentStates = useStore(componentStatesStore);
-  const availableStyleSources = useStore(availableStyleSourcesStore);
+  const availableStyleSources = useStore($availableStyleSources);
   const selectedInstanceStyleSources = useStore(
     selectedInstanceStyleSourcesStore
-  );
-  const items = availableStyleSources.map((styleSource) =>
-    convertToInputItem(styleSource, [])
   );
   const selectedInstanceStatesByStyleSourceId = useStore(
     selectedInstanceStatesByStyleSourceIdStore
@@ -367,7 +482,7 @@ export const StyleSourcesSection = () => {
   return (
     <>
       <StyleSourceInput
-        items={items}
+        items={availableStyleSources}
         value={value}
         selectedItemSelector={selectedOrLastStyleSourceSelector}
         componentStates={componentStates}

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-badge.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-badge.tsx
@@ -18,6 +18,9 @@ export const StyleSourceBadge = styled(Text, {
       token: {
         backgroundColor: theme.colors.backgroundStyleSourceToken,
       },
+      componentToken: {
+        backgroundColor: theme.colors.backgroundStyleSourceToken,
+      },
       tag: {
         backgroundColor: theme.colors.backgroundStyleSourceTag,
       },

--- a/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source.tsx
@@ -100,7 +100,7 @@ const Menu = (props: MenuProps) => {
   );
 };
 
-export type ItemSource = "token" | "tag" | "local";
+export type ItemSource = "token" | "componentToken" | "tag" | "local";
 
 type EditableTextProps = {
   label: string;
@@ -159,6 +159,11 @@ const StyleSourceContainer = styled(Box, {
           theme.colors.backgroundStyleSourceGradientToken,
       },
       token: {
+        backgroundColor: theme.colors.backgroundStyleSourceToken,
+        [menuTriggerGradientVar]:
+          theme.colors.backgroundStyleSourceGradientToken,
+      },
+      componentToken: {
         backgroundColor: theme.colors.backgroundStyleSourceToken,
         [menuTriggerGradientVar]:
           theme.colors.backgroundStyleSourceGradientToken,

--- a/apps/builder/app/shared/copy-paste/plugin-embed-template.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-embed-template.ts
@@ -51,11 +51,12 @@ export const onPaste = (clipboardData: string): boolean => {
   if (baseBreakpoint === undefined) {
     return false;
   }
+  const metas = registeredComponentMetasStore.get();
   const templateData = generateDataFromEmbedTemplate(
     template,
+    metas,
     baseBreakpoint.id
   );
-  const metas = registeredComponentMetasStore.get();
   const newInstances = new Map(
     templateData.instances.map((instance) => [instance.id, instance])
   );

--- a/apps/builder/app/shared/nano-states/nano-states.ts
+++ b/apps/builder/app/shared/nano-states/nano-states.ts
@@ -157,23 +157,6 @@ export const useInstanceStyles = (instanceId: undefined | Instance["id"]) => {
 };
 
 export const styleSourcesStore = atom<StyleSources>(new Map());
-/**
- * find all non-local style sources
- * scoped to current tree or whole project
- */
-export const availableStyleSourcesStore = shallowComputed(
-  [styleSourcesStore],
-  (styleSources) => {
-    const availableStylesSources: StyleSource[] = [];
-    for (const styleSource of styleSources.values()) {
-      if (styleSource.type === "local") {
-        continue;
-      }
-      availableStylesSources.push(styleSource);
-    }
-    return availableStylesSources;
-  }
-);
 
 export const useSetStyleSources = (
   styleSources: [StyleSource["id"], StyleSource][]

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -48,7 +48,9 @@
     "jsep": "^1.3.8",
     "nanoevents": "^8.0.0",
     "nanoid": "^4.0.2",
-    "nanostores": "^0.9.3"
+    "nanostores": "^0.9.3",
+    "no-case": "^3.0.4",
+    "title-case": "^3.0.3"
   },
   "exports": {
     ".": {

--- a/packages/react-sdk/src/component-renderer.tsx
+++ b/packages/react-sdk/src/component-renderer.tsx
@@ -56,7 +56,7 @@ export const renderComponentTemplate = ({
     });
   }
 
-  const data = generateDataFromEmbedTemplate(template, "base");
+  const data = generateDataFromEmbedTemplate(template, metas, "base");
 
   const instances: [Instance["id"], Instance][] = [
     [

--- a/packages/react-sdk/src/components/component-meta.ts
+++ b/packages/react-sdk/src/components/component-meta.ts
@@ -36,6 +36,11 @@ export const ComponentState = z.object({
 
 export type ComponentState = z.infer<typeof ComponentState>;
 
+const ComponentToken = z.object({
+  variant: z.optional(z.string()),
+  styles: z.array(EmbedTemplateStyleDecl),
+});
+
 export const defaultStates: ComponentState[] = [
   { selector: ":hover", label: "Hover" },
   { selector: ":active", label: "Active" },
@@ -67,6 +72,7 @@ const WsComponentMeta = z.object({
   description: z.string().optional(),
   icon: z.string(),
   presetStyle: z.optional(z.record(z.string(), EmbedTemplateStyleDecl)),
+  presetTokens: z.optional(z.record(z.string(), ComponentToken)),
   states: z.optional(z.array(ComponentState)),
   template: z.optional(WsEmbedTemplate),
   order: z.number().optional(),

--- a/packages/react-sdk/src/embed-template.test.ts
+++ b/packages/react-sdk/src/embed-template.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@jest/globals";
 import { generateDataFromEmbedTemplate, namespaceMeta } from "./embed-template";
 import { showAttribute } from "./tree";
+import type { WsComponentMeta } from "./components/component-meta";
 
 const expectString = expect.any(String);
 
@@ -20,6 +21,7 @@ test("generate data for embedding from instances and text", () => {
           ],
         },
       ],
+      new Map(),
       defaultBreakpointId
     )
   ).toEqual({
@@ -73,6 +75,7 @@ test("generate data for embedding from props", () => {
           ],
         },
       ],
+      new Map(),
       defaultBreakpointId
     )
   ).toEqual({
@@ -147,6 +150,7 @@ test("generate data for embedding from styles", () => {
           ],
         },
       ],
+      new Map(),
       defaultBreakpointId
     )
   ).toEqual({
@@ -245,6 +249,7 @@ test("generate data for embedding from props bound to data source variables", ()
           children: [],
         },
       ],
+      new Map(),
       defaultBreakpointId
     )
   ).toEqual({
@@ -326,6 +331,7 @@ test("generate data for embedding from props bound to data source expressions", 
           children: [],
         },
       ],
+      new Map(),
       defaultBreakpointId
     )
   ).toEqual({
@@ -422,6 +428,7 @@ test("generate data for embedding from action props", () => {
           ],
         },
       ],
+      new Map(),
       defaultBreakpointId
     )
   ).toEqual({
@@ -488,6 +495,93 @@ test("generate data for embedding from action props", () => {
   });
 });
 
+test("generate styles from tokens", () => {
+  const presetTokens: WsComponentMeta["presetTokens"] = {
+    box: {
+      styles: [
+        {
+          property: "width",
+          value: { type: "keyword", value: "max-content" },
+        },
+        {
+          property: "height",
+          value: { type: "keyword", value: "max-content" },
+        },
+      ],
+    },
+    boxBright: {
+      styles: [
+        {
+          property: "color",
+          value: { type: "keyword", value: "red" },
+        },
+        {
+          property: "backgroundColor",
+          value: { type: "keyword", value: "pink" },
+        },
+      ],
+    },
+    boxNone: {
+      styles: [
+        {
+          property: "color",
+          value: { type: "keyword", value: "transparent" },
+        },
+        {
+          property: "backgroundColor",
+          value: { type: "keyword", value: "transparent" },
+        },
+      ],
+    },
+  };
+  const { styleSourceSelections, styleSources, styles } =
+    generateDataFromEmbedTemplate(
+      [
+        {
+          type: "instance",
+          component: "Box",
+          tokens: ["box", "boxBright"],
+          children: [],
+        },
+      ],
+      new Map([["Box", { type: "container", icon: "", presetTokens }]]),
+      defaultBreakpointId
+    );
+  expect(styleSources).toEqual([
+    { id: "Box:box", name: "box", type: "token" },
+    { id: "Box:boxBright", name: "boxBright", type: "token" },
+  ]);
+  expect(styleSourceSelections).toEqual([
+    { instanceId: expectString, values: ["Box:box", "Box:boxBright"] },
+  ]);
+  expect(styles).toEqual([
+    {
+      breakpointId: "base",
+      property: "width",
+      styleSourceId: "Box:box",
+      value: { type: "keyword", value: "max-content" },
+    },
+    {
+      breakpointId: "base",
+      property: "height",
+      styleSourceId: "Box:box",
+      value: { type: "keyword", value: "max-content" },
+    },
+    {
+      breakpointId: "base",
+      property: "color",
+      styleSourceId: "Box:boxBright",
+      value: { type: "keyword", value: "red" },
+    },
+    {
+      breakpointId: "base",
+      property: "backgroundColor",
+      styleSourceId: "Box:boxBright",
+      value: { type: "keyword", value: "pink" },
+    },
+  ]);
+});
+
 test("add namespace to selected components in embed template", () => {
   expect(
     namespaceMeta(
@@ -498,10 +592,16 @@ test("add namespace to selected components in embed template", () => {
         requiredAncestors: ["Button", "Box"],
         invalidAncestors: ["Tooltip"],
         indexWithinAncestor: "Tooltip",
+        presetTokens: {
+          base: { styles: [] },
+          small: { styles: [] },
+          large: { styles: [] },
+        },
         template: [
           {
             type: "instance",
             component: "Tooltip",
+            tokens: ["base", "small"],
             children: [
               { type: "text", value: "Some text" },
               {
@@ -529,10 +629,16 @@ test("add namespace to selected components in embed template", () => {
     requiredAncestors: ["my-namespace:Button", "Box"],
     invalidAncestors: ["my-namespace:Tooltip"],
     indexWithinAncestor: "my-namespace:Tooltip",
+    presetTokens: {
+      base: { styles: [] },
+      small: { styles: [] },
+      large: { styles: [] },
+    },
     template: [
       {
         type: "instance",
         component: "my-namespace:Tooltip",
+        tokens: ["base", "small"],
         children: [
           { type: "text", value: "Some text" },
           {

--- a/packages/react-sdk/src/embed-template.test.ts
+++ b/packages/react-sdk/src/embed-template.test.ts
@@ -548,8 +548,8 @@ test("generate styles from tokens", () => {
       defaultBreakpointId
     );
   expect(styleSources).toEqual([
-    { id: "Box:box", name: "box", type: "token" },
-    { id: "Box:boxBright", name: "boxBright", type: "token" },
+    { id: "Box:box", name: "Box", type: "token" },
+    { id: "Box:boxBright", name: "Box Bright", type: "token" },
   ]);
   expect(styleSourceSelections).toEqual([
     { instanceId: expectString, values: ["Box:box", "Box:boxBright"] },

--- a/packages/sdk-components-react-radix/src/button.stories.ts
+++ b/packages/sdk-components-react-radix/src/button.stories.ts
@@ -9,19 +9,6 @@ import * as radixMetas from "./metas";
 export default {
   title: "Components/Button",
   component: ButtonPrimitive,
-  argTypes: {
-    variant: {
-      options: [
-        "default",
-        "destructive",
-        "outline",
-        "secondary",
-        "ghost",
-        "link",
-      ],
-      control: { type: "select" },
-    },
-  },
 } satisfies Meta<typeof ButtonPrimitive>;
 
 export const Button: StoryObj<typeof ButtonPrimitive> = {

--- a/packages/sdk-components-react-radix/src/button.tsx
+++ b/packages/sdk-components-react-radix/src/button.tsx
@@ -3,23 +3,9 @@
 
 import { forwardRef, type ComponentPropsWithoutRef } from "react";
 
-type ButtonVariants = {
-  variant:
-    | "default"
-    | "destructive"
-    | "outline"
-    | "secondary"
-    | "ghost"
-    | "link";
-
-  size: "default" | "sm" | "lg" | "icon";
-};
-
 export const Button = forwardRef<
   HTMLButtonElement,
-  ComponentPropsWithoutRef<"button"> & ButtonVariants
->(({ variant = "default", size = "default", ...props }, ref) => {
-  return (
-    <button ref={ref} data-size={size} data-variant={variant} {...props} />
-  );
+  ComponentPropsWithoutRef<"button">
+>((props, ref) => {
+  return <button ref={ref} {...props} />;
 });

--- a/packages/sdk-components-react-radix/src/button.ws.ts
+++ b/packages/sdk-components-react-radix/src/button.ws.ts
@@ -21,7 +21,7 @@ export const template = (props?: {
   {
     type: "instance",
     component: "Button",
-    tokens: ["button", "buttonDefault", "buttonSizeDefault"],
+    tokens: ["button", "buttonPrimary", "buttonMd"],
     children: props?.children ?? [{ type: "text", value: "Button" }],
     props: props?.props,
   },
@@ -66,7 +66,7 @@ export const meta: WsComponentMeta = {
     },
 
     // VARIANT
-    buttonDefault: {
+    buttonPrimary: {
       variant: "variant",
       styles: [
         // default: 'bg-primary text-primary-foreground hover:bg-primary/90',
@@ -127,7 +127,7 @@ export const meta: WsComponentMeta = {
     },
 
     // SIZE
-    buttonSizeDefault: {
+    buttonMd: {
       variant: "size",
       styles: [
         // default: 'h-10 px-4 py-2',
@@ -136,7 +136,7 @@ export const meta: WsComponentMeta = {
         tc.py(2),
       ].flat(),
     },
-    buttonSizeSm: {
+    buttonSm: {
       variant: "size",
       styles: [
         // sm: 'h-9 rounded-md px-3',
@@ -144,7 +144,7 @@ export const meta: WsComponentMeta = {
         tc.px(3),
       ].flat(),
     },
-    buttonSizeLg: {
+    buttonLg: {
       variant: "size",
       styles: [
         // lg: 'h-11 rounded-md px-8',
@@ -152,7 +152,7 @@ export const meta: WsComponentMeta = {
         tc.px(8),
       ].flat(),
     },
-    buttonSizeIcon: {
+    buttonIcon: {
       variant: "size",
       styles: [
         // icon: 'h-10 w-10',

--- a/packages/sdk-components-react-radix/src/button.ws.ts
+++ b/packages/sdk-components-react-radix/src/button.ws.ts
@@ -21,93 +21,7 @@ export const template = (props?: {
   {
     type: "instance",
     component: "Button",
-    styles: [
-      // 'inline-flex items-center justify-center rounded-md text-sm font-medium
-      // ring-offset-background transition-colors
-      // focus-visible:outline-none focus-visible:ring-2
-      // focus-visible:ring-ring focus-visible:ring-offset-2
-      // disabled:pointer-events-none disabled:opacity-50'
-      tc.border(0),
-      tc.bg("transparent"),
-      tc.inlineFlex(),
-      tc.items("center"),
-      tc.justify("center"),
-      tc.rounded("md"),
-      tc.text("sm"),
-      tc.font("medium"),
-      tc.focusVisible(
-        [tc.outline("none"), tc.ring("ring", 2, "background", 2)].flat()
-      ),
-      tc.state([tc.pointerEvents("none"), tc.opacity(50)].flat(), ":disabled"),
-
-      // VARIANT
-      // default: 'bg-primary text-primary-foreground hover:bg-primary/90',
-      tc.state(
-        [tc.bg("primary"), tc.text("primaryForeground")].flat(),
-        "[data-variant=default]"
-      ),
-      tc.state(
-        [[tc.bg("primary", 90)].flat()].flat(),
-        "[data-variant=default]:hover"
-      ),
-
-      // destructive:'bg-destructive text-destructive-foreground hover:bg-destructive/90',
-      tc.state(
-        [tc.bg("destructive"), tc.text("destructiveForeground")].flat(),
-        "[data-variant=destructive]"
-      ),
-      tc.state(
-        [[tc.bg("destructive", 90)].flat()].flat(),
-        "[data-variant=destructive]:hover"
-      ),
-
-      // outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
-      tc.state(
-        [tc.border(), tc.border("input"), tc.bg("background")].flat(),
-        "[data-variant=outline]"
-      ),
-      tc.state(
-        [[tc.bg("accent", 90), tc.text("accentForeground")].flat()].flat(),
-        "[data-variant=outline]:hover"
-      ),
-
-      // secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-      tc.state(
-        [tc.bg("secondary"), tc.text("secondaryForeground")].flat(),
-        "[data-variant=secondary]"
-      ),
-      tc.state(
-        [[tc.bg("secondary", 80)].flat()].flat(),
-        "[data-variant=secondary]:hover"
-      ),
-
-      // ghost: 'hover:bg-accent hover:text-accent-foreground',
-      tc.state(
-        [[tc.bg("accent"), tc.text("accentForeground")].flat()].flat(),
-        "[data-variant=ghost]:hover"
-      ),
-
-      // link: 'text-primary underline-offset-4 hover:underline',
-      tc.state(
-        [tc.text("primary"), tc.underlineOffset(4)].flat(),
-        "[data-variant=link]"
-      ),
-      tc.state([[tc.underline()].flat()].flat(), "[data-variant=link]:hover"),
-
-      // SIZE
-      // default: 'h-10 px-4 py-2',
-      tc.state([tc.h(10), tc.px(4), tc.py(2)].flat(), "[data-size=default]"),
-
-      // sm: 'h-9 rounded-md px-3',
-      tc.state([tc.h(10), tc.px(3)].flat(), "[data-size=sm]"),
-
-      // lg: 'h-11 rounded-md px-8',
-      tc.state([tc.h(11), tc.px(8)].flat(), "[data-size=lg]"),
-
-      // icon: 'h-10 w-10',
-      tc.state([tc.h(10), tc.w(10)].flat(), "[data-size=icon]"),
-    ].flat(),
-
+    tokens: ["button", "buttonDefault", "buttonSizeDefault"],
     children: props?.children ?? [{ type: "text", value: "Button" }],
     props: props?.props,
   },
@@ -119,33 +33,134 @@ export const meta: WsComponentMeta = {
   type: "container",
   invalidAncestors: ["Button"],
   icon: ButtonElementIcon,
-  presetStyle,
   states: [
     ...defaultStates,
     { selector: ":disabled", label: "Disabled" },
     { selector: ":enabled", label: "Enabled" },
-
-    { selector: "[data-variant=default]", label: "Default" },
-    { selector: "[data-variant=default]:hover", label: "Default Hover" },
-
-    { selector: "[data-variant=destructive]", label: "Destructive" },
-    {
-      selector: "[data-variant=destructive]:hover",
-      label: "Destructive Hover",
+  ],
+  presetStyle,
+  presetTokens: {
+    button: {
+      styles: [
+        // 'inline-flex items-center justify-center rounded-md text-sm font-medium
+        // ring-offset-background transition-colors
+        // focus-visible:outline-none focus-visible:ring-2
+        // focus-visible:ring-ring focus-visible:ring-offset-2
+        // disabled:pointer-events-none disabled:opacity-50'
+        tc.border(0),
+        tc.bg("transparent"),
+        tc.inlineFlex(),
+        tc.items("center"),
+        tc.justify("center"),
+        tc.rounded("md"),
+        tc.text("sm"),
+        tc.font("medium"),
+        tc.focusVisible(
+          [tc.outline("none"), tc.ring("ring", 2, "background", 2)].flat()
+        ),
+        tc.state(
+          [tc.pointerEvents("none"), tc.opacity(50)].flat(),
+          ":disabled"
+        ),
+      ].flat(),
     },
 
-    { selector: "[data-variant=outline]", label: "Outline" },
-    { selector: "[data-variant=outline]:hover", label: "Outline Hover" },
+    // VARIANT
+    buttonDefault: {
+      variant: "variant",
+      styles: [
+        // default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        tc.bg("primary"),
+        tc.text("primaryForeground"),
+        tc.state([tc.bg("primary", 90)].flat(), ":hover"),
+      ].flat(),
+    },
+    buttonDestructive: {
+      variant: "variant",
+      styles: [
+        // destructive:'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        tc.bg("destructive"),
+        tc.text("destructiveForeground"),
+        tc.state([tc.bg("destructive", 90)].flat(), ":hover"),
+      ].flat(),
+    },
+    buttonOutline: {
+      variant: "variant",
+      styles: [
+        // outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        tc.border(),
+        tc.border("input"),
+        tc.bg("background"),
+        tc.state(
+          [tc.bg("accent", 90), tc.text("accentForeground")].flat(),
+          ":hover"
+        ),
+      ].flat(),
+    },
+    buttonSecondary: {
+      variant: "variant",
+      styles: [
+        // secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        tc.bg("secondary"),
+        tc.text("secondaryForeground"),
+        tc.state([tc.bg("secondary", 80)].flat(), ":hover"),
+      ].flat(),
+    },
+    buttonGhost: {
+      variant: "variant",
+      styles: [
+        // ghost: 'hover:bg-accent hover:text-accent-foreground',
+        tc.state(
+          [tc.bg("accent"), tc.text("accentForeground")].flat(),
+          ":hover"
+        ),
+      ].flat(),
+    },
+    buttonLink: {
+      variant: "variant",
+      styles: [
+        // link: 'text-primary underline-offset-4 hover:underline',
+        tc.text("primary"),
+        tc.underlineOffset(4),
+        tc.state([tc.underline()].flat(), ":hover"),
+      ].flat(),
+    },
 
-    { selector: "[data-variant=secondary]", label: "Secondary" },
-    { selector: "[data-variant=secondary]:hover", label: "Secondary Hover" },
-
-    { selector: "[data-variant=ghost]", label: "Ghost" },
-    { selector: "[data-variant=ghost]:hover", label: "Ghost Hover" },
-
-    { selector: "[data-variant=link]", label: "Link" },
-    { selector: "[data-variant=link]:hover", label: "Link Hover" },
-  ],
+    // SIZE
+    buttonSizeDefault: {
+      variant: "size",
+      styles: [
+        // default: 'h-10 px-4 py-2',
+        tc.h(10),
+        tc.px(4),
+        tc.py(2),
+      ].flat(),
+    },
+    buttonSizeSm: {
+      variant: "size",
+      styles: [
+        // sm: 'h-9 rounded-md px-3',
+        tc.h(10),
+        tc.px(3),
+      ].flat(),
+    },
+    buttonSizeLg: {
+      variant: "size",
+      styles: [
+        // lg: 'h-11 rounded-md px-8',
+        tc.h(11),
+        tc.px(8),
+      ].flat(),
+    },
+    buttonSizeIcon: {
+      variant: "size",
+      styles: [
+        // icon: 'h-10 w-10',
+        tc.h(10),
+        tc.w(10),
+      ].flat(),
+    },
+  },
   template: template(),
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1239,6 +1239,12 @@ importers:
       nanostores:
         specifier: ^0.9.3
         version: 0.9.3
+      no-case:
+        specifier: ^3.0.4
+        version: 3.0.4
+      title-case:
+        specifier: ^3.0.3
+        version: 3.0.3
     devDependencies:
       '@jest/globals':
         specifier: ^29.6.2


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/2137

Here added static tokens support to meta. Id of resulting style source become persistent like this "componentName:tokenName". Such token styles are inserted only if style source with same id not exist. This way we prevent breaking styles already changed by user.

Style source input now autocomplete global tokens and suggest to create predefined component tokens.

Also disabled spell check in style source input.

<img width="244" alt="Screenshot 2023-08-20 at 17 18 37" src="https://github.com/webstudio-is/webstudio-builder/assets/5635476/9572f5b1-6243-49fa-83be-a0315f104987">

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
