### PR TITLE
Fix horizontal scroll and last element selection in the Tree

### DIFF
--- a/apps/builder/app/dashboard/header.tsx
+++ b/apps/builder/app/dashboard/header.tsx
@@ -67,9 +67,9 @@ export const Header = ({ user }: { user: User }) => {
       className={containerStyle()}
     >
       <WebstudioIcon width={30} height={23} />
-      <div>
+      <Flex gap="1" align="center">
         <Menu user={user} />
-      </div>
+      </Flex>
     </Flex>
   );
 };

--- a/apps/builder/app/dashboard/header.tsx
+++ b/apps/builder/app/dashboard/header.tsx
@@ -67,9 +67,9 @@ export const Header = ({ user }: { user: User }) => {
       className={containerStyle()}
     >
       <WebstudioIcon width={30} height={23} />
-      <Flex gap="1" align="center">
+      <div>
         <Menu user={user} />
-      </Flex>
+      </div>
     </Flex>
   );
 };

--- a/packages/design-system/src/components/scroll-area.tsx
+++ b/packages/design-system/src/components/scroll-area.tsx
@@ -13,7 +13,9 @@ const ScrollAreaThumb = styled(Thumb, {
   background: theme.colors.foregroundScrollBar,
   borderRadius: theme.spacing[4],
   // increase target size for touch devices https://www.w3.org/WAI/WCAG21/Understanding/target-size.html
+
   position: "relative",
+
   "&::before": {
     content: '""',
     position: "absolute",
@@ -22,8 +24,24 @@ const ScrollAreaThumb = styled(Thumb, {
     transform: "translate(-50%, -50%)",
     width: "100%",
     height: "100%",
-    minWidth: 16,
-    minHeight: 44,
+  },
+
+  variants: {
+    orientation: {
+      vertical: {
+        "&::before": {
+          minWidth: 16,
+          minHeight: 44,
+        },
+      },
+      horizontal: {
+        minHeight: "100%",
+        "&::before": {
+          minWidth: 44,
+          minHeight: 16,
+        },
+      },
+    },
   },
 });
 
@@ -32,15 +50,31 @@ const ScrollAreaScrollbar = styled(Scrollbar, {
   // ensures no selection
   userSelect: "none",
   // disable browser handling of all panning and scaleUp gestures on touch devices
-  touchAction: "none",
   padding: 2,
-  paddingRight: 3,
+  touchAction: "none",
   '&[data-orientation="vertical"]': {
     width: theme.spacing[6],
+    paddingRight: 3,
   },
   '&[data-orientation="horizontal"]': {
     flexDirection: "column",
     height: theme.spacing[6],
+    paddingBottom: 3,
+  },
+
+  variants: {
+    direction: {
+      both: {
+        "&[data-orientation=vertical]": {
+          marginBottom: theme.spacing[4],
+        },
+        '&[data-orientation="horizontal"]': {
+          marginRight: theme.spacing[4],
+        },
+      },
+      horizontal: {},
+      vertical: {},
+    },
   },
 });
 
@@ -80,13 +114,13 @@ export const ScrollArea = forwardRef(
           {children}
         </Viewport>
         {(direction === "vertical" || direction === "both") && (
-          <ScrollAreaScrollbar orientation="vertical">
-            <ScrollAreaThumb />
+          <ScrollAreaScrollbar orientation="vertical" direction={direction}>
+            <ScrollAreaThumb orientation="vertical" />
           </ScrollAreaScrollbar>
         )}
         {(direction === "horizontal" || direction === "both") && (
-          <ScrollAreaScrollbar orientation="horizontal">
-            <ScrollAreaThumb />
+          <ScrollAreaScrollbar orientation="horizontal" direction={direction}>
+            <ScrollAreaThumb orientation="horizontal" />
           </ScrollAreaScrollbar>
         )}
       </ScrollAreaRoot>

--- a/packages/design-system/src/components/tree/tree.tsx
+++ b/packages/design-system/src/components/tree/tree.tsx
@@ -22,6 +22,7 @@ import {
   getItemSelectorFromElement,
 } from "./item-utils";
 import { ScrollArea } from "../scroll-area";
+import { theme } from "../..";
 
 export type TreeProps<Data extends { id: string }> = {
   root: Data;
@@ -288,6 +289,10 @@ export const Tree = <Data extends { id: string }>({
         onBlur={keyboardNavigation.handleBlur}
         onKeyDown={keyboardNavigation.handleKeyDown}
         onClick={keyboardNavigation.handleClick}
+        css={{
+          // To not intersect last element with the scroll
+          marginBottom: theme.spacing[7],
+        }}
       >
         <TreeNode
           renderItem={renderItem}


### PR DESCRIPTION
## Description

ref #2151 

https://discord.com/channels/955905230107738152/1143789794426638377

Also made that scrollbars are not intersected
<img width="111" alt="image" src="https://github.com/webstudio-is/webstudio-builder/assets/5077042/e103e4b1-40e3-4328-b698-8cdb7b43ae4b">

## Steps for reproduction

Add a lot of elements into the tree.
Be sure last element has a long long label.

See it can be selected, 
See both scrolls work

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
