### PR TITLE
Refactor shadcn sheet with radix dialog

### DIFF
--- a/packages/sdk-components-react-radix/src/components.ts
+++ b/packages/sdk-components-react-radix/src/components.ts
@@ -14,15 +14,6 @@ export {
 } from "./dialog";
 export { Popover, PopoverTrigger, PopoverContent } from "./popover";
 export { Tooltip, TooltipTrigger, TooltipContent } from "./tooltip";
-export {
-  Sheet,
-  SheetTrigger,
-  SheetOverlay,
-  SheetContent,
-  SheetClose,
-  SheetTitle,
-  SheetDescription,
-} from "./sheet";
 export { Tabs, TabsList, TabsTrigger, TabsContent } from "./tabs";
 export { Label } from "./label";
 export {

--- a/packages/sdk-components-react-radix/src/metas.ts
+++ b/packages/sdk-components-react-radix/src/metas.ts
@@ -12,6 +12,7 @@ export {
   metaDialogTitle as DialogTitle,
   metaDialogDescription as DialogDescription,
 } from "./dialog.ws";
+export { meta as Sheet } from "./sheet.ws";
 export {
   metaPopover as Popover,
   metaPopoverTrigger as PopoverTrigger,
@@ -22,15 +23,6 @@ export {
   metaTooltipTrigger as TooltipTrigger,
   metaTooltipContent as TooltipContent,
 } from "./tooltip.ws";
-export {
-  metaSheet as Sheet,
-  metaSheetTrigger as SheetTrigger,
-  metaSheetOverlay as SheetOverlay,
-  metaSheetContent as SheetContent,
-  metaSheetClose as SheetClose,
-  metaSheetTitle as SheetTitle,
-  metaSheetDescription as SheetDescription,
-} from "./sheet.ws";
 export {
   metaTabs as Tabs,
   metaTabsList as TabsList,

--- a/packages/sdk-components-react-radix/src/props.ts
+++ b/packages/sdk-components-react-radix/src/props.ts
@@ -23,15 +23,6 @@ export {
   propsMetaTooltipContent as TooltipContent,
 } from "./tooltip.ws";
 export {
-  propsMetaSheet as Sheet,
-  propsMetaSheetTrigger as SheetTrigger,
-  propsMetaSheetOverlay as SheetOverlay,
-  propsMetaSheetContent as SheetContent,
-  propsMetaSheetClose as SheetClose,
-  propsMetaSheetTitle as SheetTitle,
-  propsMetaSheetDescription as SheetDescription,
-} from "./sheet.ws";
-export {
   propsMetaTabs as Tabs,
   propsMetaTabsList as TabsList,
   propsMetaTabsTrigger as TabsTrigger,

--- a/packages/sdk-components-react-radix/src/sheet.ws.tsx
+++ b/packages/sdk-components-react-radix/src/sheet.ws.tsx
@@ -1,106 +1,7 @@
-import type { ComponentProps } from "react";
-import {
-  HamburgerMenuIcon,
-  TriggerIcon,
-  ContentIcon,
-  OverlayIcon,
-  HeadingIcon,
-  TextIcon,
-  ButtonElementIcon,
-} from "@webstudio-is/icons/svg";
-import {
-  type PresetStyle,
-  type WsComponentMeta,
-  type WsComponentPropsMeta,
-} from "@webstudio-is/react-sdk";
-import { div, nav, button, h2, p } from "@webstudio-is/react-sdk/css-normalize";
+import { HamburgerMenuIcon } from "@webstudio-is/icons/svg";
+import type { WsComponentMeta } from "@webstudio-is/react-sdk";
 import * as tc from "./theme/tailwind-classes";
 import { getButtonStyles } from "./theme/styles";
-import {
-  propsSheet,
-  propsSheetContent,
-  propsSheetTrigger,
-  propsSheetOverlay,
-  propsSheetClose,
-  propsSheetTitle,
-  propsSheetDescription,
-} from "./__generated__/sheet.props";
-import type { SheetContent } from "./sheet";
-
-type ContentTags = NonNullable<ComponentProps<typeof SheetContent>["tag"]>;
-
-const contentPresetStyle = {
-  div,
-  nav,
-} satisfies PresetStyle<ContentTags>;
-
-const presetStyle = {
-  div,
-} satisfies PresetStyle<"div">;
-
-const buttonPresetStyle = {
-  button,
-} satisfies PresetStyle<"button">;
-
-const titlePresetStyle = {
-  h2,
-} satisfies PresetStyle<"h2">;
-
-const descriptionPresetStyle = {
-  p,
-} satisfies PresetStyle<"p">;
-
-// @todo add [data-state] to button and link
-export const metaSheetTrigger: WsComponentMeta = {
-  category: "hidden",
-  type: "container",
-  icon: TriggerIcon,
-  stylable: false,
-  detachable: false,
-};
-
-export const metaSheetContent: WsComponentMeta = {
-  category: "hidden",
-  type: "container",
-  icon: ContentIcon,
-  detachable: false,
-  presetStyle: contentPresetStyle,
-  states: [
-    { selector: "[data-side=top]", label: "Top Side" },
-    { selector: "[data-side=right]", label: "Right Side" },
-    { selector: "[data-side=bottom]", label: "Bottom Side" },
-    { selector: "[data-side=left]", label: "Left Side" },
-  ],
-};
-
-export const metaSheetOverlay: WsComponentMeta = {
-  category: "hidden",
-  type: "container",
-  presetStyle,
-  icon: OverlayIcon,
-  detachable: false,
-};
-
-export const metaSheetTitle: WsComponentMeta = {
-  category: "hidden",
-  type: "container",
-  presetStyle: titlePresetStyle,
-  icon: HeadingIcon,
-};
-
-export const metaSheetDescription: WsComponentMeta = {
-  category: "hidden",
-  type: "container",
-  presetStyle: descriptionPresetStyle,
-  icon: TextIcon,
-};
-
-export const metaSheetClose: WsComponentMeta = {
-  category: "hidden",
-  type: "container",
-  presetStyle: buttonPresetStyle,
-  icon: ButtonElementIcon,
-};
 
 /**
  * Styles source without animations:
@@ -110,7 +11,7 @@ export const metaSheetClose: WsComponentMeta = {
  * MIT License
  * Copyright (c) 2023 shadcn
  **/
-export const metaSheet: WsComponentMeta = {
+export const meta: WsComponentMeta = {
   category: "radix",
   order: 1,
   type: "container",
@@ -119,7 +20,8 @@ export const metaSheet: WsComponentMeta = {
   template: [
     {
       type: "instance",
-      component: "Sheet",
+      component: "Dialog",
+      label: "Sheet",
       dataSources: {
         sheetOpen: { type: "variable", initialValue: false },
       },
@@ -140,7 +42,8 @@ export const metaSheet: WsComponentMeta = {
       children: [
         {
           type: "instance",
-          component: "SheetTrigger",
+          component: "DialogTrigger",
+          label: "Sheet Trigger",
           children: [
             {
               type: "instance",
@@ -166,7 +69,8 @@ export const metaSheet: WsComponentMeta = {
         },
         {
           type: "instance",
-          component: "SheetOverlay",
+          component: "DialogOverlay",
+          label: "Sheet Overlay",
           /**
            * fixed inset-0 z-50 bg-background/80 backdrop-blur-sm
            * flex
@@ -185,7 +89,8 @@ export const metaSheet: WsComponentMeta = {
           children: [
             {
               type: "instance",
-              component: "SheetContent",
+              component: "DialogContent",
+              label: "Sheet Content",
               /**
                * fixed w-full z-50
                * grid gap-4 max-w-lg
@@ -203,98 +108,108 @@ export const metaSheet: WsComponentMeta = {
                 tc.p(6),
                 tc.shadow("lg"),
                 tc.relative(),
-                tc.state(
-                  [tc.mr("auto"), tc.maxW("sm"), tc.grow()].flat(),
-                  "[data-side=left]"
-                ),
-                tc.state(
-                  [tc.ml("auto"), tc.maxW("sm"), tc.grow()].flat(),
-                  "[data-side=right]"
-                ),
-                tc.state([tc.mb("auto")].flat(), "[data-side=top]"),
-                tc.state([tc.mt("auto")].flat(), "[data-side=bottom]"),
+                // side=left
+                tc.mr("auto"),
+                tc.maxW("sm"),
+                tc.grow(),
               ].flat(),
               children: [
                 {
                   type: "instance",
                   component: "Box",
-                  label: "Sheet Header",
-                  styles: [tc.flex(), tc.flex("col"), tc.gap(1)].flat(),
+                  label: "Nav",
+                  props: [
+                    { name: "tag", type: "string", value: "nav" },
+                    { name: "role", type: "string", value: "navigation" },
+                  ],
                   children: [
                     {
                       type: "instance",
-                      component: "SheetTitle",
-                      /**
-                       * text-lg leading-none tracking-tight
-                       **/
-                      styles: [
-                        tc.my(0),
-                        tc.leading("none"),
-                        tc.text("lg"),
-                        tc.tracking("tight"),
-                      ].flat(),
+                      component: "Box",
+                      label: "Sheet Header",
+                      styles: [tc.flex(), tc.flex("col"), tc.gap(1)].flat(),
                       children: [
                         {
-                          type: "text",
-                          value: "Sheet Title",
+                          type: "instance",
+                          component: "DialogTitle",
+                          label: "Sheet Title",
+                          /**
+                           * text-lg leading-none tracking-tight
+                           **/
+                          styles: [
+                            tc.my(0),
+                            tc.leading("none"),
+                            tc.text("lg"),
+                            tc.tracking("tight"),
+                          ].flat(),
+                          children: [
+                            {
+                              type: "text",
+                              value: "Sheet Title",
+                            },
+                          ],
+                        },
+                        {
+                          type: "instance",
+                          component: "DialogDescription",
+                          label: "Sheet Description",
+                          /**
+                           * text-sm text-muted-foreground
+                           **/
+                          styles: [
+                            tc.my(0),
+                            tc.text("sm"),
+                            tc.text("mutedForeground"),
+                          ].flat(),
+                          children: [
+                            {
+                              type: "text",
+                              value: "Sheet description text you can edit",
+                            },
+                          ],
                         },
                       ],
                     },
+
                     {
                       type: "instance",
-                      component: "SheetDescription",
-                      /**
-                       * text-sm text-muted-foreground
-                       **/
-                      styles: [
-                        tc.my(0),
-                        tc.text("sm"),
-                        tc.text("mutedForeground"),
-                      ].flat(),
+                      component: "Text",
                       children: [
-                        {
-                          type: "text",
-                          value: "Sheet description text you can edit",
-                        },
+                        { type: "text", value: "The text you can edit" },
                       ],
                     },
+
+                    {
+                      type: "instance",
+                      component: "DialogClose",
+                      label: "Sheet Close",
+                      /**
+                       * absolute right-4 top-4
+                       * rounded-sm opacity-70
+                       * ring-offset-background
+                       * hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2
+                       * flex items-center justify-center h-4 w-4
+                       **/
+                      styles: [
+                        tc.absolute(),
+                        tc.right(4),
+                        tc.top(4),
+                        tc.rounded("sm"),
+                        tc.opacity(70),
+                        tc.flex(),
+                        tc.items("center"),
+                        tc.justify("center"),
+                        tc.h(4),
+                        tc.w(4),
+                        tc.border(0),
+                        tc.bg("transparent"),
+                        tc.outline("none"),
+                        tc.hover(tc.opacity(100)),
+                        tc.focus(tc.ring("ring", 2, "background", 2)),
+                      ].flat(),
+                      children: [{ type: "text", value: "✕" }],
+                    },
                   ],
-                },
-
-                {
-                  type: "instance",
-                  component: "Text",
-                  children: [{ type: "text", value: "The text you can edit" }],
-                },
-
-                {
-                  type: "instance",
-                  component: "SheetClose",
-                  /**
-                   * absolute right-4 top-4
-                   * rounded-sm opacity-70
-                   * ring-offset-background
-                   * hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2
-                   * flex items-center justify-center h-4 w-4
-                   **/
-                  styles: [
-                    tc.absolute(),
-                    tc.right(4),
-                    tc.top(4),
-                    tc.rounded("sm"),
-                    tc.opacity(70),
-                    tc.flex(),
-                    tc.items("center"),
-                    tc.justify("center"),
-                    tc.h(4),
-                    tc.w(4),
-                    tc.border(0),
-                    tc.bg("transparent"),
-                    tc.outline("none"),
-                    tc.hover(tc.opacity(100)),
-                    tc.focus(tc.ring("ring", 2, "background", 2)),
-                  ].flat(),
-                  children: [{ type: "text", value: "✕" }],
                 },
               ],
             },
@@ -303,38 +218,4 @@ export const metaSheet: WsComponentMeta = {
       ],
     },
   ],
-};
-
-export const propsMetaSheet: WsComponentPropsMeta = {
-  props: propsSheet,
-  initialProps: ["open"],
-};
-
-export const propsMetaSheetTrigger: WsComponentPropsMeta = {
-  props: propsSheetTrigger,
-};
-
-export const propsMetaSheetContent: WsComponentPropsMeta = {
-  props: propsSheetContent,
-  initialProps: ["side", "role", "tag"],
-};
-
-export const propsMetaSheetOverlay: WsComponentPropsMeta = {
-  props: propsSheetOverlay,
-  initialProps: [],
-};
-
-export const propsMetaSheetClose: WsComponentPropsMeta = {
-  props: propsSheetClose,
-  initialProps: [],
-};
-
-export const propsMetaSheetTitle: WsComponentPropsMeta = {
-  props: propsSheetTitle,
-  initialProps: [],
-};
-
-export const propsMetaSheetDescription: WsComponentPropsMeta = {
-  props: propsSheetDescription,
-  initialProps: [],
 };


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-builder/issues/2151

Sheet is dialog internally with different styles. Here I refactored it to reuse dialog components and not expose own components.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
