### PR TITLE
Allow horizontal scrolling in navigator

### DIFF
--- a/packages/design-system/src/components/scroll-area.stories.tsx
+++ b/packages/design-system/src/components/scroll-area.stories.tsx
@@ -17,7 +17,7 @@ export const Story = () => {
     </div>
   );
   const css = {
-    height: 200,
+    height: 100,
     width: 100,
     background: theme.colors.backgroundPanel,
   };
@@ -27,7 +27,12 @@ export const Story = () => {
         <ScrollArea css={css}>{content}</ScrollArea>
       </StorySection>
       <StorySection title="Horizontal">
-        <ScrollArea css={css} verticalOnly={false}>
+        <ScrollArea css={css} direction="horizontal">
+          {content}
+        </ScrollArea>
+      </StorySection>
+      <StorySection title="Both">
+        <ScrollArea css={css} direction="both">
           {content}
         </ScrollArea>
       </StorySection>

--- a/packages/design-system/src/components/scroll-area.stories.tsx
+++ b/packages/design-system/src/components/scroll-area.stories.tsx
@@ -1,0 +1,37 @@
+import { StorySection } from "./storybook";
+import { ScrollArea } from "./scroll-area";
+import { theme } from "..";
+
+export default {
+  title: "Library/Scroll Area",
+};
+
+export const Story = () => {
+  const content = (
+    <div style={{ height: 1000, width: 1000 }}>
+      {Array.from(new Array(100))
+        .map(() => {
+          return "a".repeat(300);
+        })
+        .join("\n")}
+    </div>
+  );
+  const css = {
+    height: 200,
+    width: 100,
+    background: theme.colors.backgroundPanel,
+  };
+  return (
+    <>
+      <StorySection title="Vertical">
+        <ScrollArea css={css}>{content}</ScrollArea>
+      </StorySection>
+      <StorySection title="Horizontal">
+        <ScrollArea css={css} verticalOnly={false}>
+          {content}
+        </ScrollArea>
+      </StorySection>
+    </>
+  );
+};
+Story.storyName = "Scroll Area";

--- a/packages/design-system/src/components/scroll-area.tsx
+++ b/packages/design-system/src/components/scroll-area.tsx
@@ -79,9 +79,11 @@ export const ScrollArea = forwardRef(
         >
           {children}
         </Viewport>
-        <ScrollAreaScrollbar orientation="vertical">
-          <ScrollAreaThumb />
-        </ScrollAreaScrollbar>
+        {(direction === "vertical" || direction === "both") && (
+          <ScrollAreaScrollbar orientation="vertical">
+            <ScrollAreaThumb />
+          </ScrollAreaScrollbar>
+        )}
         {(direction === "horizontal" || direction === "both") && (
           <ScrollAreaScrollbar orientation="horizontal">
             <ScrollAreaThumb />

--- a/packages/design-system/src/components/scroll-area.tsx
+++ b/packages/design-system/src/components/scroll-area.tsx
@@ -51,28 +51,30 @@ const viewPortStyle = css({
   borderRadius: "inherit",
 
   variants: {
-    verticalOnly: {
+    direction: {
       // https://github.com/radix-ui/primitives/issues/926#issuecomment-1015279283
-      true: { "& > div[style]": { display: "block !important" } },
+      vertical: { "& > div[style]": { display: "block !important" } },
+      horizontal: {},
+      both: {},
     },
   },
 });
 
-type ScrollAreaProps = { css?: CSS; verticalOnly?: boolean } & Pick<
-  ComponentProps<"div">,
-  "onScroll" | "children"
->;
+type ScrollAreaProps = {
+  css?: CSS;
+  direction?: "vertical" | "horizontal" | "both";
+} & Pick<ComponentProps<"div">, "onScroll" | "children">;
 
 export const ScrollArea = forwardRef(
   (
-    { children, css, onScroll, verticalOnly = true }: ScrollAreaProps,
+    { children, css, onScroll, direction = "vertical" }: ScrollAreaProps,
     ref: Ref<HTMLDivElement>
   ) => {
     return (
       <ScrollAreaRoot scrollHideDelay={0} css={css}>
         <Viewport
           ref={ref}
-          className={viewPortStyle({ verticalOnly })}
+          className={viewPortStyle({ direction })}
           onScroll={onScroll}
         >
           {children}
@@ -80,7 +82,7 @@ export const ScrollArea = forwardRef(
         <ScrollAreaScrollbar orientation="vertical">
           <ScrollAreaThumb />
         </ScrollAreaScrollbar>
-        {verticalOnly === false && (
+        {(direction === "horizontal" || direction === "both") && (
           <ScrollAreaScrollbar orientation="horizontal">
             <ScrollAreaThumb />
           </ScrollAreaScrollbar>

--- a/packages/design-system/src/components/tree/tree.tsx
+++ b/packages/design-system/src/components/tree/tree.tsx
@@ -270,8 +270,7 @@ export const Tree = <Data extends { id: string }>({
       direction="both"
       css={{
         width: "100%",
-        overflowY: "auto",
-        overflowX: "hidden",
+        overflow: "hidden",
         flexBasis: 0,
         flexGrow: 1,
       }}

--- a/packages/design-system/src/components/tree/tree.tsx
+++ b/packages/design-system/src/components/tree/tree.tsx
@@ -266,6 +266,8 @@ export const Tree = <Data extends { id: string }>({
 
   return (
     <ScrollArea
+      // TODO allow resizing of the panel instead.
+      direction="both"
       css={{
         width: "100%",
         overflowY: "auto",


### PR DESCRIPTION

## Description

This is a workaround because we don't have a resizable panel yet. With deep nested trees we need more space

## Steps for reproduction

1. nest radix components with a lot of depth
2. see that you can scroll both vertically and horizontally
3. horizontal bar is invisible, its a separate problem, not sure why

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
