### PR TITLE
Fix navigation menu by aligning it to the left

### DIFF
--- a/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
+++ b/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
@@ -305,7 +305,7 @@ export const metaNavigationMenu: WsComponentMeta = {
       ],
       // relative
       // Omiting this: z-10 flex max-w-max flex-1 items-center justify-center
-      styles: [tc.relative(), tc.maxW("max"), tc.z(10)].flat(),
+      styles: [tc.relative(), tc.maxW("max")].flat(),
       children: [
         {
           type: "instance",

--- a/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
+++ b/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
@@ -305,7 +305,7 @@ export const metaNavigationMenu: WsComponentMeta = {
       ],
       // relative
       // Omiting this: z-10 flex max-w-max flex-1 items-center justify-center
-      styles: [tc.relative()].flat(),
+      styles: [tc.relative(), tc.maxW("max"), tc.z(10)].flat(),
       children: [
         {
           type: "instance",


### PR DESCRIPTION
## Description

Setting max-w-max we are forcing menu to be left aligned.

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
