### PR TITLE
Fix focus navigation in preview

### DIFF
--- a/apps/builder/app/canvas/canvas.tsx
+++ b/apps/builder/app/canvas/canvas.tsx
@@ -31,7 +31,10 @@ import {
 import { useSharedShortcuts } from "~/shared/shortcuts";
 import { useCanvasShortcuts } from "./canvas-shortcuts";
 import { useManageDesignModeStyles, GlobalStyles } from "./shared/styles";
-import { WebstudioComponentDev } from "./features/webstudio-component";
+import {
+  WebstudioComponentCanvas,
+  WebstudioComponentPreview,
+} from "./features/webstudio-component";
 import {
   propsIndexStore,
   assetsStore,
@@ -135,7 +138,9 @@ const useElementsTree = (
       executeEffectfulExpression:
         executeEffectfulExpressionWithDecodedVariables,
       onDataSourceUpdate,
-      Component: WebstudioComponentDev,
+      Component: isPreviewMode
+        ? WebstudioComponentPreview
+        : WebstudioComponentCanvas,
       components,
       scripts: (
         <>

--- a/apps/builder/app/canvas/features/webstudio-component/index.ts
+++ b/apps/builder/app/canvas/features/webstudio-component/index.ts
@@ -1,1 +1,1 @@
-export { WebstudioComponentDev } from "./webstudio-component";
+export * from "./webstudio-component";

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -4,7 +4,6 @@ import {
   type ForwardedRef,
   useRef,
   useLayoutEffect,
-  useContext,
 } from "react";
 import { Suspense, lazy } from "react";
 import { useStore } from "@nanostores/react";
@@ -23,7 +22,6 @@ import {
   showAttribute,
   useInstanceProps,
   selectorIdAttribute,
-  ReactSdkContext,
 } from "@webstudio-is/react-sdk";
 import {
   instancesStore,
@@ -39,7 +37,6 @@ import {
   areInstanceSelectorsEqual,
 } from "~/shared/tree-utils";
 import { mergeRefs } from "@react-aria/utils";
-import { composeEventHandlers } from "@radix-ui/primitive";
 import { setDataCollapsed } from "~/canvas/collapsed";
 import { getIsVisuallyHidden } from "~/shared/visually-hidden";
 
@@ -124,9 +121,9 @@ const getInstanceSelector = (
   return undefined;
 };
 
-type WebstudioComponentDevProps = {
+type WebstudioComponentProps = {
   instance: Instance;
-  instanceSelector: InstanceSelector;
+  instanceSelector: Instance["id"][];
   children: Array<JSX.Element | string>;
   components: Components;
 };
@@ -149,12 +146,48 @@ const useCollapsedOnNewElement = (instanceId: Instance["id"]) => {
   }, [instanceId]);
 };
 
+/**
+ * We combine Radix's implicit event handlers with user-defined ones,
+ * such as onClick or onSubmit. For instance, a Button within
+ * a TooltipTrigger receives an onClick handler from the TooltipTrigger.
+ * We might also need an additional onClick handler on the Button for other
+ * purposes (setting variable).
+ **/
+const mergeProps = (
+  restProps: Record<string, any>,
+  instanceProps: Record<string, any>,
+  callbackStrategy: "merge" | "delete"
+) => {
+  // merge props into single object
+  const props = { ...restProps, ...instanceProps };
+  for (const propName of Object.keys(props)) {
+    const restPropValue = restProps[propName];
+    const instancePropValue = instanceProps[propName];
+
+    const isHandler = /^on[A-Z]/.test(propName);
+    if (isHandler === false) {
+      continue;
+    }
+    // combine handlers for preview
+    if (callbackStrategy === "merge") {
+      props[propName] = (...args: unknown[]) => {
+        restPropValue?.(...args);
+        instancePropValue?.(...args);
+      };
+    }
+    // delete all handlers from canvas mode
+    if (callbackStrategy === "delete") {
+      delete props[propName];
+    }
+  }
+  return props;
+};
+
 // eslint-disable-next-line react/display-name
-export const WebstudioComponentDev = forwardRef<
+export const WebstudioComponentCanvas = forwardRef<
   HTMLElement,
-  WebstudioComponentDevProps
+  WebstudioComponentProps
 >(({ instance, instanceSelector, children, components, ...restProps }, ref) => {
-  const { renderer } = useContext(ReactSdkContext);
   const instanceId = instance.id;
   const instanceStyles = useInstanceStyles(instanceId);
   useCssRules({ instanceId: instance.id, instanceStyles });
@@ -207,40 +240,14 @@ export const WebstudioComponentDev = forwardRef<
     [componentAttribute]: string;
     [idAttribute]: string;
   } & Record<string, unknown> = {
-    ...instanceProps,
-    tabIndex: 0,
-    [componentAttribute]: instance.component,
-    [idAttribute]: instance.id,
-    [selectorIdAttribute]: instanceSelector.join(","),
-  };
-
-  for (const [name, value] of Object.entries(restProps)) {
-    if (typeof value === "function") {
-      // prevent passing any callbacks from outside while in canvas mode
-      // for example radix triggers bypass callbacks to button child
-      if (renderer === "canvas") {
-        continue;
-      }
-      /**
-       * We combine Radix's implicit event handlers with user-defined ones,
-       * such as onClick or onSubmit. For instance, a Button within
-       * a TooltipTrigger receives an onClick handler from the TooltipTrigger.
-       * We might also need an additional onClick handler on the Button for other
-       * purposes (setting variable).
-       **/
-      if (name.startsWith("on") && typeof props[name] === "function") {
-        type Callback = (event: unknown) => void;
-        props[name] = composeEventHandlers(
-          value as Callback,
-          props[name] as Callback
-        );
-        continue;
-      }
-    }
+    ...mergeProps(restProps, instanceProps, "delete"),
     // current props should override bypassed from parent
     // important for data-ws-* props
-    props[name] = props[name] ?? value;
-  }
+    tabIndex: 0,
+    [selectorIdAttribute]: instanceSelector.join(","),
+    [componentAttribute]: instance.component,
+    [idAttribute]: instance.id,
+  };
 
   const instanceElement = (
     <>
@@ -299,5 +306,34 @@ export const WebstudioComponentDev = forwardRef<
         }}
       />
     </Suspense>
+  );
+});
+
+// eslint-disable-next-line react/display-name
+export const WebstudioComponentPreview = forwardRef<
+  HTMLElement,
+  WebstudioComponentProps
+>(({ instance, instanceSelector, children, components, ...restProps }, ref) => {
+  const instanceStyles = useInstanceStyles(instance.id);
+  useCssRules({ instanceId: instance.id, instanceStyles });
+  const { [showAttribute]: show = true, ...instanceProps } = useInstanceProps(
+    instance.id
+  );
+  const props = {
+    ...mergeProps(restProps, instanceProps, "merge"),
+    [idAttribute]: instance.id,
+    [componentAttribute]: instance.component,
+  };
+  if (show === false) {
+    return <></>;
+  }
+  const Component = components.get(instance.component);
+  if (Component === undefined) {
+    return <></>;
+  }
+  return (
+    <Component {...props} ref={ref}>
+      {renderWebstudioComponentChildren(children)}
+    </Component>
   );
 });

--- a/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
+++ b/apps/builder/app/canvas/features/webstudio-component/webstudio-component.tsx
@@ -154,7 +154,11 @@ const useCollapsedOnNewElement = (instanceId: Instance["id"]) => {
  * purposes (setting variable).
  **/
 const mergeProps = (
+  // here we assume all on* props are callbacks
+  // cast to avoid extra checks
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   restProps: Record<string, any>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   instanceProps: Record<string, any>,
   callbackStrategy: "merge" | "delete"
 ) => {

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -27,7 +27,6 @@
     "@lexical/selection": "^0.11.3",
     "@lexical/utils": "^0.11.3",
     "@nanostores/react": "^0.7.1",
-    "@radix-ui/primitive": "1.0.1",
     "@radix-ui/react-select": "^1.2.2",
     "@radix-ui/react-tooltip": "^1.0.6",
     "@react-aria/interactions": "^3.17.0",

--- a/packages/react-sdk/src/props.ts
+++ b/packages/react-sdk/src/props.ts
@@ -31,7 +31,6 @@ export const useInstanceProps = (instanceId: Instance["id"]) => {
     dataSourceValuesStore,
     executeEffectfulExpression,
     setDataSourceValues,
-    renderer,
     indexesWithinAncestors,
   } = useContext(ReactSdkContext);
   const index = indexesWithinAncestors.get(instanceId);
@@ -61,10 +60,6 @@ export const useInstanceProps = (instanceId: Instance["id"]) => {
           }
           if (prop.type === "action") {
             instancePropsObject[prop.name] = (...args: unknown[]) => {
-              // prevent all actions in canvas mode
-              if (renderer === "canvas") {
-                return;
-              }
               for (const value of prop.value) {
                 if (value.type === "execute") {
                   const argsMap = new Map<string, unknown>();
@@ -91,7 +86,6 @@ export const useInstanceProps = (instanceId: Instance["id"]) => {
     propsByInstanceIdStore,
     dataSourceValuesStore,
     instanceId,
-    renderer,
     executeEffectfulExpression,
     setDataSourceValues,
     index,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,6 @@ importers:
       '@nanostores/react':
         specifier: ^0.7.1
         version: 0.7.1(nanostores@0.9.3)(react@18.2.0)
-      '@radix-ui/primitive':
-        specifier: 1.0.1
-        version: 1.0.1
       '@radix-ui/react-select':
         specifier: ^1.2.2
         version: 1.2.2(@types/react-dom@18.2.7)(@types/react@18.2.20)(react-dom@18.2.0)(react@18.2.0)


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/2151 https://github.com/webstudio-is/webstudio-builder/pull/2112

Here splitted webstudio component wrapper for preview and canvas. This allows us to have more granular control over preview behavior. For example canvas requres all elements to be focusable for instance selection to work. Prevew should be close to published sites and reflect user experience.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
