### PR TITLE
Schedule rect update

### DIFF
--- a/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
+++ b/apps/builder/app/builder/features/sidebar-left/panels/components/use-draggable.tsx
@@ -18,7 +18,7 @@ import {
   selectedPageStore,
 } from "~/shared/nano-states";
 import { useSubscribe, type Publish } from "~/shared/pubsub";
-import { canvasRectStore, scaleStore } from "~/builder/shared/nano-states";
+import { $canvasRect, scaleStore } from "~/builder/shared/nano-states";
 import {
   computeInstancesConstraints,
   findClosestDroppableTarget,
@@ -125,7 +125,7 @@ export const useDraggable = ({
 }) => {
   const [dragComponent, setDragComponent] = useState<Instance["component"]>();
   const [point, setPoint] = useState<Point>({ x: 0, y: 0 });
-  const canvasRect = useStore(canvasRectStore);
+  const canvasRect = useStore($canvasRect);
   const scale = useStore(scaleStore);
   const { enableCanvasPointerEvents, disableCanvasPointerEvents } =
     useDisableCanvasPointerEvents();

--- a/apps/builder/app/builder/features/workspace/use-read-canvas-rect.ts
+++ b/apps/builder/app/builder/features/workspace/use-read-canvas-rect.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useState } from "react";
 import {
   scaleStore,
   canvasWidthStore,
-  canvasRectStore,
+  $canvasRect,
 } from "~/builder/shared/nano-states";
 import { useWindowResizeDebounced } from "~/shared/dom-hooks";
 
@@ -16,12 +16,25 @@ export const useReadCanvasRect = () => {
     null
   );
 
+  // react updates dom asynchronously so here schedule rect
+  // computing into effect when react done with dom
+  const [updateCallback, setUpdateCallback] = useState<
+    undefined | (() => void)
+  >(undefined);
+  useEffect(() => {
+    updateCallback?.();
+  }, [updateCallback]);
+
   const updateRect = useCallback(() => {
     if (iframeElement === null) {
       return;
     }
-    const rect = iframeElement.getBoundingClientRect();
-    canvasRectStore.set(rect);
+    // create new function to trigger effect
+    const task = () => {
+      const rect = iframeElement.getBoundingClientRect();
+      $canvasRect.set(rect);
+    };
+    setUpdateCallback(() => task);
   }, [iframeElement]);
 
   useEffect(() => {

--- a/apps/builder/app/builder/shared/nano-states/index.ts
+++ b/apps/builder/app/builder/shared/nano-states/index.ts
@@ -15,7 +15,7 @@ export const useIsPublishDialogOpen = () => useValue(isPublishDialogOpenStore);
 export const canvasWidthStore = atom<number | undefined>();
 export const useCanvasWidth = () => useValue(canvasWidthStore);
 
-export const canvasRectStore = atom<DOMRect | undefined>();
+export const $canvasRect = atom<DOMRect | undefined>();
 
 export const workspaceRectStore = atom<DOMRect | undefined>();
 


### PR DESCRIPTION
Here changed canvas rect subscription to read always in effect to not get stale state.
This fixes the issue with drag'n'drop when switch to another breakpoint.

## Code Review

- [ ] hi @kof, I need you to do
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
