### PR TITLE
No content Nav menu items

### DIFF
--- a/packages/sdk-components-react-radix/src/navigation-menu.tsx
+++ b/packages/sdk-components-react-radix/src/navigation-menu.tsx
@@ -107,11 +107,24 @@ export const hooksNavigationMenu: Hook = {
           `${namespace}:NavigationMenu`
         );
 
-        const contentValue =
-          context.getPropValue(instance.id, "value") ??
-          context.indexesWithinAncestors.get(instance.id)?.toString();
+        const menuItem = getClosestInstance(
+          event.instancePath,
+          instance,
+          `${namespace}:NavigationMenuItem`
+        );
 
-        if (menu && contentValue) {
+        if (menuItem === undefined) {
+          return;
+        }
+        if (menu === undefined) {
+          return;
+        }
+
+        const contentValue =
+          context.getPropValue(menuItem.id, "value") ??
+          context.indexesWithinAncestors.get(menuItem.id)?.toString();
+
+        if (contentValue) {
           context.setPropVariable(menu.id, "value", contentValue);
         }
       }

--- a/packages/sdk-components-react-radix/src/navigation-menu.tsx
+++ b/packages/sdk-components-react-radix/src/navigation-menu.tsx
@@ -113,10 +113,7 @@ export const hooksNavigationMenu: Hook = {
           `${namespace}:NavigationMenuItem`
         );
 
-        if (menuItem === undefined) {
-          return;
-        }
-        if (menu === undefined) {
+        if (menuItem === undefined || menu === undefined) {
           return;
         }
 

--- a/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
+++ b/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
@@ -482,7 +482,10 @@ export const metaNavigationMenuLink: WsComponentMeta = {
   type: "container",
   stylable: false,
   icon: BoxIcon,
+  // https://github.com/webstudio-is/webstudio-builder/issues/2193
   // requiredAncestors: ["NavigationMenuContent", "NavigationMenuItem"],
+  // Temporary restrict to NavigationMenu
+  requiredAncestors: ["NavigationMenu"],
   presetStyle,
   label: "Accessible Link Wrapper",
 };

--- a/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
+++ b/packages/sdk-components-react-radix/src/navigation-menu.ws.ts
@@ -178,6 +178,33 @@ const navItemsList = (props: {
   },
 ];
 
+const menuItemLink = (props: {
+  title: string;
+}): NonNullable<WsComponentMeta["template"]> => [
+  {
+    type: "instance",
+    component: "NavigationMenuItem",
+    children: [
+      {
+        type: "instance",
+        component: "NavigationMenuLink",
+        children: [
+          {
+            type: "instance",
+            component: "Link",
+            styles: [
+              getButtonStyles("ghost", "sm"),
+              tc.noUnderline(),
+              tc.text("current"),
+            ].flat(),
+            children: [{ type: "text", value: props.title }],
+          },
+        ],
+      },
+    ],
+  },
+];
+
 const menuItem = (props: {
   title: string;
   children: NonNullable<WsComponentMeta["template"]>;
@@ -354,6 +381,7 @@ export const metaNavigationMenu: WsComponentMeta = {
                 ...navItemsList({ count: 3, offset: 6 }),
               ],
             }),
+            ...menuItemLink({ title: "Standalone" }),
           ],
         },
 
@@ -454,7 +482,7 @@ export const metaNavigationMenuLink: WsComponentMeta = {
   type: "container",
   stylable: false,
   icon: BoxIcon,
-  requiredAncestors: ["NavigationMenuContent"],
+  // requiredAncestors: ["NavigationMenuContent", "NavigationMenuItem"],
   presetStyle,
   label: "Accessible Link Wrapper",
 };


### PR DESCRIPTION
## Description

Menu items without content (just with Link)

<img width="707" alt="image" src="https://github.com/webstudio-is/webstudio-builder/assets/5077042/63cf6a84-08bc-4f8f-b307-41323921c78c">

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
