### PR TITLE
Drag on canvas closest detachable

### DIFF
--- a/apps/builder/app/canvas/shared/use-drag-drop.ts
+++ b/apps/builder/app/canvas/shared/use-drag-drop.ts
@@ -8,7 +8,6 @@ import {
   useDrag,
   useDrop,
   computeIndicatorPlacement,
-  toast,
 } from "@webstudio-is/design-system";
 import {
   instancesStore,
@@ -18,12 +17,11 @@ import { publish, useSubscribe } from "~/shared/pubsub";
 import {
   computeInstancesConstraints,
   findClosestDroppableComponentIndex,
-  findClosestEditableInstanceSelector,
+  findClosestDetachableInstanceSelector,
   getComponentTemplateData,
   insertTemplateData,
   reparentInstance,
   type InsertConstraints,
-  isInstanceDetachable,
 } from "~/shared/instance-utils";
 import {
   getElementByInstanceSelector,
@@ -229,21 +227,15 @@ export const useDragAndDrop = () => {
       }
       // When trying to drag an instance inside editor, drag the editor instead
       return (
-        findClosestEditableInstanceSelector(
+        findClosestDetachableInstanceSelector(
           instanceSelector,
           instancesStore.get(),
           registeredComponentMetasStore.get()
-        ) ?? instanceSelector
+        ) ?? false
       );
     },
 
     onStart({ data: dragInstanceSelector }) {
-      if (isInstanceDetachable(dragInstanceSelector) === false) {
-        toast.error(
-          "This instance can not be moved outside of its parent component."
-        );
-        return;
-      }
       publish({
         type: "dragStart",
         payload: {

--- a/apps/builder/app/shared/instance-utils.ts
+++ b/apps/builder/app/shared/instance-utils.ts
@@ -93,6 +93,28 @@ export const findClosestEditableInstanceSelector = (
   }
 };
 
+export const findClosestDetachableInstanceSelector = (
+  instanceSelector: InstanceSelector,
+  instances: Instances,
+  metas: Map<string, WsComponentMeta>
+) => {
+  for (const instanceId of instanceSelector) {
+    const instance = instances.get(instanceId);
+    if (instance === undefined) {
+      return;
+    }
+    const meta = metas.get(instance.component);
+    if (meta === undefined) {
+      return;
+    }
+    const detachable = meta.detachable ?? true;
+    if (meta.type !== "container" || detachable === false) {
+      continue;
+    }
+    return getAncestorInstanceSelector(instanceSelector, instanceId);
+  }
+};
+
 export const isInstanceDetachable = (instanceSelector: InstanceSelector) => {
   const instances = instancesStore.get();
   const metas = registeredComponentMetasStore.get();

--- a/packages/sdk-components-react-radix/src/__generated__/select.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/select.props.ts
@@ -919,6 +919,7 @@ export const propsSelectValue: Record<string, PropMeta> = {
   itemType: { required: false, control: "text", type: "string" },
   lang: { required: false, control: "text", type: "string" },
   nonce: { required: false, control: "text", type: "string" },
+  placeholder: { required: false, control: "text", type: "string" },
   prefix: { required: false, control: "text", type: "string" },
   property: { required: false, control: "text", type: "string" },
   radioGroup: { required: false, control: "text", type: "string" },

--- a/packages/sdk-components-react-radix/src/select.tsx
+++ b/packages/sdk-components-react-radix/src/select.tsx
@@ -37,9 +37,14 @@ export const SelectTrigger: ForwardRefExoticComponent<
   ComponentPropsWithRef<typeof Trigger>
 > = Trigger;
 
-export const SelectValue: ForwardRefExoticComponent<
-  ComponentPropsWithRef<typeof Value>
-> = Value;
+export const SelectValue = forwardRef<
+  HTMLDivElement,
+  Omit<ComponentPropsWithoutRef<typeof Value>, "placeholder"> & {
+    placeholder?: string;
+  }
+>((props, ref) => {
+  return <Value ref={ref} {...props} />;
+});
 
 export const SelectContent = forwardRef<
   HTMLDivElement,


### PR DESCRIPTION
Before when start dragging we searched for closest rich editor under cursor and did nothing when the instance is not detachable (for example select value or switch indicator).

Here I changed the behavior to also look for closest detachable instance and drag whole thing. This way we do not need toast like in navigator and can canvas dnd just work.

Also fixed placeholder in "Select Value" component. Before was no way to change it.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
