### PR TITLE
Refactor navigation menu with local styles

### DIFF
--- a/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
+++ b/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
@@ -253,7 +253,14 @@ const menuItem = (props: {
       {
         type: "instance",
         component: "NavigationMenuContent",
-        tokens: ["navigationMenuContent"],
+        // left-0 top-0 absolute w-max
+        styles: [
+          tc.left(0),
+          tc.top(0),
+          tc.absolute(),
+          tc.w("max"),
+          tc.p(4),
+        ].flat(),
         children: [
           {
             type: "instance",
@@ -274,18 +281,11 @@ export const metaNavigationMenu: WsComponentMeta = {
   type: "container",
   icon: NavigationMenuIcon,
   presetStyle,
-  presetTokens: {
-    navigationMenu: {
-      // relative
-      // Omiting this: z-10 flex max-w-max flex-1 items-center justify-center
-      styles: [tc.relative()].flat(),
-    },
-  },
+
   template: [
     {
       type: "instance",
       component: "NavigationMenu",
-
       dataSources: {
         menuValue: { type: "variable", initialValue: "" },
       },
@@ -303,14 +303,25 @@ export const metaNavigationMenu: WsComponentMeta = {
           ],
         },
       ],
-
-      tokens: ["navigationMenu"],
-
+      // relative
+      // Omiting this: z-10 flex max-w-max flex-1 items-center justify-center
+      styles: [tc.relative()].flat(),
       children: [
         {
           type: "instance",
           component: "NavigationMenuList",
-          tokens: ["navigationMenuList"],
+          styles: [
+            // ul defaults in tailwind
+            tc.p(0),
+            tc.m(0),
+            // shadcdn styles
+            tc.flex(),
+            tc.flex(1),
+            tc.list("none"),
+            tc.items("center"),
+            tc.justify("center"),
+            tc.gap(1),
+          ].flat(),
           children: [
             ...menuItem({
               title: "About",
@@ -363,7 +374,31 @@ export const metaNavigationMenu: WsComponentMeta = {
             {
               type: "instance",
               component: "NavigationMenuViewport",
-              tokens: ["navigationMenuViewport"],
+              /*
+                origin-top-center relative mt-1.5 w-full
+                overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg
+                h-[var(--radix-navigation-menu-viewport-height)]
+                w-[var(--radix-navigation-menu-viewport-width)]
+                // anims
+                [animation-duration:150ms!important] [transition-duration:150ms!important]
+                data-[state=open]:animate-in data-[state=closed]:animate-out
+                data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90
+              */
+              styles: [
+                tc.relative(),
+                tc.mt(1.5),
+                tc.overflow("hidden"),
+                tc.rounded("md"),
+                tc.border(),
+                tc.bg("popover"),
+                tc.text("popoverForeground"),
+                tc.shadow("lg"),
+                tc.property(
+                  "height",
+                  "--radix-navigation-menu-viewport-height"
+                ),
+                tc.property("width", "--radix-navigation-menu-viewport-width"),
+              ].flat(),
               children: [],
             },
           ],
@@ -380,22 +415,6 @@ export const metaNavigationMenuList: WsComponentMeta = {
   icon: ListIcon,
   requiredAncestors: ["NavigationMenu"],
   presetStyle,
-  presetTokens: {
-    navigationMenuList: {
-      styles: [
-        // ul defaults in tailwind
-        tc.p(0),
-        tc.m(0),
-        // shadcdn styles
-        tc.flex(),
-        tc.flex(1),
-        tc.list("none"),
-        tc.items("center"),
-        tc.justify("center"),
-        tc.gap(1),
-      ].flat(),
-    },
-  },
 };
 
 export const metaNavigationMenuItem: WsComponentMeta = {
@@ -405,7 +424,6 @@ export const metaNavigationMenuItem: WsComponentMeta = {
   requiredAncestors: ["NavigationMenu"],
   presetStyle,
   indexWithinAncestor: "NavigationMenu",
-  // no default tokens
 };
 export const metaNavigationMenuTrigger: WsComponentMeta = {
   category: "hidden",
@@ -423,20 +441,6 @@ export const metaNavigationMenuContent: WsComponentMeta = {
   icon: ContentIcon,
   requiredAncestors: ["NavigationMenuItem"],
   indexWithinAncestor: "NavigationMenu",
-
-  presetTokens: {
-    navigationMenuContent: {
-      // left-0 top-0 absolute w-max
-      styles: [
-        tc.left(0),
-        tc.top(0),
-        tc.absolute(),
-        tc.w("max"),
-        tc.p(4),
-      ].flat(),
-    },
-  },
-
   presetStyle,
 };
 
@@ -457,32 +461,6 @@ export const metaNavigationMenuViewport: WsComponentMeta = {
   icon: ViewportIcon,
   requiredAncestors: ["NavigationMenu"],
   presetStyle,
-  presetTokens: {
-    navigationMenuViewport: {
-      /*
-        origin-top-center relative mt-1.5 w-full
-        overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg
-        h-[var(--radix-navigation-menu-viewport-height)]
-        w-[var(--radix-navigation-menu-viewport-width)]
-        // anims
-        [animation-duration:150ms!important] [transition-duration:150ms!important]
-        data-[state=open]:animate-in data-[state=closed]:animate-out
-        data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90
-      */
-      styles: [
-        tc.relative(),
-        tc.mt(1.5),
-        tc.overflow("hidden"),
-        tc.rounded("md"),
-        tc.border(),
-        tc.bg("popover"),
-        tc.text("popoverForeground"),
-        tc.shadow("lg"),
-        tc.property("height", "--radix-navigation-menu-viewport-height"),
-        tc.property("width", "--radix-navigation-menu-viewport-width"),
-      ].flat(),
-    },
-  },
 };
 
 export const propsMetaNavigationMenu: WsComponentPropsMeta = {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/2151

We decided to not use preset tokens for default styling and get back to local styles. Here migrated navigation menu.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
