### PR TITLE
Merge tabs trigger and button into single component

### DIFF
--- a/packages/sdk-components-react-radix/src/tabs.tsx
+++ b/packages/sdk-components-react-radix/src/tabs.tsx
@@ -5,9 +5,7 @@ import {
   type ComponentPropsWithoutRef,
   type ForwardRefExoticComponent,
   type ComponentPropsWithRef,
-  type ReactNode,
   forwardRef,
-  Children,
 } from "react";
 import { Root, List, Trigger, Content } from "@radix-ui/react-tabs";
 import {
@@ -22,28 +20,17 @@ export const Tabs: ForwardRefExoticComponent<
 
 export const TabsList = List;
 
-/**
- * We're not exposing the 'asChild' property for the Trigger.
- * Instead, we're enforcing 'asChild=true' for the Trigger and making it style-less.
- * This avoids situations where the Trigger inadvertently passes all styles to its child,
- * which would prevent us from displaying styles properly in the builder.
- */
 export const TabsTrigger = forwardRef<
   HTMLButtonElement,
-  { value: string; children: ReactNode }
->(({ value, children, ...props }, ref) => {
-  const firstChild = Children.toArray(children)[0];
+  ComponentPropsWithoutRef<typeof Trigger>
+>(({ value, ...props }, ref) => {
   const index = getIndexWithinAncestorFromComponentProps(props);
-  return (
-    <Trigger ref={ref} value={value ?? index} asChild={true} {...props}>
-      {firstChild ?? <button>Add button</button>}
-    </Trigger>
-  );
+  return <Trigger ref={ref} value={value ?? index} {...props} />;
 });
 
 export const TabsContent = forwardRef<
   HTMLDivElement,
-  Omit<ComponentPropsWithoutRef<typeof Content>, "asChild">
+  ComponentPropsWithoutRef<typeof Content>
 >(({ value, ...props }, ref) => {
   const index = getIndexWithinAncestorFromComponentProps(props);
   return <Content ref={ref} value={value ?? index} {...props} />;

--- a/packages/sdk-components-react-radix/src/tabs.ws.ts
+++ b/packages/sdk-components-react-radix/src/tabs.ws.ts
@@ -5,6 +5,7 @@ import {
   TriggerIcon,
 } from "@webstudio-is/icons/svg";
 import type {
+  EmbedTemplateStyleDecl,
   PresetStyle,
   WsComponentMeta,
   WsComponentPropsMeta,
@@ -30,6 +31,39 @@ const presetStyle = {
  * MIT License
  * Copyright (c) 2023 shadcn
  **/
+
+// inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all
+// focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
+// disabled:pointer-events-none disabled:opacity-50
+// data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm
+const tabsTriggerStyles = [
+  tc.inlineFlex(),
+  tc.items("center"),
+  tc.justify("center"),
+  tc.whitespace("nowrap"),
+  tc.rounded("md"),
+  tc.px(3),
+  tc.py(1.5),
+  tc.text("sm"),
+  tc.font("medium"),
+  tc.transition("all"),
+  tc.focusVisible(
+    [tc.outline("none"), tc.ring("ring", 2, "background", 2)].flat()
+  ),
+  tc.disabled([tc.pointerEvents("none"), tc.opacity(50)].flat()),
+  tc.state(
+    [tc.bg("background"), tc.text("foreground"), tc.shadow("sm")].flat(),
+    "[data-state=active]"
+  ),
+].flat();
+
+// mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
+const tabsContentStyles: EmbedTemplateStyleDecl[] = [
+  tc.mt(2),
+  tc.focusVisible(
+    [tc.outline("none"), tc.ring("ring", 2, "background", 2)].flat()
+  ),
+].flat();
 
 export const metaTabs: WsComponentMeta = {
   category: "radix",
@@ -58,18 +92,28 @@ export const metaTabs: WsComponentMeta = {
         {
           type: "instance",
           component: "TabsList",
-          tokens: ["tabsList"],
+          // inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground
+          styles: [
+            tc.inlineFlex(),
+            tc.h(10),
+            tc.items("center"),
+            tc.justify("center"),
+            tc.rounded("md"),
+            tc.bg("muted"),
+            tc.p(1),
+            tc.text("mutedForeground"),
+          ].flat(),
           children: [
             {
               type: "instance",
               component: "TabsTrigger",
-              tokens: ["tabsTrigger"],
+              styles: tabsTriggerStyles,
               children: [{ type: "text", value: "Account" }],
             },
             {
               type: "instance",
               component: "TabsTrigger",
-              tokens: ["tabsTrigger"],
+              styles: tabsTriggerStyles,
               children: [{ type: "text", value: "Password" }],
             },
           ],
@@ -77,7 +121,7 @@ export const metaTabs: WsComponentMeta = {
         {
           type: "instance",
           component: "TabsContent",
-          tokens: ["tabsContent"],
+          styles: tabsContentStyles,
           children: [
             { type: "text", value: "Make changes to your account here." },
           ],
@@ -85,7 +129,7 @@ export const metaTabs: WsComponentMeta = {
         {
           type: "instance",
           component: "TabsContent",
-          tokens: ["tabsContent"],
+          styles: tabsContentStyles,
           children: [{ type: "text", value: "Change your password here." }],
         },
       ],
@@ -100,21 +144,6 @@ export const metaTabsList: WsComponentMeta = {
   icon: HeaderIcon,
   requiredAncestors: ["Tabs"],
   presetStyle,
-  presetTokens: {
-    tabsList: {
-      // inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground
-      styles: [
-        tc.inlineFlex(),
-        tc.h(10),
-        tc.items("center"),
-        tc.justify("center"),
-        tc.rounded("md"),
-        tc.bg("muted"),
-        tc.p(1),
-        tc.text("mutedForeground"),
-      ].flat(),
-    },
-  },
 };
 
 export const metaTabsTrigger: WsComponentMeta = {
@@ -142,34 +171,6 @@ export const metaTabsTrigger: WsComponentMeta = {
       tc.border(0),
     ].flat(),
   },
-  presetTokens: {
-    tabsTrigger: {
-      // inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all
-      // focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
-      // disabled:pointer-events-none disabled:opacity-50
-      // data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm
-      styles: [
-        tc.inlineFlex(),
-        tc.items("center"),
-        tc.justify("center"),
-        tc.whitespace("nowrap"),
-        tc.rounded("md"),
-        tc.px(3),
-        tc.py(1.5),
-        tc.text("sm"),
-        tc.font("medium"),
-        tc.transition("all"),
-        tc.focusVisible(
-          [tc.outline("none"), tc.ring("ring", 2, "background", 2)].flat()
-        ),
-        tc.disabled([tc.pointerEvents("none"), tc.opacity(50)].flat()),
-        tc.state(
-          [tc.bg("background"), tc.text("foreground"), tc.shadow("sm")].flat(),
-          "[data-state=active]"
-        ),
-      ].flat(),
-    },
-  },
 };
 
 export const metaTabsContent: WsComponentMeta = {
@@ -179,17 +180,6 @@ export const metaTabsContent: WsComponentMeta = {
   requiredAncestors: ["Tabs"],
   indexWithinAncestor: "Tabs",
   presetStyle,
-  presetTokens: {
-    tabsContent: {
-      // mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
-      styles: [
-        tc.mt(2),
-        tc.focusVisible(
-          [tc.outline("none"), tc.ring("ring", 2, "background", 2)].flat()
-        ),
-      ].flat(),
-    },
-  },
 };
 
 export const propsMetaTabs: WsComponentPropsMeta = {

--- a/packages/sdk-components-react-radix/src/tabs.ws.ts
+++ b/packages/sdk-components-react-radix/src/tabs.ws.ts
@@ -5,12 +5,11 @@ import {
   TriggerIcon,
 } from "@webstudio-is/icons/svg";
 import type {
-  EmbedTemplateStyleDecl,
   PresetStyle,
   WsComponentMeta,
   WsComponentPropsMeta,
 } from "@webstudio-is/react-sdk";
-import { div } from "@webstudio-is/react-sdk/css-normalize";
+import { button, div } from "@webstudio-is/react-sdk/css-normalize";
 import * as tc from "./theme/tailwind-classes";
 import {
   propsTabs,
@@ -31,36 +30,6 @@ const presetStyle = {
  * MIT License
  * Copyright (c) 2023 shadcn
  **/
-
-// inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm
-const tabsTriggerStyles: EmbedTemplateStyleDecl[] = [
-  tc.inlineFlex(),
-  tc.items("center"),
-  tc.justify("center"),
-  tc.whitespace("nowrap"),
-  tc.rounded("md"),
-  tc.px(3),
-  tc.py(1.5),
-  tc.text("sm"),
-  tc.font("medium"),
-  tc.transition("all"),
-  tc.focusVisible(
-    [tc.outline("none"), tc.ring("ring", 2, "background", 2)].flat()
-  ),
-  tc.disabled([tc.pointerEvents("none"), tc.opacity(50)].flat()),
-  tc.state(
-    [tc.bg("background"), tc.text("foreground"), tc.shadow("sm")].flat(),
-    "[data-state=active]"
-  ),
-].flat();
-
-// mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
-const tabsContentStyles: EmbedTemplateStyleDecl[] = [
-  tc.mt(2),
-  tc.focusVisible(
-    [tc.outline("none"), tc.ring("ring", 2, "background", 2)].flat()
-  ),
-].flat();
 
 export const metaTabs: WsComponentMeta = {
   category: "radix",
@@ -89,48 +58,26 @@ export const metaTabs: WsComponentMeta = {
         {
           type: "instance",
           component: "TabsList",
-          // inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground
-          styles: [
-            tc.inlineFlex(),
-            tc.h(10),
-            tc.items("center"),
-            tc.justify("center"),
-            tc.rounded("md"),
-            tc.bg("muted"),
-            tc.p(1),
-            tc.text("mutedForeground"),
-          ].flat(),
+          tokens: ["tabsList"],
           children: [
             {
               type: "instance",
               component: "TabsTrigger",
-              children: [
-                {
-                  type: "instance",
-                  component: "Button",
-                  styles: tabsTriggerStyles,
-                  children: [{ type: "text", value: "Account" }],
-                },
-              ],
+              tokens: ["tabsTrigger"],
+              children: [{ type: "text", value: "Account" }],
             },
             {
               type: "instance",
               component: "TabsTrigger",
-              children: [
-                {
-                  type: "instance",
-                  component: "Button",
-                  styles: tabsTriggerStyles,
-                  children: [{ type: "text", value: "Password" }],
-                },
-              ],
+              tokens: ["tabsTrigger"],
+              children: [{ type: "text", value: "Password" }],
             },
           ],
         },
         {
           type: "instance",
           component: "TabsContent",
-          styles: tabsContentStyles,
+          tokens: ["tabsContent"],
           children: [
             { type: "text", value: "Make changes to your account here." },
           ],
@@ -138,7 +85,7 @@ export const metaTabs: WsComponentMeta = {
         {
           type: "instance",
           component: "TabsContent",
-          styles: tabsContentStyles,
+          tokens: ["tabsContent"],
           children: [{ type: "text", value: "Change your password here." }],
         },
       ],
@@ -153,6 +100,21 @@ export const metaTabsList: WsComponentMeta = {
   icon: HeaderIcon,
   requiredAncestors: ["Tabs"],
   presetStyle,
+  presetTokens: {
+    tabsList: {
+      // inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground
+      styles: [
+        tc.inlineFlex(),
+        tc.h(10),
+        tc.items("center"),
+        tc.justify("center"),
+        tc.rounded("md"),
+        tc.bg("muted"),
+        tc.p(1),
+        tc.text("mutedForeground"),
+      ].flat(),
+    },
+  },
 };
 
 export const metaTabsTrigger: WsComponentMeta = {
@@ -162,6 +124,52 @@ export const metaTabsTrigger: WsComponentMeta = {
   requiredAncestors: ["TabsList"],
   invalidAncestors: ["TabsTrigger"],
   indexWithinAncestor: "Tabs",
+  presetStyle: {
+    button: [
+      button,
+      {
+        property: "backgroundColor",
+        value: { type: "keyword", value: "transparent" },
+      } as const,
+      {
+        property: "backgroundImage",
+        value: { type: "keyword", value: "none" },
+      } as const,
+      {
+        property: "cursor",
+        value: { type: "keyword", value: "pointer" },
+      } as const,
+      tc.border(0),
+    ].flat(),
+  },
+  presetTokens: {
+    tabsTrigger: {
+      // inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all
+      // focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
+      // disabled:pointer-events-none disabled:opacity-50
+      // data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm
+      styles: [
+        tc.inlineFlex(),
+        tc.items("center"),
+        tc.justify("center"),
+        tc.whitespace("nowrap"),
+        tc.rounded("md"),
+        tc.px(3),
+        tc.py(1.5),
+        tc.text("sm"),
+        tc.font("medium"),
+        tc.transition("all"),
+        tc.focusVisible(
+          [tc.outline("none"), tc.ring("ring", 2, "background", 2)].flat()
+        ),
+        tc.disabled([tc.pointerEvents("none"), tc.opacity(50)].flat()),
+        tc.state(
+          [tc.bg("background"), tc.text("foreground"), tc.shadow("sm")].flat(),
+          "[data-state=active]"
+        ),
+      ].flat(),
+    },
+  },
 };
 
 export const metaTabsContent: WsComponentMeta = {
@@ -171,6 +179,17 @@ export const metaTabsContent: WsComponentMeta = {
   requiredAncestors: ["Tabs"],
   indexWithinAncestor: "Tabs",
   presetStyle,
+  presetTokens: {
+    tabsContent: {
+      // mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
+      styles: [
+        tc.mt(2),
+        tc.focusVisible(
+          [tc.outline("none"), tc.ring("ring", 2, "background", 2)].flat()
+        ),
+      ].flat(),
+    },
+  },
 };
 
 export const propsMetaTabs: WsComponentPropsMeta = {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/2151

Separate buttons from tab triggers does not make much sense and complicate logic.
Here I merged tab trigger and button into single styleable component.

<img width="284" alt="image" src="https://github.com/webstudio-is/webstudio-builder/assets/5635476/94f7c8e5-d876-4949-81d5-9472f054bb5e">


## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
