### PR TITLE
Add dialog close button states

### DIFF
--- a/packages/sdk-components-react-radix/src/dialog.ws.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.ws.tsx
@@ -9,6 +9,7 @@ import {
   LargeXIcon,
 } from "@webstudio-is/icons/svg";
 import {
+  defaultStates,
   type PresetStyle,
   type WsComponentMeta,
   type WsComponentPropsMeta,
@@ -83,6 +84,7 @@ export const metaDialogClose: WsComponentMeta = {
   presetStyle: {
     button: [buttonReset, button].flat(),
   },
+  states: defaultStates,
   icon: ButtonElementIcon,
   label: "Close Button",
 };


### PR DESCRIPTION
## Description

Close button was missing CSS states

## Steps for reproduction

1. select close button in dialog
2. see the states on local token

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-builder/blob/main/apps/builder/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `builder/env-check.js` if mandatory
