### PR TITLE
Fix parent style calculation for unstylable parent components

### DIFF
--- a/apps/builder/app/builder/features/style-panel/parent-style.ts
+++ b/apps/builder/app/builder/features/style-panel/parent-style.ts
@@ -1,0 +1,31 @@
+import { useStore } from "@nanostores/react";
+import { useStyleInfoByInstanceId } from "./shared/style-info";
+import {
+  instancesStore,
+  registeredComponentMetasStore,
+  selectedInstanceSelectorStore,
+} from "~/shared/nano-states";
+
+/**
+ * Gets styleable parent style
+ **/
+export const useParentStyle = () => {
+  const selectedInstanceSelector = useStore(selectedInstanceSelectorStore);
+  const instances = useStore(instancesStore);
+  const registeredComponentMetas = useStore(registeredComponentMetasStore);
+
+  let parentInstanceSelector: string[] | undefined = undefined;
+  for (let i = 1; i < (selectedInstanceSelector?.length ?? 0); ++i) {
+    parentInstanceSelector = selectedInstanceSelector!.slice(i);
+    const component = instances.get(parentInstanceSelector[0])?.component;
+    const meta = component
+      ? registeredComponentMetas.get(component)
+      : undefined;
+    if (meta?.stylable !== false) {
+      break;
+    }
+  }
+
+  const parentStyleInfo = useStyleInfoByInstanceId(parentInstanceSelector);
+  return parentStyleInfo;
+};

--- a/apps/builder/app/builder/features/style-panel/sections/position/position.tsx
+++ b/apps/builder/app/builder/features/style-panel/sections/position/position.tsx
@@ -6,23 +6,9 @@ import { SelectControl, TextControl } from "../../controls";
 import { PropertyName } from "../../shared/property-name";
 import { styleConfigByName } from "../../shared/configs";
 import { PositionControl } from "./position-control";
-import { useStyleInfoByInstanceId } from "../../shared/style-info";
-import { selectedInstanceSelectorStore } from "~/shared/nano-states";
-import { useStore } from "@nanostores/react";
+import { useParentStyle } from "../../parent-style";
 
 const properties: StyleProperty[] = ["position"];
-
-const useParentStyle = () => {
-  const selectedInstanceSelector = useStore(selectedInstanceSelectorStore);
-  const parentInstanceSelector =
-    // root does not have parent
-    selectedInstanceSelector?.length === 1
-      ? undefined
-      : selectedInstanceSelector?.slice(1);
-  const parentStyleInfo = useStyleInfoByInstanceId(parentInstanceSelector);
-
-  return parentStyleInfo;
-};
 
 const positionControlVisibleProperties = [
   "relative",

--- a/apps/builder/app/builder/features/style-panel/style-settings.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-settings.tsx
@@ -13,26 +13,14 @@ import {
   selectedInstanceIntanceToTagStore,
   selectedInstanceSelectorStore,
 } from "~/shared/nano-states";
-import { useStyleInfoByInstanceId } from "./shared/style-info";
 import { computed } from "nanostores";
+import { useParentStyle } from "./parent-style";
 
 export type StyleSettingsProps = {
   currentStyle: StyleInfo;
   setProperty: SetProperty;
   deleteProperty: (property: StyleProperty) => void;
   createBatchUpdate: CreateBatchUpdate;
-};
-
-const useParentStyle = () => {
-  const selectedInstanceSelector = useStore(selectedInstanceSelectorStore);
-  const parentInstanceSelector =
-    // root does not have parent
-    selectedInstanceSelector?.length === 1
-      ? undefined
-      : selectedInstanceSelector?.slice(1);
-  const parentStyleInfo = useStyleInfoByInstanceId(parentInstanceSelector);
-
-  return parentStyleInfo;
 };
 
 const selectedInstanceTagStore = computed(

--- a/packages/sdk-components-react-radix/src/button.ws.ts
+++ b/packages/sdk-components-react-radix/src/button.ws.ts
@@ -169,5 +169,5 @@ export const meta: WsComponentMeta = {
 
 export const propsMeta: WsComponentPropsMeta = {
   props,
-  initialProps: ["id", "type", "variant", "size", "aria-label"],
+  initialProps: ["id", "type", "aria-label"],
 };

--- a/packages/sdk-components-react-radix/src/dialog.ws.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.ws.tsx
@@ -272,7 +272,7 @@ export const metaDialog: WsComponentMeta = {
 
 export const propsMetaDialog: WsComponentPropsMeta = {
   props: propsDialog,
-  initialProps: ["open", "modal"],
+  initialProps: ["open"],
 };
 
 export const propsMetaDialogTrigger: WsComponentPropsMeta = {

--- a/packages/sdk-components-react-radix/src/popover.ws.tsx
+++ b/packages/sdk-components-react-radix/src/popover.ws.tsx
@@ -111,7 +111,7 @@ export const metaPopover: WsComponentMeta = {
 
 export const propsMetaPopover: WsComponentPropsMeta = {
   props: propsPopover,
-  initialProps: ["open", "modal"],
+  initialProps: ["open"],
 };
 
 export const propsMetaPopoverTrigger: WsComponentPropsMeta = {

--- a/packages/sdk-components-react-radix/src/sheet.ws.tsx
+++ b/packages/sdk-components-react-radix/src/sheet.ws.tsx
@@ -306,7 +306,7 @@ export const metaSheet: WsComponentMeta = {
 
 export const propsMetaSheet: WsComponentPropsMeta = {
   props: propsSheet,
-  initialProps: ["open", "modal"],
+  initialProps: ["open"],
 };
 
 export const propsMetaSheetTrigger: WsComponentPropsMeta = {


### PR DESCRIPTION
## Description

If the parent component has `meta.stylable = false`, we need to skip it to get the correct style of the parent.


## Steps for reproduction

Create the Box and add the Sheet to it. 
When you go to the sheet/trigger/button, you will notice that it does not have a 'Flex Child' section or a 'zIndex' property. 

To add these, add 'display: flex' to the box you created initially. When you go back to the sheet/trigger/button, you will see that it now has a 'Flex Child' section and a 'zIndex' property.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
