### PR TITLE
Subscribe selected instance for component hooks

### DIFF
--- a/apps/builder/app/builder/features/inspector/inspector.tsx
+++ b/apps/builder/app/builder/features/inspector/inspector.tsx
@@ -73,7 +73,7 @@ export const Inspector = ({ publish, navigatorLayout }: InspectorProps) => {
   const metas = useStore(registeredComponentMetasStore);
 
   if (navigatorLayout === "docked" && isDragging) {
-    return <NavigatorTree publish={publish} />;
+    return <NavigatorTree />;
   }
 
   if (selectedInstance === undefined) {

--- a/apps/builder/app/builder/features/sidebar-left/navigator/navigator.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/navigator/navigator.tsx
@@ -21,7 +21,7 @@ export const Navigator = ({ isClosable, onClose, publish }: NavigatorProps) => {
         suffix={isClosable && <CloseButton onClick={() => onClose?.()} />}
       />
       <Flex grow direction="column" justify="end">
-        <NavigatorTree publish={publish} />
+        <NavigatorTree />
         <Separator />
         <CssPreview />
       </Flex>

--- a/apps/builder/app/builder/shared/navigator-tree.tsx
+++ b/apps/builder/app/builder/shared/navigator-tree.tsx
@@ -22,10 +22,9 @@ import {
   isInstanceDetachable,
   getComponentTemplateData,
 } from "~/shared/instance-utils";
-import type { Publish } from "~/shared/pubsub";
 import { InstanceTree } from "./tree";
 
-export const NavigatorTree = ({ publish }: { publish: Publish }) => {
+export const NavigatorTree = () => {
   const selectedInstanceSelector = useStore(selectedInstanceSelectorStore);
   const rootInstance = useStore(rootInstanceStore);
   const instances = useStore(instancesStore);
@@ -108,50 +107,17 @@ export const NavigatorTree = ({ publish }: { publish: Publish }) => {
     [setState]
   );
 
-  const handleSelect = useCallback(
-    (instanceSelector: InstanceSelector) => {
-      // TreeNode is refocused during "delete" hot key here https://github.com/webstudio-is/webstudio-builder/blob/5935d7818fba3739e4f16fe710ea468bf9d0ac78/packages/design-system/src/components/tree/tree.tsx#L435
-      // and then focus cause handleSelect to be called with the same instanceSelector
-      // This avoids additional rerender on node delete
-      if (
-        shallowEqual(selectedInstanceSelectorStore.get(), instanceSelector) ===
-        false
-      ) {
-        const instances = instancesStore.get();
-        const previousInstanceSelector = selectedInstanceSelectorStore.get();
-        if (previousInstanceSelector) {
-          publish({
-            type: "emitComponentHook",
-            payload: {
-              name: "onNavigatorUnselect",
-              data: {
-                instancePath: previousInstanceSelector.flatMap((id) => {
-                  const instance = instances.get(id);
-                  return instance ? [instance] : [];
-                }),
-              },
-            },
-          });
-        }
-        selectedInstanceSelectorStore.set(instanceSelector);
-        textEditingInstanceSelectorStore.set(undefined);
-        selectedStyleSourceSelectorStore.set(undefined);
-        publish({
-          type: "emitComponentHook",
-          payload: {
-            name: "onNavigatorSelect",
-            data: {
-              instancePath: instanceSelector.flatMap((id) => {
-                const instance = instances.get(id);
-                return instance ? [instance] : [];
-              }),
-            },
-          },
-        });
-      }
-    },
-    [publish]
-  );
+  const handleSelect = useCallback((instanceSelector: InstanceSelector) => {
+    // TreeNode is refocused during "delete" hot key here https://github.com/webstudio-is/webstudio-builder/blob/5935d7818fba3739e4f16fe710ea468bf9d0ac78/packages/design-system/src/components/tree/tree.tsx#L435
+    // and then focus cause handleSelect to be called with the same instanceSelector
+    // This avoids additional rerender on node delete
+    if (shallowEqual(selectedInstanceSelectorStore.get(), instanceSelector)) {
+      return;
+    }
+    selectedInstanceSelectorStore.set(instanceSelector);
+    textEditingInstanceSelectorStore.set(undefined);
+    selectedStyleSourceSelectorStore.set(undefined);
+  }, []);
 
   if (rootInstance === undefined) {
     return null;


### PR DESCRIPTION
Here subscribed selected instance selector store instead of navigator events. Now selection from canvas trigger hooks as well. Necessary to support navigation menu component.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
