### PR TITLE
Support expand all when alt+click on navigator chevron

### DIFF
--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -464,7 +464,7 @@ export const TreeNode = <Data extends { id: string }>({
           shouldRenderExpandButton,
           isExpanded,
           onToggle: (expandAll) => {
-            let type = isExpanded
+            const type = isExpanded
               ? ("collapse" as const)
               : expandAll
               ? ("expand-all" as const)

--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -241,7 +241,7 @@ export type TreeItemRenderProps<Data extends { id: string }> = {
   isAlwaysExpanded: boolean;
   shouldRenderExpandButton: boolean;
   isExpanded: boolean;
-  onToggle: () => void;
+  onToggle: (expandAll: boolean) => void;
 };
 
 export const TreeItemBody = <Data extends { id: string }>({
@@ -351,7 +351,7 @@ export const TreeItemBody = <Data extends { id: string }>({
           style={{ left: (level - 1) * INDENT + ITEM_PADDING_LEFT }}
           // We don't want this trigger to be focusable
           tabIndex={-1}
-          onClick={onToggle}
+          onClick={(event) => onToggle(event.altKey)}
         >
           {isExpanded ? <ChevronFilledDownIcon /> : <ChevronFilledRightIcon />}
         </CollapsibleTrigger>
@@ -398,7 +398,10 @@ export type TreeNodeProps<Data extends { id: ItemId }> = {
   renderItem: (props: TreeItemRenderProps<Data>) => React.ReactNode;
 
   getIsExpanded: (itemSelector: ItemSelector) => boolean;
-  setIsExpanded?: (itemSelector: ItemSelector, expanded: boolean) => void;
+  setIsExpanded?: (
+    itemSelector: ItemSelector,
+    type: "collapse" | "expand" | "expand-all"
+  ) => void;
 
   selectedItemSelector?: ItemSelector;
   dropTargetItemSelector?: ItemSelector;
@@ -460,7 +463,14 @@ export const TreeNode = <Data extends { id: string }>({
           isAlwaysExpanded,
           shouldRenderExpandButton,
           isExpanded,
-          onToggle: () => setIsExpanded?.(itemSelector, isExpanded === false),
+          onToggle: (expandAll) => {
+            let type = isExpanded
+              ? ("collapse" as const)
+              : expandAll
+              ? ("expand-all" as const)
+              : ("expand" as const);
+            setIsExpanded?.(itemSelector, type);
+          },
         })}
       {isExpandable &&
         isExpanded &&

--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -241,7 +241,7 @@ export type TreeItemRenderProps<Data extends { id: string }> = {
   isAlwaysExpanded: boolean;
   shouldRenderExpandButton: boolean;
   isExpanded: boolean;
-  onToggle: (expandAll: boolean) => void;
+  onToggle: (all: boolean) => void;
 };
 
 export const TreeItemBody = <Data extends { id: string }>({
@@ -400,7 +400,8 @@ export type TreeNodeProps<Data extends { id: ItemId }> = {
   getIsExpanded: (itemSelector: ItemSelector) => boolean;
   setIsExpanded?: (
     itemSelector: ItemSelector,
-    type: "collapse" | "expand" | "expand-all"
+    value: boolean,
+    all?: boolean
   ) => void;
 
   selectedItemSelector?: ItemSelector;
@@ -463,13 +464,12 @@ export const TreeNode = <Data extends { id: string }>({
           isAlwaysExpanded,
           shouldRenderExpandButton,
           isExpanded,
-          onToggle: (expandAll) => {
-            const type = isExpanded
-              ? ("collapse" as const)
-              : expandAll
-              ? ("expand-all" as const)
-              : ("expand" as const);
-            setIsExpanded?.(itemSelector, type);
+          onToggle: (all) => {
+            setIsExpanded?.(
+              itemSelector,
+              getIsExpanded(itemSelector) === false,
+              all
+            );
           },
         })}
       {isExpandable &&

--- a/packages/sdk-components-react-radix/src/accordion.tsx
+++ b/packages/sdk-components-react-radix/src/accordion.tsx
@@ -63,17 +63,24 @@ const namespace = "@webstudio-is/sdk-components-react-radix";
 export const hooksAccordion: Hook = {
   onNavigatorSelect: (context, event) => {
     for (const instance of event.instancePath) {
-      if (instance.component === `${namespace}:AccordionItem`) {
+      if (instance.component === `${namespace}:AccordionContent`) {
         const accordion = getClosestInstance(
           event.instancePath,
           instance,
           `${namespace}:Accordion`
         );
-        const itemValue =
-          context.getPropValue(instance.id, "value") ??
-          context.indexesWithinAncestors.get(instance.id)?.toString();
-        if (accordion && itemValue) {
-          context.setPropVariable(accordion.id, "value", itemValue);
+        const item = getClosestInstance(
+          event.instancePath,
+          instance,
+          `${namespace}:AccordionItem`
+        );
+        if (accordion && item) {
+          const itemValue =
+            context.getPropValue(item.id, "value") ??
+            context.indexesWithinAncestors.get(item.id)?.toString();
+          if (itemValue) {
+            context.setPropVariable(accordion.id, "value", itemValue);
+          }
         }
       }
     }

--- a/packages/sdk-components-react-radix/src/accordion.tsx
+++ b/packages/sdk-components-react-radix/src/accordion.tsx
@@ -57,7 +57,7 @@ export const AccordionContent: ForwardRefExoticComponent<
 
 const namespace = "@webstudio-is/sdk-components-react-radix";
 
-// For each AccordionItem component within the selection,
+// For each AccordionContent component within the selection,
 // we identify its closest parent Accordion component
 // and update its open prop bound to variable.
 export const hooksAccordion: Hook = {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/2151

Here added alt+click or opt+click support to navigator chevron to expand whole tree and simplify user navigation into hidden contents.

Also changed accordion hooks behaviour. Now only selecting accordion content expands its item. Before was possible to expand on item select.

Alt+click will help to reach accordion contents faster.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
- [ ] hi @GoharAkram, I need you to do
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
