### PR TITLE
Fix new href property duplicated on unmount

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
+++ b/apps/builder/app/builder/features/settings-panel/props-section/props-section.tsx
@@ -217,6 +217,17 @@ export const PropsSectionContainer = ({
         dataSourceVariablesStore.set(dataSourceVariables);
       } else {
         store.createTransaction([propsStore], (props) => {
+          const istanceProps = propsByInstanceId.get(instance.id) ?? [];
+          // Fixing a bug that caused some props to be duplicated on unmount by removing duplicates.
+          // see for details https://github.com/webstudio-is/webstudio-builder/pull/2170
+          const duplicateProps = istanceProps
+            .filter((prop) => prop.id !== update.id)
+            .filter((prop) => prop.name === update.name);
+
+          for (const prop of duplicateProps) {
+            props.delete(prop.id);
+          }
+
           props.set(update.id, update);
         });
       }

--- a/apps/builder/app/builder/features/settings-panel/shared.tsx
+++ b/apps/builder/app/builder/features/settings-panel/shared.tsx
@@ -87,10 +87,13 @@ export const useLocalValue = <Type,>(
 
   const [_, setRefresh] = useState(0);
 
+  const onSaveRef = useRef(onSave);
+  onSaveRef.current = onSave;
+
   const save = () => {
     if (equal(localValueRef.current, savedValue) === false) {
       // To synchronize with setState immediately followed by save
-      onSave(localValueRef.current);
+      onSaveRef.current(localValueRef.current);
     }
   };
 

--- a/packages/react-sdk/src/props.test.ts
+++ b/packages/react-sdk/src/props.test.ts
@@ -87,6 +87,24 @@ describe("resolveUrlProp", () => {
     value: unique(),
   };
 
+  const duplicatePropName = unique();
+
+  const duplicateUrlPropFirst: Prop = {
+    type: "string",
+    id: unique(),
+    instanceId,
+    name: duplicatePropName,
+    value: unique(),
+  };
+
+  const duplicateUrlPropSecond: Prop = {
+    type: "string",
+    id: unique(),
+    instanceId,
+    name: duplicatePropName,
+    value: unique(),
+  };
+
   const props: PropsByInstanceId = new Map([
     [
       instanceId,
@@ -96,6 +114,8 @@ describe("resolveUrlProp", () => {
         arbitraryUrlProp,
         assetProp,
         pageSectionProp,
+        duplicateUrlPropFirst,
+        duplicateUrlPropSecond,
       ],
     ],
     [instnaceIdProp.instanceId, [instnaceIdProp]],
@@ -154,6 +174,15 @@ describe("resolveUrlProp", () => {
     expect(resolveUrlProp(instanceId, arbitraryUrlProp.name, stores)).toEqual({
       type: "string",
       url: arbitraryUrlProp.value,
+    });
+  });
+
+  // We had a bug that some props were duplicated https://github.com/webstudio-is/webstudio-builder/pull/2170
+  // Use the latest prop to ensure consistency with the builder settings panel.
+  test("duplicate prop name", () => {
+    expect(resolveUrlProp(instanceId, duplicatePropName, stores)).toEqual({
+      type: "string",
+      url: duplicateUrlPropSecond.value,
     });
   });
 });

--- a/packages/react-sdk/src/props.ts
+++ b/packages/react-sdk/src/props.ts
@@ -147,54 +147,64 @@ export const resolveUrlProp = (
   if (instanceProps === undefined) {
     return;
   }
-  for (const prop of instanceProps) {
-    if (prop.name !== name) {
+
+  let prop = undefined;
+
+  // We had a bug that some props were duplicated https://github.com/webstudio-is/webstudio-builder/pull/2170
+  // Use the latest prop to ensure consistency with the builder settings panel.
+  for (const intanceProp of instanceProps) {
+    if (intanceProp.name !== name) {
       continue;
     }
+    prop = intanceProp;
+  }
 
-    if (prop.type === "page") {
-      if (typeof prop.value === "string") {
-        const page = pages.get(prop.value);
-        return page && { type: "page", page };
-      }
-
-      const { instanceId, pageId } = prop.value;
-
-      const page = pages.get(pageId);
-
-      if (page === undefined) {
-        return;
-      }
-
-      const idProp = props.get(instanceId)?.find((prop) => prop.name === "id");
-
-      return {
-        type: "page",
-        page,
-        instanceId,
-        hash:
-          idProp === undefined || idProp.type !== "string"
-            ? undefined
-            : idProp.value,
-      };
-    }
-
-    if (prop.type === "string") {
-      for (const page of pages.values()) {
-        if (page.path === prop.value) {
-          return { type: "page", page };
-        }
-      }
-      return { type: "string", url: prop.value };
-    }
-
-    if (prop.type === "asset") {
-      const asset = assets.get(prop.value);
-      return asset && { type: "asset", asset };
-    }
-
+  if (prop === undefined) {
     return;
   }
+
+  if (prop.type === "page") {
+    if (typeof prop.value === "string") {
+      const page = pages.get(prop.value);
+      return page && { type: "page", page };
+    }
+
+    const { instanceId, pageId } = prop.value;
+
+    const page = pages.get(pageId);
+
+    if (page === undefined) {
+      return;
+    }
+
+    const idProp = props.get(instanceId)?.find((prop) => prop.name === "id");
+
+    return {
+      type: "page",
+      page,
+      instanceId,
+      hash:
+        idProp === undefined || idProp.type !== "string"
+          ? undefined
+          : idProp.value,
+    };
+  }
+
+  if (prop.type === "string") {
+    for (const page of pages.values()) {
+      if (page.path === prop.value) {
+        return { type: "page", page };
+      }
+    }
+    return { type: "string", url: prop.value };
+  }
+
+  if (prop.type === "asset") {
+    const asset = assets.get(prop.value);
+    return asset && { type: "asset", asset };
+  }
+
+  return;
 };
 
 // this utility is used for link component in both builder and preview


### PR DESCRIPTION
## Description

On onmount outdated onSave were used. What cause creation of additional href property on instance.

- [x] - Fix duplication on unmount (1st commit)
- [x] - Fix save, to validate if multiple properties with same name exists. (2nd commit)
- [x] - Use latest prop in resolveUrlProp (3rd commit)

Use hide whitespaces.

<img width="303" alt="image" src="https://github.com/webstudio-is/webstudio-builder/assets/5077042/156fc5a4-c697-4b05-8caf-7a3b7fa29264">


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
