### PR TITLE
Fix font weight detection of uploaded fonts

### DIFF
--- a/packages/fonts/src/font-data.ts
+++ b/packages/fonts/src/font-data.ts
@@ -25,9 +25,8 @@ export const parseSubfamily = (subfamily: string) => {
   }
   let weight: FontWeight = "400";
   for (weight in fontWeights) {
-    const { name } = fontWeights[weight];
-    const { alt } = fontWeights[weight];
-    if (subfamilyLow.includes(name) || subfamilyLow.includes(alt)) {
+    const { names } = fontWeights[weight];
+    if (names.some((name) => subfamilyLow.includes(name))) {
       break;
     }
   }

--- a/packages/fonts/src/font-weights.ts
+++ b/packages/fonts/src/font-weights.ts
@@ -1,52 +1,40 @@
 export const fontWeights = {
   "100": {
     label: "Thin",
-    name: "thin",
-    alt: "hairline",
+    names: ["thin", "hairline"],
   },
   "200": {
     label: "Extra Light",
-    name: "extra light",
-    alt: "ultra light",
+    names: ["extra light", "extralight", "ultra light", "ultralight"],
   },
   "300": {
     label: "Light",
-    name: "light",
-    alt: "light",
+    names: ["light"],
   },
   "400": {
     label: "Normal",
-    name: "normal",
-    alt: "normal",
+    names: ["normal", "regular"],
   },
   "500": {
     label: "Medium",
-    name: "medium",
-    alt: "medium",
+    names: ["medium"],
   },
   "600": {
     label: "Semi Bold",
-    name: "semi bold",
-    alt: "demi bold",
+    names: ["semi bold", "semibold", "demi bold", "demibold"],
   },
   "700": {
     label: "Bold",
-    name: "bold",
-    alt: "bold",
+    names: ["bold", "bold"],
   },
   "800": {
     label: "Extra Bold",
-    name: "extra bold",
-    alt: "ultra bold",
+    names: ["extra bold", "extrabold", "ultra bold", "ultrabold"],
   },
   "900": {
     label: "Black",
-    name: "black",
-    alt: "heavy",
+    names: ["black", "heavy"],
   },
 } as const;
 
 export type FontWeight = keyof typeof fontWeights;
-export type FontWeightKeyword =
-  | (typeof fontWeights)[FontWeight]["name"]
-  | (typeof fontWeights)[FontWeight]["alt"];


### PR DESCRIPTION
Ref https://discord.com/channels/955905230107738152/1144505313358254120

Here turns out there is not standard in naming font subfamilies. To fix I expanded the list of weights wiith spaceless variants. Added "regular" keyword to detect normal font weight.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
- [ ] hi @itsNintu, I need you to do
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
